### PR TITLE
add additional author field

### DIFF
--- a/app/services/fixture_indexing_service.rb
+++ b/app/services/fixture_indexing_service.rb
@@ -23,6 +23,7 @@ class FixtureIndexingService
       # title_vern_ssim # title in the vernacular
       # subtitle_tsim
       # subtitle_vern_ssim # subtitle in the vernacular
+      author_ssim: data_hash["creator"],
       author_tsim: data_hash["creator"],
       # author_vern_ssim # author in the vernacular
       extent_ssim: data_hash["extent"],


### PR DESCRIPTION
Adds additional author field to allow for user friendly faceting.

Faceting on existing author_tsim field split the facet terms into
individual words.  By providing an author_ssim field to facet on
the user will be able to facet on full author names.

Resolves #209
See Also #190