### PR TITLE
Use port 3001 for management app so it doesn't run into Blacklight ap…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN /sbin/setuser app bash -l -c "set -x && \
     DB_ADAPTER=nulldb bundle exec rake assets:precompile && \
     mv ./public/assets ./public/assets-new"
 
-EXPOSE 3000
+EXPOSE 3001
 
 CMD /sbin/my_init

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ touch .secrets
   ``` bash
   docker-compose up web
   ```
-- Access the web app at `http://localhost:3000`
+- Access the web app at `http://localhost:3001`
 - Access the solr instance at `http://localhost:8983`
 
 ##### Accessing the web container

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,8 +11,8 @@ min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port        ENV.fetch("PORT") { 3000 }
+# Changing to alternate so it doesn't crash into Blacklight application
+port        ENV.fetch("PORT") { 3001 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - .env.test
       - .secrets
     ports:
-      - '3000:3000'
+      - '3001:3001'
     volumes:
       - .:/home/app/webapp
     # Keep the stdin open, so we can attach to our app container's process

--- a/ops/webapp.conf
+++ b/ops/webapp.conf
@@ -1,5 +1,5 @@
 server {
-    listen 3000;
+    listen 3001;
     server_name _;
     root /home/app/webapp/public;
     client_body_in_file_only clean;


### PR DESCRIPTION
- On deploy, the Blacklight application runs on port 3000, so we need to use a different port
- McClain suggested 3001 as a good port to use