### PR TITLE
Fixture indexing service takes metadata_source

### DIFF
--- a/app/controllers/management_controller.rb
+++ b/app/controllers/management_controller.rb
@@ -4,7 +4,7 @@ class ManagementController < ApplicationController
   def index; end
 
   def run_task
-    FixtureIndexingService.index_fixture_data
+    @metadata_source = FixtureIndexingService.index_fixture_data(params[:metadata_source])
     redirect_to management_index_path
     flash[:notice] = "These files are being indexed in the background and will be ready soon."
   end

--- a/app/services/fixture_indexing_service.rb
+++ b/app/services/fixture_indexing_service.rb
@@ -15,7 +15,7 @@ class FixtureIndexingService
 
   def self.index_to_solr(oid, metadata_source)
     mcs = MetadataCloudService.new
-    id_prefix =  mcs.file_prefix(metadata_source)
+    id_prefix = mcs.file_prefix(metadata_source)
     file = mcs.get_fixture_file(oid, metadata_source)
     data_hash = JSON.parse(file)
     solr_doc = {

--- a/app/services/fixture_indexing_service.rb
+++ b/app/services/fixture_indexing_service.rb
@@ -1,24 +1,25 @@
 # frozen_string_literal: true
 
 class FixtureIndexingService
-  def self.index_fixture_data
+  def self.index_fixture_data(metadata_source)
     oid_path = Rails.root.join("spec", "fixtures", "fixture_ids.csv")
     mcs = MetadataCloudService.new
     mcs.build_oid_array(oid_path).each do |oid|
-      index_to_solr oid
+      index_to_solr(oid, metadata_source)
     end
   end
 
-  def self.ladybird_metadata_path
-    Rails.root.join('spec', 'fixtures', 'ladybird').to_s
+  def self.metadata_path(metadata_source)
+    Rails.root.join('spec', 'fixtures', metadata_source).to_s
   end
 
-  def self.index_to_solr(oid)
-    filename = "LB-#{oid}.json"
-    file = File.read(File.join(ladybird_metadata_path, filename))
+  def self.index_to_solr(oid, metadata_source)
+    mcs = MetadataCloudService.new
+    id_prefix =  mcs.file_prefix(metadata_source)
+    file = mcs.get_fixture_file(oid, metadata_source)
     data_hash = JSON.parse(file)
     solr_doc = {
-      id: oid,
+      id: "#{id_prefix}-#{oid}",
       title_tsim: data_hash["title"],
       # title_vern_ssim # title in the vernacular
       # subtitle_tsim
@@ -61,7 +62,7 @@ class FixtureIndexingService
       # children_ssim
       # importUrl_ssim
       illustrative_matter_tsi: data_hash["illustrativeMatter"],
-      oid_ssim: data_hash["oid"],
+      oid_ssim: data_hash["oid"] || oid,
       identifierMfhd_ssim: data_hash["identifierMfhd"],
       identifierShelfMark_ssim: data_hash["identifierShelfMark"],
       box_ssim: data_hash["identifierShelfMark"],

--- a/app/services/fixture_indexing_service.rb
+++ b/app/services/fixture_indexing_service.rb
@@ -5,6 +5,7 @@ class FixtureIndexingService
     oid_path = Rails.root.join("spec", "fixtures", "fixture_ids.csv")
     mcs = MetadataCloudService.new
     mcs.build_oid_array(oid_path).each do |oid|
+      next unless mcs.get_fixture_file(oid, metadata_source)
       index_to_solr(oid, metadata_source)
     end
   end
@@ -16,6 +17,7 @@ class FixtureIndexingService
   def self.index_to_solr(oid, metadata_source)
     mcs = MetadataCloudService.new
     id_prefix = mcs.file_prefix(metadata_source)
+    return nil unless mcs.get_fixture_file(oid, metadata_source)
     file = mcs.get_fixture_file(oid, metadata_source)
     data_hash = JSON.parse(file)
     solr_doc = {

--- a/app/services/metadata_cloud_service.rb
+++ b/app/services/metadata_cloud_service.rb
@@ -94,7 +94,8 @@ class MetadataCloudService
   def get_fixture_file(oid, metadata_source)
     fixture_file_folder = Rails.root.join("spec", "fixtures", metadata_source)
     file_prefix = file_prefix(metadata_source)
-    File.read(fixture_file_folder.join("#{file_prefix}-#{oid}" + ".json"))
+    file_path = fixture_file_folder.join("#{file_prefix}-#{oid}" + ".json")
+    File.read(file_path) if File.exist?(file_path)
   end
 
   def file_prefix(metadata_source)

--- a/app/views/management/index.html.erb
+++ b/app/views/management/index.html.erb
@@ -2,13 +2,18 @@
 
 
 <div>
-  <h3> Run Rake Task </h3>
+  <h3> Index Metadata to Solr </h3>
     <%= link_to "Index Voyager Records to Solr", metadata_source_path("ils"), class: "btn btn-primary" %>
     <% if flash[:notice] %>
       <div class="notice"><%= flash[:notice] %></div>
     <% end %>
 
     <%= link_to "Index Ladybird Records to Solr", metadata_source_path("ladybird"), class: "btn btn-primary" %>
+    <% if flash[:notice] %>
+      <div class="notice"><%= flash[:notice] %></div>
+    <% end %>
+
+    <%= link_to "Index ArchiveSpace Records to Solr", metadata_source_path("aspace"), class: "btn btn-primary" %>
     <% if flash[:notice] %>
       <div class="notice"><%= flash[:notice] %></div>
     <% end %>

--- a/app/views/management/index.html.erb
+++ b/app/views/management/index.html.erb
@@ -3,9 +3,13 @@
 
 <div>
   <h3> Run Rake Task </h3>
-    <%= link_to "Index to Solr", run_solr_index_path, class: "btn btn-primary" %>
+    <%= link_to "Index Voyager Records to Solr", metadata_source_path("ils"), class: "btn btn-primary" %>
+    <% if flash[:notice] %>
+      <div class="notice"><%= flash[:notice] %></div>
+    <% end %>
+
+    <%= link_to "Index Ladybird Records to Solr", metadata_source_path("ladybird"), class: "btn btn-primary" %>
     <% if flash[:notice] %>
       <div class="notice"><%= flash[:notice] %></div>
     <% end %>
 </div>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   get 'management/index'
   get 'management/', to: 'management#index'
 
-  get "management/run_task", to: 'management#run_task', as: 'run_solr_index'
+  get "management/run_task/:metadata_source", to: 'management#run_task', as: 'metadata_source'
 end

--- a/lib/tasks/index_sample_data.rake
+++ b/lib/tasks/index_sample_data.rake
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 namespace :yale do
-  desc "Index fixture data"
+  desc "METADATA_SOURCE=aspace|ils|ladybird rake yale:index_fixture_data Index fixture data"
   task index_fixture_data: :environment do
-    FixtureIndexingService.index_fixture_data
+    metadata_source = ENV["METADATA_SOURCE"]
+    FixtureIndexingService.index_fixture_data(metadata_source)
     puts "Sample metadata indexed"
   end
 

--- a/spec/fixtures/ils/V-16189097-priv.json
+++ b/spec/fixtures/ils/V-16189097-priv.json
@@ -1,0 +1,79 @@
+{
+  "recordType": "bib",
+  "source": "ils",
+  "uri": "/ils/bib/8330740",
+  "title": [
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [private copy].",
+    "大明九辺万国人跡路程全図"
+  ],
+  "alternativeTitle": [
+    "Dai Min kyōshō kyūhen gaikoku fushūken rotei zu.",
+    "大明京省  九辺外国府州県路程図"
+  ],
+  "publicationPlace": [
+    "Kyōto",
+    "京都",
+    "Japan Kyoto"
+  ],
+  "publisher": [
+    "Umemura Yahaku",
+    "梅村弥白"
+  ],
+  "date": [
+    "[between 1890 and 1899?]"
+  ],
+  "extent": [
+    "1 map : folded in covers 25 x 16 cm"
+  ],
+  "material": [
+    "col. ;"
+  ],
+  "language": [
+    "jp"
+  ],
+  "description": [
+    "Relief shown pictorially.",
+    "Japanese reprint of a Chinese map published in 1663.",
+    "In Japanese.",
+    "BEIN Lanman Covers 56 189X: From the library of Jonathan T. Lanman (#18)."
+  ],
+  "scale": "Scale not given.",
+  "coordinate": [
+    "a"
+  ],
+  "genre": [
+    "Maps",
+    "Maps"
+  ],
+  "format": [
+    "cartographic image"
+  ],
+  "orbisRecord": "8330740",
+  "findingAid": [
+    "http://beinecke.library.yale.edu/dl_crosscollex/brbldl_getrec.asp?fld=img&id=16189150"
+  ],
+  "dateStructured": [
+    "189u   "
+  ],
+  "illustrativeMatter": "i  ",
+  "titleStatement": [
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [private copy].",
+    "大明九辺万国人跡路程全図"
+  ],
+  "provenanceControlled": "Lanman, Jonathan T. Ownership.",
+  "alternativeTitleDisplay": [
+    "Dai Min kyōshō kyūhen gaikoku fushūken rotei zu.",
+    "大明京省  九辺外国府州県路程図"
+  ],
+  "subjectGeographic": [
+    "a-cc---",
+    "China"
+  ],
+  "bibId": 8330740,
+  "suppressInOpac": true,
+  "createDate": "2008-08-15T14:47:48.000+0000",
+  "updateDate": "2019-06-05T21:33:00.000+0000",
+  "holdingId": 0,
+  "itemId": 0,
+  "children": []
+}

--- a/spec/fixtures/ils/V-16189097-yale.json
+++ b/spec/fixtures/ils/V-16189097-yale.json
@@ -1,0 +1,79 @@
+{
+  "recordType": "bib",
+  "source": "ils",
+  "uri": "/ils/bib/8330740",
+  "title": [
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [yale-only copy].",
+    "大明九辺万国人跡路程全図"
+  ],
+  "alternativeTitle": [
+    "Dai Min kyōshō kyūhen gaikoku fushūken rotei zu.",
+    "大明京省  九辺外国府州県路程図"
+  ],
+  "publicationPlace": [
+    "Kyōto",
+    "京都",
+    "Japan Kyoto"
+  ],
+  "publisher": [
+    "Umemura Yahaku",
+    "梅村弥白"
+  ],
+  "date": [
+    "[between 1890 and 1899?]"
+  ],
+  "extent": [
+    "1 map : folded in covers 25 x 16 cm"
+  ],
+  "material": [
+    "col. ;"
+  ],
+  "language": [
+    "jp"
+  ],
+  "description": [
+    "Relief shown pictorially.",
+    "Japanese reprint of a Chinese map published in 1663.",
+    "In Japanese.",
+    "BEIN Lanman Covers 56 189X: From the library of Jonathan T. Lanman (#18)."
+  ],
+  "scale": "Scale not given.",
+  "coordinate": [
+    "a"
+  ],
+  "genre": [
+    "Maps",
+    "Maps"
+  ],
+  "format": [
+    "cartographic image"
+  ],
+  "orbisRecord": "8330740",
+  "findingAid": [
+    "http://beinecke.library.yale.edu/dl_crosscollex/brbldl_getrec.asp?fld=img&id=16189150"
+  ],
+  "dateStructured": [
+    "189u   "
+  ],
+  "illustrativeMatter": "i  ",
+  "titleStatement": [
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [yale-only copy].",
+    "大明九辺万国人跡路程全図"
+  ],
+  "provenanceControlled": "Lanman, Jonathan T. Ownership.",
+  "alternativeTitleDisplay": [
+    "Dai Min kyōshō kyūhen gaikoku fushūken rotei zu.",
+    "大明京省  九辺外国府州県路程図"
+  ],
+  "subjectGeographic": [
+    "a-cc---",
+    "China"
+  ],
+  "bibId": 8330740,
+  "suppressInOpac": false,
+  "createDate": "2008-08-15T14:47:48.000+0000",
+  "updateDate": "2019-06-05T21:33:00.000+0000",
+  "holdingId": 0,
+  "itemId": 0,
+  "children": []
+}

--- a/spec/fixtures/ils/V-2107188-priv.json
+++ b/spec/fixtures/ils/V-2107188-priv.json
@@ -1,0 +1,55 @@
+{
+  "recordType": "bib",
+  "source": "ils",
+  "uri": "/ils/bib/7972227",
+  "creator": [
+    "Viets, Dan, 1751-"
+  ],
+  "title": [
+    "Fair Lucretia's garland [private copy]"
+  ],
+  "publicationPlace": [
+    "New Haven?"
+  ],
+  "publisher": [
+    "Printed for Dan Viets"
+  ],
+  "date": [
+    "September, MDCCLXXIX [1779]"
+  ],
+  "extent": [
+    "1 sheet ([1] p.) ; 36 x 24 cm."
+  ],
+  "language": [
+    "en"
+  ],
+  "description": [
+    "Poem.",
+    "Not in Evans.",
+    "BEIN Broadsides 2007 18: In ms. on verso: Colebrook."
+  ],
+  "genre": [
+    "Broadside poems Connecticut New Haven 1779"
+  ],
+  "orbisRecord": "7972227",
+  "findingAid": [
+    "http://beinecke.library.yale.edu/dl_crosscollex/brbldl_getrec.asp?fld=img&id=1329643"
+  ],
+  "dateStructured": [
+    "1779   "
+  ],
+  "illustrativeMatter": "   ",
+  "titleStatement": [
+    "Fair Lucretia's garland [private copy]"
+  ],
+  "creatorDisplay": [
+    "Viets, Dan, 1751-"
+  ],
+  "bibId": 7972227,
+  "suppressInOpac": true,
+  "createDate": "2007-09-18T19:49:12.000+0000",
+  "updateDate": "2011-03-08T16:52:15.000+0000",
+  "holdingId": 0,
+  "itemId": 0,
+  "children": []
+}

--- a/spec/fixtures/ils/V-2107188-yale.json
+++ b/spec/fixtures/ils/V-2107188-yale.json
@@ -1,0 +1,55 @@
+{
+  "recordType": "bib",
+  "source": "ils",
+  "uri": "/ils/bib/7972227",
+  "creator": [
+    "Viets, Dan, 1751-"
+  ],
+  "title": [
+    "Fair Lucretia's garland [yale-only copy]"
+  ],
+  "publicationPlace": [
+    "New Haven?"
+  ],
+  "publisher": [
+    "Printed for Dan Viets"
+  ],
+  "date": [
+    "September, MDCCLXXIX [1779]"
+  ],
+  "extent": [
+    "1 sheet ([1] p.) ; 36 x 24 cm."
+  ],
+  "language": [
+    "en"
+  ],
+  "description": [
+    "Poem.",
+    "Not in Evans.",
+    "BEIN Broadsides 2007 18: In ms. on verso: Colebrook."
+  ],
+  "genre": [
+    "Broadside poems Connecticut New Haven 1779"
+  ],
+  "orbisRecord": "7972227",
+  "findingAid": [
+    "http://beinecke.library.yale.edu/dl_crosscollex/brbldl_getrec.asp?fld=img&id=1329643"
+  ],
+  "dateStructured": [
+    "1779   "
+  ],
+  "illustrativeMatter": "   ",
+  "titleStatement": [
+    "Fair Lucretia's garland [yale-only copy]"
+  ],
+  "creatorDisplay": [
+    "Viets, Dan, 1751-"
+  ],
+  "bibId": 7972227,
+  "suppressInOpac": false,
+  "createDate": "2007-09-18T19:49:12.000+0000",
+  "updateDate": "2011-03-08T16:52:15.000+0000",
+  "holdingId": 0,
+  "itemId": 0,
+  "children": []
+}

--- a/spec/services/fixture_indexing_service_spec.rb
+++ b/spec/services/fixture_indexing_service_spec.rb
@@ -2,7 +2,6 @@
 require "rails_helper"
 
 RSpec.describe FixtureIndexingService, clean: true do
-
   context "with Voyager fixture data" do
     let(:metadata_fixture_path) { File.join(fixture_path, metadata_source) }
     let(:oid) { "2034600" }
@@ -26,7 +25,6 @@ RSpec.describe FixtureIndexingService, clean: true do
       expect(response["response"]["numFound"]).to be > 45
       expect(response["response"]["numFound"]).to be < 101
     end
-
   end
 
   context "with combined fixture data" do
@@ -39,7 +37,6 @@ RSpec.describe FixtureIndexingService, clean: true do
       response = solr.get 'select', params: { q: '*:*' }
       expect(response["response"]["numFound"]).to eq 2
     end
-
   end
 
   context "with ladybird fixture data" do

--- a/spec/services/fixture_indexing_service_spec.rb
+++ b/spec/services/fixture_indexing_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FixtureIndexingService, clean: true do
     let(:metadata_source) { "aspace" }
     let(:non_aspace_oid) { "14716192" }
 
-    it "knows where to find the Voyager metadata" do
+    it "knows where to find the ArchiveSpace metadata" do
       expect(FixtureIndexingService.metadata_path(metadata_source)).to eq metadata_fixture_path
     end
 

--- a/spec/services/fixture_indexing_service_spec.rb
+++ b/spec/services/fixture_indexing_service_spec.rb
@@ -2,65 +2,106 @@
 require "rails_helper"
 
 RSpec.describe FixtureIndexingService, clean: true do
-  let(:ladybird_metadata_path) { File.join(fixture_path, 'ladybird') }
-  let(:solr_core) { ENV["SOLR_TEST_CORE"] ||= "blacklight-test" }
-  let(:solr_url) { ENV["SOLR_URL"] ||= "http://localhost:8983/solr" }
-  let(:oid) { "2034600" }
 
-  it "can index the contents of a directory to Solr" do
-    FixtureIndexingService.index_fixture_data
-    solr = SolrService.connection
-    response = solr.get 'select', params: { q: '*:*' }
-    expect(response["response"]["numFound"]).to be > 45
-    expect(response["response"]["numFound"]).to be < 101
-  end
+  context "with Voyager fixture data" do
+    let(:metadata_fixture_path) { File.join(fixture_path, metadata_source) }
+    let(:oid) { "2034600" }
+    let(:metadata_source) { "ils" }
 
-  it "knows where to find the ladybird metadata" do
-    expect(FixtureIndexingService.ladybird_metadata_path).to eq ladybird_metadata_path
-  end
+    it "knows where to find the Voyager metadata" do
+      expect(FixtureIndexingService.metadata_path(metadata_source)).to eq metadata_fixture_path
+    end
 
-  it "can index a single file to Solr" do
-    FixtureIndexingService.index_to_solr(oid)
-    solr = SolrService.connection
-    response = solr.get 'select', params: { q: '*:*' }
-    expect(response["response"]["numFound"]).to eq 1
-  end
-
-  context "Private objects" do
-    let(:priv_oid) { "16189097-priv" }
-
-    it "indexes Private as one of the visibility values" do
-      FixtureIndexingService.index_to_solr(priv_oid)
+    it "can index a single file to Solr" do
+      FixtureIndexingService.index_to_solr(oid, metadata_source)
       solr = SolrService.connection
       response = solr.get 'select', params: { q: '*:*' }
-      expect(response["response"]["docs"].first["visibility_ssi"]).to eq("Private")
-      expect(response["response"]["docs"].first.dig("title_tsim").join).to eq("[Map of China]. [private copy]")
+      expect(response["response"]["numFound"]).to eq 1
     end
 
-    it "can find objects according to visibility" do
-      FixtureIndexingService.index_fixture_data
-      solr = SolrService.connection
-      response = solr.get 'select', params: { q: 'visibility_ssi:"Private"' }
-      expect(response["response"]["numFound"]).to eq 2
-    end
-  end
-
-  context "Yale Community Only objects" do
-    let(:yale_oid) { "2107188-yale" }
-
-    it "indexes Yale Community Only as one of the visibility values" do
-      FixtureIndexingService.index_to_solr(yale_oid)
+    it "can index the contents of a CSV file to Solr" do
+      FixtureIndexingService.index_fixture_data(metadata_source)
       solr = SolrService.connection
       response = solr.get 'select', params: { q: '*:*' }
-      expect(response["response"]["docs"].first["visibility_ssi"]).to eq("Yale Community Only")
-      expect(response["response"]["docs"].first.dig("title_tsim").join).to eq("Fair Lucretia’s garland [yale-only copy]")
+      expect(response["response"]["numFound"]).to be > 45
+      expect(response["response"]["numFound"]).to be < 101
     end
 
-    it "can find objects according to visibility" do
-      FixtureIndexingService.index_fixture_data
+  end
+
+  context "with combined fixture data" do
+    let(:oid) { "2034600" }
+
+    it "can index the same digital object's data from two different metadata sources to Solr" do
+      FixtureIndexingService.index_to_solr(oid, "ladybird")
+      FixtureIndexingService.index_to_solr(oid, "ils")
       solr = SolrService.connection
-      response = solr.get 'select', params: { q: 'visibility_ssi:"Yale Community Only"' }
+      response = solr.get 'select', params: { q: '*:*' }
       expect(response["response"]["numFound"]).to eq 2
+    end
+
+  end
+
+  context "with ladybird fixture data" do
+    let(:metadata_fixture_path) { File.join(fixture_path, metadata_source) }
+    let(:oid) { "2034600" }
+    let(:metadata_source) { "ladybird" }
+
+    it "can index the contents of a directory to Solr" do
+      FixtureIndexingService.index_fixture_data(metadata_source)
+      solr = SolrService.connection
+      response = solr.get 'select', params: { q: '*:*' }
+      expect(response["response"]["numFound"]).to be > 45
+      expect(response["response"]["numFound"]).to be < 101
+    end
+
+    it "knows where to find the ladybird metadata" do
+      expect(FixtureIndexingService.metadata_path(metadata_source)).to eq metadata_fixture_path
+    end
+
+    it "can index a single file to Solr" do
+      FixtureIndexingService.index_to_solr(oid, metadata_source)
+      solr = SolrService.connection
+      response = solr.get 'select', params: { q: '*:*' }
+      expect(response["response"]["numFound"]).to eq 1
+    end
+
+    context "Private objects" do
+      let(:priv_oid) { "16189097-priv" }
+
+      it "indexes Private as one of the visibility values" do
+        FixtureIndexingService.index_to_solr(priv_oid, metadata_source)
+        solr = SolrService.connection
+        response = solr.get 'select', params: { q: '*:*' }
+        expect(response["response"]["docs"].first["visibility_ssi"]).to eq("Private")
+        expect(response["response"]["docs"].first.dig("title_tsim").join).to eq("[Map of China]. [private copy]")
+      end
+
+      it "can find objects according to visibility" do
+        FixtureIndexingService.index_fixture_data(metadata_source)
+        solr = SolrService.connection
+        response = solr.get 'select', params: { q: 'visibility_ssi:"Private"' }
+        expect(response["response"]["numFound"]).to eq 2
+      end
+    end
+
+    context "Yale Community Only objects" do
+      let(:yale_oid) { "2107188-yale" }
+
+      it "indexes Yale Community Only as one of the visibility values" do
+        FixtureIndexingService.index_to_solr(yale_oid, metadata_source)
+        solr = SolrService.connection
+        response = solr.get 'select', params: { q: '*:*' }
+        expect(response["response"]["docs"].first["visibility_ssi"]).to eq("Yale Community Only")
+        expect(response["response"]["docs"].first.dig("title_tsim").join).to eq("Fair Lucretia’s garland [yale-only copy]")
+      end
+
+      it "can find objects according to visibility" do
+        FixtureIndexingService.index_fixture_data(metadata_source)
+        solr = SolrService.connection
+        response = solr.get 'select', params: { q: 'visibility_ssi:"Yale Community Only"' }
+        expect(response["response"]["numFound"]).to eq 2
+      end
     end
   end
 end

--- a/spec/services/fixture_indexing_service_spec.rb
+++ b/spec/services/fixture_indexing_service_spec.rb
@@ -40,10 +40,6 @@ RSpec.describe FixtureIndexingService, clean: true do
     let(:oid) { "2034600" }
     let(:metadata_source) { "ils" }
 
-  it "knows where to find the ladybird metadata" do
-    expect(FixtureIndexingService.metadata_path(metadata_source)).to eq metadata_fixture_path
-  end
-
     it "knows where to find the Voyager metadata" do
       expect(FixtureIndexingService.metadata_path(metadata_source)).to eq metadata_fixture_path
     end

--- a/spec/system/solr_tasks_spec.rb
+++ b/spec/system/solr_tasks_spec.rb
@@ -2,21 +2,43 @@
 require 'rails_helper'
 
 RSpec.describe "Solr Indexing Tasks", type: :system, clean: true do
-  describe 'Click solr task button' do
+  describe 'Click Index to Solr button' do
     before do
       visit management_index_path
-      click_on("Index to Solr")
     end
 
-    it 'displays a flash message that indexing is occuring in the background' do
-      expect(page.status_code).to eq(200)
-      expect(page).to have_content(/These files are being indexed in the background and will be ready soon./)
+    context "with a Voyager button press" do
+      before do
+        click_on("Index Voyager Records to Solr")
+      end
+
+      it 'displays a flash message that indexing is occuring in the background' do
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content(/These files are being indexed in the background and will be ready soon./)
+      end
+
+      it "can index the contents of a directory to Solr" do
+        response = SolrService.connection.get 'select', params: { q: '*:*' }
+        expect(response["response"]["numFound"]).to be > 45
+        expect(response["response"]["numFound"]).to be < 101
+      end
     end
 
-    it "can index the contents of a directory to Solr" do
-      response = SolrService.connection.get 'select', params: { q: '*:*' }
-      expect(response["response"]["numFound"]).to be > 45
-      expect(response["response"]["numFound"]).to be < 101
+    context "with a Ladybird button press" do
+      before do
+        click_on("Index Ladybird Records to Solr")
+      end
+
+      it 'displays a flash message that indexing is occuring in the background' do
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content(/These files are being indexed in the background and will be ready soon./)
+      end
+
+      it "can index the contents of a directory to Solr" do
+        response = SolrService.connection.get 'select', params: { q: '*:*' }
+        expect(response["response"]["numFound"]).to be > 45
+        expect(response["response"]["numFound"]).to be < 101
+      end
     end
   end
 end


### PR DESCRIPTION
* Can now index to Solr from Voyager ("ils") or Ladybird.
* Updated UI buttons to allow for either

![image](https://user-images.githubusercontent.com/45948126/84160005-b6823380-aa3b-11ea-8ea3-344d95159575.png)
