### PR TITLE
Dockerfile Consolidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,5 @@ RUN /sbin/setuser app bash -l -c " \
     DB_ADAPTER=nulldb bundle exec rake assets:precompile && \
     mv ./public/assets ./public/assets-new && \
     mv ./public/packs ./public/packs-new"
+
+EXPOSE 3001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,26 @@
-FROM yalelibraryit/dc-management-base:v1.0.2
+FROM yalelibraryit/dc-base:v0.0.1
 
-ADD https://time.is/just build-time
-COPY ops/nginx.sh /etc/service/nginx/run
 COPY ops/webapp.conf /etc/nginx/sites-enabled/webapp.conf
 COPY ops/env.conf /etc/nginx/main.d/env.conf
-
-# Added this because of permissions errors runsv nginx: fatal: unable to start ./run: access denied
+# Asset compile and migrate if prod, otherwise just start nginx
+COPY ops/nginx.sh /etc/service/nginx/run
 RUN chmod +x /etc/service/nginx/run
+RUN rm -f /etc/service/nginx/down
+
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+BUNDLE_JOBS=4
+RUN gem install bundler -v 2.1.4
+
+COPY --chown=app Gemfile* $APP_HOME/
+RUN /sbin/setuser app bash -l -c "bundle check || bundle install"
 
 COPY  --chown=app . $APP_HOME
-RUN /sbin/setuser app bash -l -c "set -x && \
-    (bundle check || bundle install) && \
+
+# Assets and packs are moved aside - building them means you find out early if the asset compilation is broken
+# not on final deploy. It means that public/assets and public/packs can be volumes in production allowing for
+# cached pages / assets to be kept and cleaned the way Rails expects them to be while keeping deployment very fast.
+# The assets/packs get copied back by rsync on app load (see ops/nginx.sh)
+RUN /sbin/setuser app bash -l -c " \
     DB_ADAPTER=nulldb bundle exec rake assets:precompile && \
-    mv ./public/assets ./public/assets-new"
-
-EXPOSE 3001
-
-CMD /sbin/my_init
+    mv ./public/assets ./public/assets-new && \
+    mv ./public/packs ./public/packs-new"

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ cd ./yul-dc-management
 touch .secrets
 ```
 
-## If this is your first time working in this repo, pull the base service (dependencies, etc. that don't change)
-
-```bash
-  docker-compose pull base
-```
-
 ## If this is your first time working in this repo or the Dockerfile has been updated you will need to pull your services
 
 ```bash
@@ -134,7 +128,18 @@ touch .secrets
       rake yale:clean_solr
   ```
 
-  ## Releasing a new version
+## Pulling or Building Docker Images
+  Any time you pull a branch with a Gemfile change you need to pull or build a new Docker image. If you change the Dockerfile, you
+  need to build a new Docker image. If you change a file in ./ops you need to build a new Docker image. These are the primary
+  times in which you need to pull or build.
+
+## When Installing a New Gem
+  For the most part images are created and maintained by the CI process. However, if you change the Gemfile you need
+  to take a few extra steps.  Make sure the application is running before you make your Gemfile change. Once you've
+  updated the Gemfile, inside the container, run `bundle && nginx -s reload`. The next time you stop your running containers
+  you need to rebuild.
+
+## Releasing a new version
 
   1. Decide on a new version number. We use [semantic versioning](https://semver.org/).
   2. Update the version number in `.github_changelog_generator`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,5 @@
-version: '2.1'
+version: '3'
 services:
-
-  base:
-    image: '${REGISTRY_HOST}${REGISTRY_URI}-base:${MANAGEMENT_BASE_VERSION:-latest}'
-    env_file:
-      - .env
-    build:
-      context: .
-      dockerfile: Dockerfile.base
 
   web:
     build: .


### PR DESCRIPTION
After playing with multi-stage Docker builds, I no longer think it is exactly what we need for this project. We are not dealing with build dependencies that we do not want in the final build, but are instead working with trying to get a stable platform that is as uniform and efficient as possible for each project to work from.  That let me to feel like there was a single base that both projects should pull from. It still makes each project simpler to reason about, while reducing the deploy footprint.  It does not force both projects to upgrade to a new base at the same time, but any time they are in sync than all layers of the base will be shared between the two projects which will aid in disk space / network up and down speed.

This PR comes with a sister PR over in Camerata which is where I put the Base (https://github.com/yalelibrary/yul-dc-camerata/pull/44) . I not sure that's the right spot, but it didn't seem like a terrible spot to start with. 