### PR TITLE
Add basic management page so there's somewhere to land on deploy

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby26
+FROM phusion/passenger-ruby26:1.0.10
 
 RUN echo 'Downloading Packages' && \
   curl -sL https://deb.nodesource.com/setup_12.x | bash - && \

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'turbolinks', '~> 5'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 5.1', '>= 5.1.1'
+gem 'webpacker', '~> 4.0'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'turbolinks', '~> 5'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 4.0'
+gem 'webpacker', '~> 5.1', '>= 5.1.1'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webmock (~> 3.8, >= 3.8.3)
-  webpacker
+  webpacker (~> 5.1, >= 5.1.1)
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    semantic_range (2.3.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -264,10 +265,11 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webpacker (4.2.2)
-      activesupport (>= 4.2)
+    webpacker (5.1.1)
+      activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
-      railties (>= 4.2)
+      railties (>= 5.2)
+      semantic_range (>= 2.3.0)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -302,7 +304,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webmock (~> 3.8, >= 3.8.3)
-  webpacker (~> 4.0)
+  webpacker
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/controllers/management_controller.rb
+++ b/app/controllers/management_controller.rb
@@ -1,0 +1,4 @@
+class ManagementController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/management_controller.rb
+++ b/app/controllers/management_controller.rb
@@ -1,4 +1,5 @@
+# frozen_string_literal: true
+
 class ManagementController < ApplicationController
-  def index
-  end
+  def index; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%# <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %> %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,9 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%# <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %> %>
+    <!-- commenting out for now until we have actual CSS for webpacker to pack
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    -->
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,10 +6,10 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <!-- commenting out for now until we have actual CSS for webpacker to pack
+    <%# commenting out for now until we have actual CSS for webpacker to pack
     see https://github.com/rails/webpacker/issues/2071 for context
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    -->
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %> %>
+
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <!-- commenting out for now until we have actual CSS for webpacker to pack
+    see https://github.com/rails/webpacker/issues/2071 for context
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     -->
   </head>

--- a/app/views/management/index.html.erb
+++ b/app/views/management/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Management#index</h1>
+<p>Future homepage of the management application</p>
+<p>Find me in app/views/management/index.html.erb</p>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.hosts.clear
+
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get 'management/index'
+  get 'management/', to: 'management#index'
 end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -74,8 +74,6 @@ development:
       'Access-Control-Allow-Origin': '*'
     watch_options:
       ignored: '**/node_modules/**'
-    compile: true
-
 
 test:
   <<: *default

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -74,6 +74,7 @@ development:
       'Access-Control-Allow-Origin': '*'
     watch_options:
       ignored: '**/node_modules/**'
+    compile: true
 
 
 test:

--- a/spec/requests/management_request_spec.rb
+++ b/spec/requests/management_request_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe "Managements", type: :request do
-
   describe "GET /" do
     it "returns http success" do
       get "/management/"
@@ -15,5 +16,4 @@ RSpec.describe "Managements", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/management_request_spec.rb
+++ b/spec/requests/management_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "Managements", type: :request do
+
+  describe "GET /" do
+    it "returns http success" do
+      get "/management/"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /index" do
+    it "returns http success" do
+      get "/management/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
- The Load Balancer is set up to send requests for the management app (e.g. www.collections-test.curationexperts.com/management) to the management app, running on port 3001; however, it sends them to 3001/management. We need a controller & filler page so that it doesn't crash the deployment.