### PR TITLE
Fix url for Voyager records with barcode so full record is retrieved

### DIFF
--- a/app/services/metadata_cloud_service.rb
+++ b/app/services/metadata_cloud_service.rb
@@ -34,13 +34,13 @@ class MetadataCloudService
       identifier_block = if barcode.nil?
                            "/bib/#{bib_id}"
                          else
-                           "/barcode/#{barcode}/bib/#{bib_id}"
+                           "/barcode/#{barcode}?bib=#{bib_id}"
                          end
     elsif metadata_source == "aspace"
       return nil unless get_archive_space_uri(oid)
       identifier_block = get_archive_space_uri(oid)
     end
-    "https://metadata-api-test.library.yale.edu/metadatacloud/api/#{metadata_source}#{identifier_block}?mediaType=json"
+    "https://metadata-api-test.library.yale.edu/metadatacloud/api/#{metadata_source}#{identifier_block}"
   end
 
   def create_crosswalk(oid)

--- a/spec/fixtures/aspace/AS-16854285.json
+++ b/spec/fixtures/aspace/AS-16854285.json
@@ -44,6 +44,12 @@
 
   ],
   "archiveSpaceUri": "/repositories/11/archival_objects/515305",
+  "dependentUris": [
+    "/aspace/repositories/11/archival_objects/515305",
+    "/aspace/repositories/11/resources/1394",
+    "/aspace/agents/corporate_entities/12845",
+    "/aspace/repositories/11/top_containers/66093"
+  ],
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-10001192.json
+++ b/spec/fixtures/ils/V-10001192.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/3659107",
+  "uri": "/ils/barcode/39002091548348?bib=3659107",
+  "identifierShelfMark": "963 GEN MSS Former call number: MS Vault Eliot",
   "creator": [
     "Eliot, George, 1819-1880"
   ],
@@ -79,6 +80,7 @@
   ],
   "provenanceControlled": "Lewes, Gertrude.",
   "provenanceUncontrolled": "Purchased and acquired from various sources.",
+  "repository": "beingen",
   "relatedTitle": [
     ""
   ],
@@ -116,12 +118,20 @@
   "contributorDisplay": [
     "Lewes, George Henry, 1817-1878."
   ],
+  "barcode": "39002091548348",
+  "volumeEnumeration": "Box 7",
+  "dependentUris": [
+    "/ils/holding/4004455",
+    "/ils/item/10558993",
+    "/ils/bib/3659107",
+    "/ils/barcode/39002091548348"
+  ],
   "bibId": 3659107,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2019-04-23T19:21:08.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 4004455,
+  "itemId": 10558993,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-10269867.json
+++ b/spec/fixtures/ils/V-10269867.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/9734851",
+  "uri": "/ils/barcode/39002091597519?bib=9734851",
+  "identifierShelfMark": "410 Beinecke MS",
   "title": [
     "Indulgence scroll"
   ],
@@ -64,6 +65,7 @@
     "Indulgence scroll"
   ],
   "provenanceUncontrolled": "Purchased from H. M. Fletcher in 1969 by Edwin J. Beinecke for the Beinecke Library.",
+  "repository": "beingen",
   "indexedBy": [
     "Shailor, B. Catalogue of Medieval and Renaissance Manuscripts in the Beinecke Rare Book and Manuscript Library, MS 410."
   ],
@@ -74,12 +76,20 @@
   "subjectTitleDisplay": [
     "Catholic Church"
   ],
+  "barcode": "39002091597519",
+  "volumeEnumeration": "Box",
+  "dependentUris": [
+    "/ils/holding/10050461",
+    "/ils/item/9280988",
+    "/ils/bib/9734851",
+    "/ils/barcode/39002091597519"
+  ],
   "bibId": 9734851,
   "suppressInOpac": false,
   "createDate": "2011-04-20T15:43:05.000+0000",
   "updateDate": "2018-10-01T19:00:20.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 10050461,
+  "itemId": 9280988,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-10958722.json
+++ b/spec/fixtures/ils/V-10958722.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/9869346",
+  "uri": "/ils/barcode/39002104686564?bib=9869346",
+  "identifierShelfMark": "801 Beinecke MS",
   "title": [
     "Texts on St. Jerome"
   ],
@@ -62,6 +63,7 @@
     "Texts on St. Jerome"
   ],
   "provenanceUncontrolled": "Collection of Bernard M. Rosenthal (MS 38). Purchased from him on the Edwin J. Beinecke Fund.",
+  "repository": "beingen",
   "subjectGeographic": [
     "Connecticut",
     "New Haven."
@@ -69,12 +71,19 @@
   "subjectTitleDisplay": [
     "Jerome, Saint, -419 or 420."
   ],
+  "barcode": "39002104686564",
+  "dependentUris": [
+    "/ils/holding/10167771",
+    "/ils/item/9317044",
+    "/ils/bib/9869346",
+    "/ils/barcode/39002104686564"
+  ],
   "bibId": 9869346,
   "suppressInOpac": false,
   "createDate": "2011-07-22T19:20:26.000+0000",
   "updateDate": "2018-10-10T21:35:20.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 10167771,
+  "itemId": 9317044,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-11607445.json
+++ b/spec/fixtures/ils/V-11607445.json
@@ -37,6 +37,9 @@
   "indexedBy": [
     "Brockelmann, S I, pp. 237, 239, 252."
   ],
+  "dependentUris": [
+    "/ils/bib/3832098"
+  ],
   "bibId": 3832098,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",

--- a/spec/fixtures/ils/V-11684565.json
+++ b/spec/fixtures/ils/V-11684565.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/9801995",
+  "uri": "/ils/barcode/39002091594300?bib=9801995",
+  "identifierShelfMark": "2 Beinecke MS",
   "creator": [
     "Zeno, Jacopo, 1417-1481"
   ],
@@ -66,6 +67,7 @@
     "Vita Caroli Zeni"
   ],
   "provenanceUncontrolled": "Purchased by William Loring Andrews who presented it to Yale in 1894.",
+  "repository": "beingen",
   "indexedBy": [
     "Shailor, B. Catalogue of Medieval and Renaissance Manuscripts in the Beinecke Rare Book and Manuscript Library, MS 2."
   ],
@@ -80,12 +82,19 @@
   "creatorDisplay": [
     "Zeno, Jacopo, 1417-1481"
   ],
+  "barcode": "39002091594300",
+  "dependentUris": [
+    "/ils/holding/10109058",
+    "/ils/item/9264097",
+    "/ils/bib/9801995",
+    "/ils/barcode/39002091594300"
+  ],
   "bibId": 9801995,
   "suppressInOpac": false,
   "createDate": "2011-06-20T15:39:47.000+0000",
   "updateDate": "2018-10-01T19:00:38.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 10109058,
+  "itemId": 9264097,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-11913649.json
+++ b/spec/fixtures/ils/V-11913649.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/3827095",
+  "uri": "/ils/barcode/39002097273412?bib=3827095",
+  "identifierShelfMark": "492 Landberg MSS",
   "creator": [
     "Maqrīzī, Aḥmad ibn ʻAlī, 1364-1442"
   ],
@@ -34,18 +35,27 @@
   "titleStatement": [
     "al-Bayān wa-al-iʻrāb ʻammā bi-arḍ Miṣr min al-Aʻrāb / Aḥmad ibn ʻAlī al-Maqrīzī. -- [18--?]."
   ],
+  "repository": "lsfbeir",
   "indexedBy": [
     "Brockelmann, II, 40; S II, p. 37."
   ],
   "creatorDisplay": [
     "Maqrīzī, Aḥmad ibn ʻAlī, 1364-1442"
   ],
+  "barcode": "39002097273412",
+  "volumeEnumeration": "Box",
+  "dependentUris": [
+    "/ils/holding/4184367",
+    "/ils/item/10907425",
+    "/ils/bib/3827095",
+    "/ils/barcode/39002097273412"
+  ],
   "bibId": 3827095,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2018-10-01T18:58:13.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 4184367,
+  "itemId": 10907425,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-14716192.json
+++ b/spec/fixtures/ils/V-14716192.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/3798665",
+  "uri": "/ils/barcode/39002094341147?bib=3798665",
+  "identifierShelfMark": "75 Landberg MSS",
   "creator": [
     "Kinānī, ʻAbd al-ʻAzīz ibn Yaḥyá, d. 854 or 5."
   ],
@@ -41,6 +42,7 @@
   "titleStatement": [
     "Kitāb al-ḥaydah / li-ʻAbd al-ʻAzīz al-Kinānī al-Makkī. -- 1116"
   ],
+  "repository": "lsfbeir",
   "indexedBy": [
     "Brockelmann, I, 193; S I, p. 340.",
     "Berlin catalog, 440."
@@ -52,12 +54,20 @@
   "creatorDisplay": [
     "Kinānī, ʻAbd al-ʻAzīz ibn Yaḥyá, d. 854 or 5."
   ],
+  "barcode": "39002094341147",
+  "volumeEnumeration": "Box",
+  "dependentUris": [
+    "/ils/holding/4154518",
+    "/ils/item/10900008",
+    "/ils/bib/3798665",
+    "/ils/barcode/39002094341147"
+  ],
   "bibId": 3798665,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2018-10-01T18:58:04.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 4154518,
+  "itemId": 10900008,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-15234629.json
+++ b/spec/fixtures/ils/V-15234629.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/8394689",
+  "uri": "/ils/barcode/39002091118928?bib=8394689",
+  "identifierShelfMark": "1860A 11",
   "title": [
     "Di qiu quan tu",
     "地球全圖"
@@ -65,6 +66,7 @@
   "contributor": [
     "Chen, Xiutang."
   ],
+  "repository": "beingen",
   "alternativeTitleDisplay": [
     "Shi jie di tu",
     "世界地圖"
@@ -79,12 +81,19 @@
   "contributorDisplay": [
     "Chen, Xiutang."
   ],
+  "barcode": "39002091118928",
+  "dependentUris": [
+    "/ils/holding/8833608",
+    "/ils/item/7599022",
+    "/ils/bib/8394689",
+    "/ils/barcode/39002091118928"
+  ],
   "bibId": 8394689,
   "suppressInOpac": false,
   "createDate": "2008-10-15T15:01:44.000+0000",
   "updateDate": "2018-11-28T16:47:49.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 8833608,
+  "itemId": 7599022,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-16057777.json
+++ b/spec/fixtures/ils/V-16057777.json
@@ -111,6 +111,9 @@
     "Colt's Patent Fire Arms Manufacturing Co.,",
     "James Dalziel Dougall & Sons,"
   ],
+  "dependentUris": [
+    "/ils/bib/12442385"
+  ],
   "bibId": 12442385,
   "suppressInOpac": false,
   "createDate": "2015-04-24T17:38:04.000+0000",

--- a/spec/fixtures/ils/V-16057779.json
+++ b/spec/fixtures/ils/V-16057779.json
@@ -111,6 +111,9 @@
     "Colt's Patent Fire Arms Manufacturing Co.,",
     "James Dalziel Dougall & Sons,"
   ],
+  "dependentUris": [
+    "/ils/bib/12442385"
+  ],
   "bibId": 12442385,
   "suppressInOpac": false,
   "createDate": "2015-04-24T17:38:04.000+0000",

--- a/spec/fixtures/ils/V-16057780.json
+++ b/spec/fixtures/ils/V-16057780.json
@@ -111,6 +111,9 @@
     "Colt's Patent Fire Arms Manufacturing Co.,",
     "James Dalziel Dougall & Sons,"
   ],
+  "dependentUris": [
+    "/ils/bib/12442385"
+  ],
   "bibId": 12442385,
   "suppressInOpac": false,
   "createDate": "2015-04-24T17:38:04.000+0000",

--- a/spec/fixtures/ils/V-16156712.json
+++ b/spec/fixtures/ils/V-16156712.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/11756910",
+  "uri": "/ils/barcode/39002091549304?bib=11756910",
+  "identifierShelfMark": "97 Takamiya MS",
   "title": [
     "Mirour of mans salvacioune"
   ],
@@ -69,6 +70,7 @@
   ],
   "provenanceControlled": "Foyle, William A. (William Alfred), 1885-1963 Bookplate. Harmsworth, R. Leicester (Robert Leicester), Sir, 1870-1937 Ownership. Huth, Alfred Henry, 1850-1910 Bookplate.",
   "provenanceUncontrolled": "Ex libris Alfred Henry Huth. Formerly owned by Sir Leicester Harmsworth. Ex libris William and Christina Foyle. Purchased from Toshiyuki Takamiya on the Edwin J. Beinecke Book Fund, 2017.",
+  "repository": "beingen",
   "indexedBy": [
     "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437."
   ],
@@ -76,12 +78,20 @@
     "Connecticut",
     "New Haven."
   ],
+  "barcode": "39002091549304",
+  "volumeEnumeration": "Box",
+  "dependentUris": [
+    "/ils/holding/11876007",
+    "/ils/item/10697900",
+    "/ils/bib/11756910",
+    "/ils/barcode/39002091549304"
+  ],
   "bibId": 11756910,
   "suppressInOpac": false,
   "createDate": "2013-11-14T20:16:50.000+0000",
   "updateDate": "2019-02-24T22:33:39.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 11876007,
+  "itemId": 10697900,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16162984.json
+++ b/spec/fixtures/ils/V-16162984.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/11781026",
+  "uri": "/ils/barcode/39002091549445?bib=11781026",
+  "identifierShelfMark": "36 Takamiya MS",
   "title": [
     "Old testament chronicle and genealogy of Christ (Part 1)."
   ],
@@ -67,6 +68,7 @@
     "Old testament chronicle and genealogy of Christ (Part 1)."
   ],
   "provenanceUncontrolled": "Purchased from Toshiyuki Takamiya on the Edwin J. Beinecke Book Fund, 2017.",
+  "repository": "beingen",
   "subjectTitle": "Bible",
   "indexedBy": [
     "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437."
@@ -79,12 +81,20 @@
     "Jesus Christ",
     "Bible"
   ],
+  "barcode": "39002091549445",
+  "volumeEnumeration": "Roll",
+  "dependentUris": [
+    "/ils/holding/11898564",
+    "/ils/item/10710370",
+    "/ils/bib/11781026",
+    "/ils/barcode/39002091549445"
+  ],
   "bibId": 11781026,
   "suppressInOpac": false,
   "createDate": "2013-12-02T19:44:01.000+0000",
   "updateDate": "2019-02-24T22:33:49.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 11898564,
+  "itemId": 10710370,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16173726.json
+++ b/spec/fixtures/ils/V-16173726.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/12286028",
+  "uri": "/ils/barcode/39002113593728?bib=12286028",
+  "identifierShelfMark": "+1880 5626 Covers",
   "creator": [
     "Li, Mengquan (Cartographer), cartographer",
     "李蒙泉 (Cartographer), cartographer"
@@ -64,6 +65,7 @@
   "contributor": [
     "Chen, Jiaxun (Cartographer), cartographer."
   ],
+  "repository": "beingen",
   "relatedTitle": [
     ""
   ],
@@ -85,12 +87,19 @@
   "contributorDisplay": [
     "Chen, Jiaxun (Cartographer),"
   ],
+  "barcode": "39002113593728",
+  "dependentUris": [
+    "/ils/holding/12453009",
+    "/ils/item/11656798",
+    "/ils/bib/12286028",
+    "/ils/barcode/39002113593728"
+  ],
   "bibId": 12286028,
   "suppressInOpac": false,
   "createDate": "2014-10-28T21:12:40.000+0000",
   "updateDate": "2017-08-01T20:05:06.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 12453009,
+  "itemId": 11656798,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-16189096.json
+++ b/spec/fixtures/ils/V-16189096.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/8317945",
+  "uri": "/ils/barcode/39002113593827?bib=8317945",
+  "identifierShelfMark": "+1857 5615 Covers",
   "creator": [
     "Dong, Chun (Cartographer), cartographer",
     "董醇 (Cartographer), cartographer"
@@ -61,6 +62,7 @@
     "Zhi li Da Qing He yuan liu zong tu / Qing he dao Dong Chun",
     "直隷大清河源流總圖 / 清河道董醇"
   ],
+  "repository": "beingen",
   "alternativeTitleDisplay": [
     "Map of Ta Ch'ing River Container has title"
   ],
@@ -72,12 +74,19 @@
     "Dong, Chun (Cartographer), cartographer",
     "董醇 (Cartographer), cartographer"
   ],
+  "barcode": "39002113593827",
+  "dependentUris": [
+    "/ils/holding/8710417",
+    "/ils/item/11686833",
+    "/ils/bib/8317945",
+    "/ils/barcode/39002113593827"
+  ],
   "bibId": 8317945,
   "suppressInOpac": false,
   "createDate": "2008-08-05T15:29:21.000+0000",
   "updateDate": "2018-05-29T15:48:35.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 8710417,
+  "itemId": 11686833,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-16189097-priv.json
+++ b/spec/fixtures/ils/V-16189097-priv.json
@@ -1,9 +1,10 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/8330740",
+  "uri": "/ils/barcode/39002113593819?bib=8330740",
+  "identifierShelfMark": "189x 56 Lanman Covers",
   "title": [
-    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [private copy].",
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material].",
     "大明九辺万国人跡路程全図"
   ],
   "alternativeTitle": [
@@ -57,10 +58,11 @@
   ],
   "illustrativeMatter": "i  ",
   "titleStatement": [
-    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [private copy].",
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material].",
     "大明九辺万国人跡路程全図"
   ],
   "provenanceControlled": "Lanman, Jonathan T. Ownership.",
+  "repository": "beingen",
   "alternativeTitleDisplay": [
     "Dai Min kyōshō kyūhen gaikoku fushūken rotei zu.",
     "大明京省  九辺外国府州県路程図"
@@ -69,11 +71,20 @@
     "a-cc---",
     "China"
   ],
+  "barcode": "39002113593819",
+  "dependentUris": [
+    "/ils/holding/8742070",
+    "/ils/item/11686828",
+    "/ils/bib/8330740",
+    "/ils/barcode/39002113593819"
+  ],
   "bibId": 8330740,
-  "suppressInOpac": true,
+  "suppressInOpac": false,
   "createDate": "2008-08-15T14:47:48.000+0000",
   "updateDate": "2019-06-05T21:33:00.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
-  "children": []
+  "holdingId": 8742070,
+  "itemId": 11686828,
+  "children": [
+
+  ]
 }

--- a/spec/fixtures/ils/V-16189097-yale.json
+++ b/spec/fixtures/ils/V-16189097-yale.json
@@ -1,9 +1,10 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/8330740",
+  "uri": "/ils/barcode/39002113593819?bib=8330740",
+  "identifierShelfMark": "189x 56 Lanman Covers",
   "title": [
-    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [yale-only copy].",
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material].",
     "大明九辺万国人跡路程全図"
   ],
   "alternativeTitle": [
@@ -57,10 +58,11 @@
   ],
   "illustrativeMatter": "i  ",
   "titleStatement": [
-    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material] [yale-only copy].",
+    "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material].",
     "大明九辺万国人跡路程全図"
   ],
   "provenanceControlled": "Lanman, Jonathan T. Ownership.",
+  "repository": "beingen",
   "alternativeTitleDisplay": [
     "Dai Min kyōshō kyūhen gaikoku fushūken rotei zu.",
     "大明京省  九辺外国府州県路程図"
@@ -69,11 +71,20 @@
     "a-cc---",
     "China"
   ],
+  "barcode": "39002113593819",
+  "dependentUris": [
+    "/ils/holding/8742070",
+    "/ils/item/11686828",
+    "/ils/bib/8330740",
+    "/ils/barcode/39002113593819"
+  ],
   "bibId": 8330740,
   "suppressInOpac": false,
   "createDate": "2008-08-15T14:47:48.000+0000",
   "updateDate": "2019-06-05T21:33:00.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
-  "children": []
+  "holdingId": 8742070,
+  "itemId": 11686828,
+  "children": [
+
+  ]
 }

--- a/spec/fixtures/ils/V-16189097.json
+++ b/spec/fixtures/ils/V-16189097.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/8330740",
+  "uri": "/ils/barcode/39002113593819?bib=8330740",
+  "identifierShelfMark": "189x 56 Lanman Covers",
   "title": [
     "Dai Min kyūhen bankoku jinseki rotei zenzu [cartographic material].",
     "大明九辺万国人跡路程全図"
@@ -61,6 +62,7 @@
     "大明九辺万国人跡路程全図"
   ],
   "provenanceControlled": "Lanman, Jonathan T. Ownership.",
+  "repository": "beingen",
   "alternativeTitleDisplay": [
     "Dai Min kyōshō kyūhen gaikoku fushūken rotei zu.",
     "大明京省  九辺外国府州県路程図"
@@ -69,12 +71,19 @@
     "a-cc---",
     "China"
   ],
+  "barcode": "39002113593819",
+  "dependentUris": [
+    "/ils/holding/8742070",
+    "/ils/item/11686828",
+    "/ils/bib/8330740",
+    "/ils/barcode/39002113593819"
+  ],
   "bibId": 8330740,
   "suppressInOpac": false,
   "createDate": "2008-08-15T14:47:48.000+0000",
   "updateDate": "2019-06-05T21:33:00.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 8742070,
+  "itemId": 11686828,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-16301942.json
+++ b/spec/fixtures/ils/V-16301942.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/7748458",
+  "uri": "/ils/barcode/39002098971766?bib=7748458",
+  "identifierShelfMark": "229 YCAL MSS",
   "creator": [
     "Wodening, Jane, 1936-"
   ],
@@ -105,6 +106,7 @@
     "http://id.loc.gov/authorities/names/n79032189"
   ],
   "provenanceUncontrolled": "Purchased from Granary Books on the Elizabeth Wakeman Dwight Memorial Fund, 2006.",
+  "repository": "beinycal",
   "relatedTitle": [
     "",
     "Snarling garland of Xmas verses.",
@@ -174,12 +176,20 @@
     "Kelly, Robert, 1935-",
     "McClure, Michael."
   ],
+  "barcode": "39002098971766",
+  "volumeEnumeration": "3",
+  "dependentUris": [
+    "/ils/holding/8398033",
+    "/ils/item/8246364",
+    "/ils/bib/7748458",
+    "/ils/barcode/39002098971766"
+  ],
   "bibId": 7748458,
   "suppressInOpac": false,
   "createDate": "2006-11-30T21:58:33.000+0000",
   "updateDate": "2019-10-23T20:51:00.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 8398033,
+  "itemId": 8246364,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16371253.json
+++ b/spec/fixtures/ils/V-16371253.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/12297336",
+  "uri": "/ils/barcode/39002104623971?bib=12297336",
+  "identifierShelfMark": "81 Takamiya MS",
   "title": [
     "Missal, use of Sarum (fragment)"
   ],
@@ -61,6 +62,7 @@
     "Missal, use of Sarum (fragment)"
   ],
   "provenanceUncontrolled": "Purchased from Toshiyuki Takamiya on the Edwin J. Beinecke Book Fund, 2017.",
+  "repository": "beingen",
   "subjectTitle": "Sarum manual.",
   "indexedBy": [
     "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437."
@@ -72,12 +74,20 @@
   "subjectTitleDisplay": [
     "Catholic Church. Sarum manual."
   ],
+  "barcode": "39002104623971",
+  "volumeEnumeration": "File (Oversize)",
+  "dependentUris": [
+    "/ils/holding/12462455",
+    "/ils/item/10982675",
+    "/ils/bib/12297336",
+    "/ils/barcode/39002104623971"
+  ],
   "bibId": 12297336,
   "suppressInOpac": false,
   "createDate": "2014-11-12T19:59:10.000+0000",
   "updateDate": "2019-02-24T22:33:44.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 12462455,
+  "itemId": 10982675,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16371267.json
+++ b/spec/fixtures/ils/V-16371267.json
@@ -68,6 +68,9 @@
   "subjectTitleDisplay": [
     "Lancelot (Legendary character)"
   ],
+  "dependentUris": [
+    "/ils/bib/13006050"
+  ],
   "bibId": 13006050,
   "suppressInOpac": false,
   "createDate": "2016-12-19T15:07:22.000+0000",

--- a/spec/fixtures/ils/V-16371272.json
+++ b/spec/fixtures/ils/V-16371272.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/12329381",
+  "uri": "/ils/barcode/39002104624045?bib=12329381",
+  "identifierShelfMark": "104 Takamiya MS",
   "title": [
     "Bible (Proverbs to Apocalypse)."
   ],
@@ -64,6 +65,7 @@
   ],
   "provenanceControlled": "Coates, Ronald A. Autograph. Cron, Brian S. Ownership. Millar, Eric George Bookplate.",
   "provenanceUncontrolled": "Ex libris Ronald A. Coates. Ex libris Eric Millar. Formerly owned by Brian S. Cron. Purchased from Toshiyuki Takamiya on the Edwin J. Beinecke Book Fund, 2017.",
+  "repository": "beingen",
   "subjectTitle": "Bible. Bible.",
   "indexedBy": [
     "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437."
@@ -79,12 +81,20 @@
     "Bible. Latin.",
     "Bible. Latin"
   ],
+  "barcode": "39002104624045",
+  "volumeEnumeration": "Box",
+  "dependentUris": [
+    "/ils/holding/12491792",
+    "/ils/item/11006104",
+    "/ils/bib/12329381",
+    "/ils/barcode/39002104624045"
+  ],
   "bibId": 12329381,
   "suppressInOpac": false,
   "createDate": "2014-12-15T15:09:26.000+0000",
   "updateDate": "2019-02-24T22:34:16.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 12491792,
+  "itemId": 11006104,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16414889.json
+++ b/spec/fixtures/ils/V-16414889.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/3577942",
+  "uri": "/ils/barcode/39002113596465?bib=3577942",
+  "identifierShelfMark": "1351 1978",
   "creator": [
     "Cruikshank, George, 1792-1878"
   ],
@@ -35,15 +36,23 @@
   "titleStatement": [
     "A comic alphabet, designed, etched & published by George Cruikshank, No. 23 Myddelton Terrace, Pentonville"
   ],
+  "repository": "beingen",
   "creatorDisplay": [
     "Cruikshank, George, 1792-1878"
+  ],
+  "barcode": "39002113596465",
+  "dependentUris": [
+    "/ils/holding/3917998",
+    "/ils/item/11873270",
+    "/ils/bib/3577942",
+    "/ils/barcode/39002113596465"
   ],
   "bibId": 3577942,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2011-03-30T18:19:01.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 3917998,
+  "itemId": 11873270,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-16425155.json
+++ b/spec/fixtures/ils/V-16425155.json
@@ -63,6 +63,9 @@
   "creatorDisplay": [
     "Coronelli, Vincenzo, 1650-1718"
   ],
+  "dependentUris": [
+    "/ils/bib/9884809"
+  ],
   "bibId": 9884809,
   "suppressInOpac": false,
   "createDate": "2011-08-04T15:17:30.000+0000",

--- a/spec/fixtures/ils/V-16570776.json
+++ b/spec/fixtures/ils/V-16570776.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/5404463",
+  "uri": "/ils/barcode/39002002294065?bib=5404463",
+  "identifierShelfMark": "794b EEa",
   "creator": [
     "Baldwyn, George Augustus"
   ],
@@ -51,6 +52,7 @@
     "Robertson, Charles Andrew."
   ],
   "provenanceControlled": "Haswell, N.B. Autograph.",
+  "repository": "lsfbeir",
   "relatedTitle": [
     "",
     "",
@@ -69,12 +71,19 @@
     "Outlon, Clement Walley.",
     "Robertson, Charles Andrew."
   ],
+  "barcode": "39002002294065",
+  "dependentUris": [
+    "/ils/holding/5879227",
+    "/ils/item/4267559",
+    "/ils/bib/5404463",
+    "/ils/barcode/39002002294065"
+  ],
   "bibId": 5404463,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2019-01-02T18:24:22.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 5879227,
+  "itemId": 4267559,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-16685691.json
+++ b/spec/fixtures/ils/V-16685691.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/13881242",
+  "uri": "/ils/barcode/39002131329220?bib=13881242",
+  "identifierShelfMark": "Elephant Folio 2018 22 BrSides",
   "creator": [
     "United States. Hydrographic Office, cartographer"
   ],
@@ -62,18 +63,26 @@
   "titleStatement": [
     "Tracks for full powered steam vessels with the shortest navigable distances in nautical miles from anchorage to anchorage, New York distances are measures to and from the Battery achorage"
   ],
+  "repository": "beingen",
   "subjectGeographic": [
     "x------"
   ],
   "creatorDisplay": [
     "United States. Hydrographic Office, cartographer"
   ],
+  "barcode": "39002131329220",
+  "dependentUris": [
+    "/ils/holding/13895201",
+    "/ils/item/12140816",
+    "/ils/bib/13881242",
+    "/ils/barcode/39002131329220"
+  ],
   "bibId": 13881242,
   "suppressInOpac": false,
   "createDate": "2018-12-11T15:54:53.000+0000",
   "updateDate": "2019-03-18T16:35:52.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 13895201,
+  "itemId": 12140816,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-16700283.json
+++ b/spec/fixtures/ils/V-16700283.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/13640726",
+  "uri": "/ils/barcode/39002094365690?bib=13640726",
+  "identifierShelfMark": "142 Takamiya MS",
   "title": [
     "Book of hours (fragment)"
   ],
@@ -57,6 +58,7 @@
   ],
   "provenanceControlled": "Cockerell, Sydney Carlyle, Sir, 1867-1962 Ownership. Thomas, Alan G. Ownership.",
   "provenanceUncontrolled": "Previously owned by Sir Sydney Cockerell? Previously owned by Alan G. Thomas. Purchased from Toshiyuki Takamiya on the Edwin J. Beinecke Book Fund, 2017.",
+  "repository": "beingen",
   "indexedBy": [
     "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437."
   ],
@@ -64,12 +66,20 @@
     "Connecticut",
     "New Haven."
   ],
+  "barcode": "39002094365690",
+  "volumeEnumeration": "File",
+  "dependentUris": [
+    "/ils/holding/13669853",
+    "/ils/item/11982215",
+    "/ils/bib/13640726",
+    "/ils/barcode/39002094365690"
+  ],
   "bibId": 13640726,
   "suppressInOpac": false,
   "createDate": "2018-06-18T15:04:26.000+0000",
   "updateDate": "2019-04-23T14:13:33.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 13669853,
+  "itemId": 11982215,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16712419.json
+++ b/spec/fixtures/ils/V-16712419.json
@@ -69,6 +69,9 @@
   "contributorDisplay": [
     "Miltitz, Carl Borromäus von, 1781-1845."
   ],
+  "dependentUris": [
+    "/ils/bib/1289001"
+  ],
   "bibId": 1289001,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",

--- a/spec/fixtures/ils/V-16797069.json
+++ b/spec/fixtures/ils/V-16797069.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/3435140",
+  "uri": "/ils/barcode/39002075038423?bib=3435140",
+  "identifierShelfMark": "42 YCAL MSS",
   "creator": [
     "Wharton, Edith, 1862-1937"
   ],
@@ -91,6 +92,7 @@
     "Edith Wharton collection, 1868-1981 (inclusive)."
   ],
   "provenanceUncontrolled": "Bequest of Edith Wharton (1937); gifts of Louis Auchincloss, Gaillard Lapsley, Percy Lubbock, Oscar Lichtenberg, and Georges Markow-Totevy.",
+  "repository": "beinycal",
   "subjectGeographic": [
     "France.",
     "France.",
@@ -142,12 +144,20 @@
   "creatorDisplay": [
     "Wharton, Edith, 1862-1937"
   ],
+  "barcode": "39002075038423",
+  "volumeEnumeration": "Box 25",
+  "dependentUris": [
+    "/ils/holding/3764443",
+    "/ils/item/8114701",
+    "/ils/bib/3435140",
+    "/ils/barcode/39002075038423"
+  ],
   "bibId": 3435140,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2019-05-28T13:10:04.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 3764443,
+  "itemId": 8114701,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16854285.json
+++ b/spec/fixtures/ils/V-16854285.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/12307100",
+  "uri": "/ils/barcode/39002102340669?bib=12307100",
+  "identifierShelfMark": "1000 YCAL MSS",
   "creator": [
     "Fowler & Wells, attributed name"
   ],
@@ -219,6 +220,7 @@
     "[Portrait posters for physiognomy lectures]."
   ],
   "provenanceUncontrolled": "Purchased from Ian Brabner, Bookseller, on the Edwin J. Beinecke Book Fund, 2011.",
+  "repository": "beinycal",
   "subjectGeographic": [
     "United States.",
     "United States."
@@ -308,12 +310,20 @@
   "creatorDisplay": [
     "Fowler & Wells, attributed name"
   ],
+  "barcode": "39002102340669",
+  "volumeEnumeration": "Box 1",
+  "dependentUris": [
+    "/ils/holding/12484205",
+    "/ils/item/10996370",
+    "/ils/bib/12307100",
+    "/ils/barcode/39002102340669"
+  ],
   "bibId": 12307100,
   "suppressInOpac": false,
   "createDate": "2014-11-25T15:46:12.000+0000",
   "updateDate": "2019-12-10T15:48:49.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 12484205,
+  "itemId": 10996370,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-16854582.json
+++ b/spec/fixtures/ils/V-16854582.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/7151233",
+  "uri": "/ils/barcode/39002104850970?bib=7151233",
+  "identifierShelfMark": "702 YCAL MSS Former call numbers: Uncat MSS 765, Uncat MSS 1274",
   "creator": [
     "Giard, Robert"
   ],
@@ -57,6 +58,7 @@
     "Robert Giard papers, 1972-2002"
   ],
   "provenanceUncontrolled": "Purchased from Jonathan G. Silin on the Eugene G. O'Neill Memorial Fund, 2004. Gift of Jonathan G. Silin, 2011.",
+  "repository": "lsfbeiar",
   "subjectGeographic": [
     "United States",
     "United States",
@@ -73,12 +75,20 @@
   "creatorDisplay": [
     "Giard, Robert"
   ],
+  "barcode": "39002104850970",
+  "volumeEnumeration": "Box 8",
+  "dependentUris": [
+    "/ils/holding/7686921",
+    "/ils/item/10378652",
+    "/ils/bib/7151233",
+    "/ils/barcode/39002104850970"
+  ],
   "bibId": 7151233,
   "suppressInOpac": false,
   "createDate": "2006-01-09T19:38:56.000+0000",
   "updateDate": "2019-04-23T19:22:01.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 7686921,
+  "itemId": 10378652,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-2003431.json
+++ b/spec/fixtures/ils/V-2003431.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/9734763",
+  "uri": "/ils/barcode/39002091549668?bib=9734763",
+  "identifierShelfMark": "407 Beinecke MS",
   "title": [
     "Albergati bible"
   ],
@@ -15,7 +16,7 @@
     "1428."
   ],
   "extent": [
-    "ff. i + 682 + i : 231 x 161 (135 x 111) mm."
+    "ff. i + 682 + i : 231 x 161 (135 x 111) mm"
   ],
   "material": [
     "parchment ;"
@@ -32,7 +33,7 @@
     "In Latin."
   ],
   "subjectName": [
-    "Langton, Stephen, d. 1228."
+    "Langton, Stephen, -1228."
   ],
   "subjectTopic": [
     "Illumination of books and manuscripts, Medieval",
@@ -63,24 +64,35 @@
     "Albergati bible"
   ],
   "provenanceUncontrolled": "From the collection of A. Chester Beatty (Western MS 79). Acquired from H. P. Kraus in 1969 as the gift of Edwin J. Beinecke.",
+  "repository": "beingen",
   "subjectTitle": "Bible.",
   "indexedBy": [
     "Shailor, B. Catalogue of Medieval and Renaissance Manuscripts in the Beinecke Rare Book and Manuscript Library, MS 407."
   ],
   "subjectGeographic": [
+    "n-us-ct",
+    "e-it---",
     "Connecticut",
     "New Haven."
   ],
   "subjectTitleDisplay": [
-    "Langton, Stephen, d. 1228.",
+    "Langton, Stephen, -1228.",
     "Bible. Latin"
+  ],
+  "barcode": "39002091549668",
+  "volumeEnumeration": "Box",
+  "dependentUris": [
+    "/ils/holding/10050400",
+    "/ils/item/10763785",
+    "/ils/bib/9734763",
+    "/ils/barcode/39002091549668"
   ],
   "bibId": 9734763,
   "suppressInOpac": false,
   "createDate": "2011-04-20T14:54:55.000+0000",
-  "updateDate": "2019-02-24T22:33:39.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "updateDate": "2020-06-05T03:09:29.000+0000",
+  "holdingId": 10050400,
+  "itemId": 10763785,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-2004628.json
+++ b/spec/fixtures/ils/V-2004628.json
@@ -76,6 +76,9 @@
   "creatorDisplay": [
     "Kane, Paul, 1810-1871"
   ],
+  "dependentUris": [
+    "/ils/bib/3163155"
+  ],
   "bibId": 3163155,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",

--- a/spec/fixtures/ils/V-2005512.json
+++ b/spec/fixtures/ils/V-2005512.json
@@ -74,6 +74,9 @@
   "creatorDisplay": [
     "Lincoln, Abraham, 1809-1865"
   ],
+  "dependentUris": [
+    "/ils/bib/4113177"
+  ],
   "bibId": 4113177,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",

--- a/spec/fixtures/ils/V-2012036.json
+++ b/spec/fixtures/ils/V-2012036.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/6805375",
+  "uri": "/ils/barcode/39002091459793?bib=6805375",
+  "identifierShelfMark": "202 YCAL MSS",
   "creator": [
     "Whitman, Walt, 1819-1892"
   ],
@@ -80,6 +81,7 @@
     "Walt Whitman collection, 1842-1949"
   ],
   "provenanceUncontrolled": "Acquired by gift from various sources.",
+  "repository": "beinycal",
   "subjectGeographic": [
     "United States"
   ],
@@ -121,12 +123,20 @@
   "creatorDisplay": [
     "Whitman, Walt, 1819-1892"
   ],
+  "barcode": "39002091459793",
+  "volumeEnumeration": "Box 4",
+  "dependentUris": [
+    "/ils/holding/7397126",
+    "/ils/item/8200460",
+    "/ils/bib/6805375",
+    "/ils/barcode/39002091459793"
+  ],
   "bibId": 6805375,
   "suppressInOpac": false,
   "createDate": "2005-02-09T19:05:27.000+0000",
   "updateDate": "2019-04-23T19:24:29.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 7397126,
+  "itemId": 8200460,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-2012143.json
+++ b/spec/fixtures/ils/V-2012143.json
@@ -50,6 +50,9 @@
   "titleStatement": [
     "[Ethiopian scroll of spiritual healing]."
   ],
+  "dependentUris": [
+    "/ils/bib/13888969"
+  ],
   "bibId": 13888969,
   "suppressInOpac": false,
   "createDate": "2018-12-19T19:46:46.000+0000",

--- a/spec/fixtures/ils/V-2012315.json
+++ b/spec/fixtures/ils/V-2012315.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/13226126",
+  "uri": "/ils/barcode/39002099391428?bib=13226126",
+  "identifierShelfMark": "suppl. 584 Arabic MSS",
   "title": [
     "Islamic prayers, invocations and decorations : manuscript"
   ],
@@ -61,12 +62,20 @@
     "Islamic prayers, invocations and decorations : manuscript"
   ],
   "provenanceUncontrolled": "Purchased from Worldwide Antiquarian on the Edwin J. Beinecke Book Fund, 2005.",
+  "repository": "beingen",
+  "barcode": "39002099391428",
+  "dependentUris": [
+    "/ils/holding/13289360",
+    "/ils/item/11683506",
+    "/ils/bib/13226126",
+    "/ils/barcode/39002099391428"
+  ],
   "bibId": 13226126,
   "suppressInOpac": false,
   "createDate": "2017-07-17T16:37:15.000+0000",
   "updateDate": "2018-03-26T16:38:51.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 13289360,
+  "itemId": 11683506,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-2019757.json
+++ b/spec/fixtures/ils/V-2019757.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/7748458",
+  "uri": "/ils/barcode/39002098971741?bib=7748458",
+  "identifierShelfMark": "229 YCAL MSS",
   "creator": [
     "Wodening, Jane, 1936-"
   ],
@@ -105,6 +106,7 @@
     "http://id.loc.gov/authorities/names/n79032189"
   ],
   "provenanceUncontrolled": "Purchased from Granary Books on the Elizabeth Wakeman Dwight Memorial Fund, 2006.",
+  "repository": "beinycal",
   "relatedTitle": [
     "",
     "Snarling garland of Xmas verses.",
@@ -174,12 +176,20 @@
     "Kelly, Robert, 1935-",
     "McClure, Michael."
   ],
+  "barcode": "39002098971741",
+  "volumeEnumeration": "1",
+  "dependentUris": [
+    "/ils/holding/8398033",
+    "/ils/item/8246360",
+    "/ils/bib/7748458",
+    "/ils/barcode/39002098971741"
+  ],
   "bibId": 7748458,
   "suppressInOpac": false,
   "createDate": "2006-11-30T21:58:33.000+0000",
   "updateDate": "2019-10-23T20:51:00.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 8398033,
+  "itemId": 8246360,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-2019759.json
+++ b/spec/fixtures/ils/V-2019759.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/7748458",
+  "uri": "/ils/barcode/39002098971758?bib=7748458",
+  "identifierShelfMark": "229 YCAL MSS",
   "creator": [
     "Wodening, Jane, 1936-"
   ],
@@ -105,6 +106,7 @@
     "http://id.loc.gov/authorities/names/n79032189"
   ],
   "provenanceUncontrolled": "Purchased from Granary Books on the Elizabeth Wakeman Dwight Memorial Fund, 2006.",
+  "repository": "beinycal",
   "relatedTitle": [
     "",
     "Snarling garland of Xmas verses.",
@@ -174,12 +176,20 @@
     "Kelly, Robert, 1935-",
     "McClure, Michael."
   ],
+  "barcode": "39002098971758",
+  "volumeEnumeration": "2",
+  "dependentUris": [
+    "/ils/holding/8398033",
+    "/ils/item/8246363",
+    "/ils/bib/7748458",
+    "/ils/barcode/39002098971758"
+  ],
   "bibId": 7748458,
   "suppressInOpac": false,
   "createDate": "2006-11-30T21:58:33.000+0000",
   "updateDate": "2019-10-23T20:51:00.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 8398033,
+  "itemId": 8246363,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-2030006.json
+++ b/spec/fixtures/ils/V-2030006.json
@@ -66,6 +66,9 @@
     "Marlborough, Sarah Jennings Churchill, Duchess of, 1660-1744.",
     "Bailey, William."
   ],
+  "dependentUris": [
+    "/ils/bib/1264367"
+  ],
   "bibId": 1264367,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",

--- a/spec/fixtures/ils/V-2034600.json
+++ b/spec/fixtures/ils/V-2034600.json
@@ -71,6 +71,9 @@
   "subjectGeographic": [
     "n-us---"
   ],
+  "dependentUris": [
+    "/ils/bib/752400"
+  ],
   "bibId": 752400,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",

--- a/spec/fixtures/ils/V-2041002.json
+++ b/spec/fixtures/ils/V-2041002.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/1169354",
+  "uri": "/ils/barcode/39002094045128?bib=1169354",
+  "identifierShelfMark": "728 (Oversize) GEN MSS VOL Bound with 1 other title. To view full description, search by call number: GEN MSS VOL 728 (Oversize) Former call number: MS Vault Johnson",
   "creator": [
     "Johnson, Samuel, 1709-1784"
   ],
@@ -44,15 +45,24 @@
     "A dictionary of the English language ... / by Samuel Johnson ..."
   ],
   "provenanceControlled": "Johnson, Samuel, 1709-1784 Ms. notes. Sneyd, Ralph Binding.",
+  "repository": "beingen",
   "creatorDisplay": [
     "Johnson, Samuel, 1709-1784"
+  ],
+  "barcode": "39002094045128",
+  "volumeEnumeration": "1",
+  "dependentUris": [
+    "/ils/holding/1303025",
+    "/ils/item/9136055",
+    "/ils/bib/1169354",
+    "/ils/barcode/39002094045128"
   ],
   "bibId": 1169354,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2020-03-03T13:49:15.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 1303025,
+  "itemId": 9136055,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-2046567.json
+++ b/spec/fixtures/ils/V-2046567.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/1169354",
+  "uri": "/ils/barcode/39002094045136?bib=1169354",
+  "identifierShelfMark": "728 (Oversize) GEN MSS VOL Bound with 1 other title. To view full description, search by call number: GEN MSS VOL 728 (Oversize) Former call number: MS Vault Johnson",
   "creator": [
     "Johnson, Samuel, 1709-1784"
   ],
@@ -44,15 +45,24 @@
     "A dictionary of the English language ... / by Samuel Johnson ..."
   ],
   "provenanceControlled": "Johnson, Samuel, 1709-1784 Ms. notes. Sneyd, Ralph Binding.",
+  "repository": "beingen",
   "creatorDisplay": [
     "Johnson, Samuel, 1709-1784"
+  ],
+  "barcode": "39002094045136",
+  "volumeEnumeration": "2",
+  "dependentUris": [
+    "/ils/holding/1303025",
+    "/ils/item/9136058",
+    "/ils/bib/1169354",
+    "/ils/barcode/39002094045136"
   ],
   "bibId": 1169354,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2020-03-03T13:49:15.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 1303025,
+  "itemId": 9136058,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-2055095.json
+++ b/spec/fixtures/ils/V-2055095.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/1169354",
+  "uri": "/ils/barcode/39002094045110?bib=1169354",
+  "identifierShelfMark": "728 (Oversize) GEN MSS VOL Bound with 1 other title. To view full description, search by call number: GEN MSS VOL 728 (Oversize) Former call number: MS Vault Johnson",
   "creator": [
     "Johnson, Samuel, 1709-1784"
   ],
@@ -44,15 +45,24 @@
     "A dictionary of the English language ... / by Samuel Johnson ..."
   ],
   "provenanceControlled": "Johnson, Samuel, 1709-1784 Ms. notes. Sneyd, Ralph Binding.",
+  "repository": "beingen",
   "creatorDisplay": [
     "Johnson, Samuel, 1709-1784"
+  ],
+  "barcode": "39002094045110",
+  "volumeEnumeration": "3",
+  "dependentUris": [
+    "/ils/holding/1303025",
+    "/ils/item/9136062",
+    "/ils/bib/1169354",
+    "/ils/barcode/39002094045110"
   ],
   "bibId": 1169354,
   "suppressInOpac": false,
   "createDate": "2002-06-01T04:00:00.000+0000",
   "updateDate": "2020-03-03T13:49:15.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 1303025,
+  "itemId": 9136062,
   "children": [
 
   ]

--- a/spec/fixtures/ils/V-2057976.json
+++ b/spec/fixtures/ils/V-2057976.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/7039963",
+  "uri": "/ils/barcode/39002094210060?bib=7039963",
+  "identifierShelfMark": "7 Osborn Music MS",
   "title": [
     "\"Vaudevilles et chansons\", [18th Century]."
   ],
@@ -30,12 +31,20 @@
     "\"Vaudevilles et chansons\", [18th Century]."
   ],
   "provenanceUncontrolled": "For information on the source of acquisition, consult the appropriate curator.",
+  "repository": "beinosb",
+  "barcode": "39002094210060",
+  "dependentUris": [
+    "/ils/holding/7597151",
+    "/ils/item/8097775",
+    "/ils/bib/7039963",
+    "/ils/barcode/39002094210060"
+  ],
   "bibId": 7039963,
   "suppressInOpac": false,
   "createDate": "2005-08-08T18:02:48.000+0000",
   "updateDate": "2018-07-06T14:27:08.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 7597151,
+  "itemId": 8097775,
   "children": [
 
   ],

--- a/spec/fixtures/ils/V-2107188-priv.json
+++ b/spec/fixtures/ils/V-2107188-priv.json
@@ -6,7 +6,7 @@
     "Viets, Dan, 1751-"
   ],
   "title": [
-    "Fair Lucretia's garland [private copy]"
+    "Fair Lucretia's garland"
   ],
   "publicationPlace": [
     "New Haven?"
@@ -40,16 +40,21 @@
   ],
   "illustrativeMatter": "   ",
   "titleStatement": [
-    "Fair Lucretia's garland [private copy]"
+    "Fair Lucretia's garland"
   ],
   "creatorDisplay": [
     "Viets, Dan, 1751-"
   ],
+  "dependentUris": [
+    "/ils/bib/7972227"
+  ],
   "bibId": 7972227,
-  "suppressInOpac": true,
+  "suppressInOpac": false,
   "createDate": "2007-09-18T19:49:12.000+0000",
   "updateDate": "2011-03-08T16:52:15.000+0000",
   "holdingId": 0,
   "itemId": 0,
-  "children": []
+  "children": [
+
+  ]
 }

--- a/spec/fixtures/ils/V-2107188-yale.json
+++ b/spec/fixtures/ils/V-2107188-yale.json
@@ -6,7 +6,7 @@
     "Viets, Dan, 1751-"
   ],
   "title": [
-    "Fair Lucretia's garland [yale-only copy]"
+    "Fair Lucretia's garland"
   ],
   "publicationPlace": [
     "New Haven?"
@@ -40,10 +40,13 @@
   ],
   "illustrativeMatter": "   ",
   "titleStatement": [
-    "Fair Lucretia's garland [yale-only copy]"
+    "Fair Lucretia's garland"
   ],
   "creatorDisplay": [
     "Viets, Dan, 1751-"
+  ],
+  "dependentUris": [
+    "/ils/bib/7972227"
   ],
   "bibId": 7972227,
   "suppressInOpac": false,
@@ -51,5 +54,7 @@
   "updateDate": "2011-03-08T16:52:15.000+0000",
   "holdingId": 0,
   "itemId": 0,
-  "children": []
+  "children": [
+
+  ]
 }

--- a/spec/fixtures/ils/V-2107188.json
+++ b/spec/fixtures/ils/V-2107188.json
@@ -45,6 +45,9 @@
   "creatorDisplay": [
     "Viets, Dan, 1751-"
   ],
+  "dependentUris": [
+    "/ils/bib/7972227"
+  ],
   "bibId": 7972227,
   "suppressInOpac": false,
   "createDate": "2007-09-18T19:49:12.000+0000",

--- a/spec/fixtures/ils/V-2111169.json
+++ b/spec/fixtures/ils/V-2111169.json
@@ -1,7 +1,8 @@
 {
   "recordType": "bib",
   "source": "ils",
-  "uri": "/ils/bib/9896328",
+  "uri": "/ils/barcode/39002099258734?bib=9896328",
+  "identifierShelfMark": "1121 Beinecke MS",
   "creator": [
     "Galen"
   ],
@@ -53,6 +54,7 @@
   "titleStatement": [
     "Opera varia"
   ],
+  "repository": "beingen",
   "subjectGeographic": [
     "Connecticut",
     "New Haven."
@@ -63,12 +65,19 @@
   "creatorDisplay": [
     "Galen"
   ],
+  "barcode": "39002099258734",
+  "dependentUris": [
+    "/ils/holding/10191430",
+    "/ils/item/9349078",
+    "/ils/bib/9896328",
+    "/ils/barcode/39002099258734"
+  ],
   "bibId": 9896328,
   "suppressInOpac": false,
   "createDate": "2011-08-09T15:55:02.000+0000",
   "updateDate": "2018-10-01T19:01:04.000+0000",
-  "holdingId": 0,
-  "itemId": 0,
+  "holdingId": 10191430,
+  "itemId": 9349078,
   "children": [
 
   ],

--- a/spec/services/metadata_cloud_service_spec.rb
+++ b/spec/services/metadata_cloud_service_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe MetadataCloudService do
 
   context "it can build MetadataCloud urls for ParentObjects", vpn_only: false do
     it "can take an oid and build a metadata cloud Ladybird url" do
-      expect(mcs.build_metadata_cloud_url("2034600", "ladybird").to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2034600?mediaType=json"
+      expect(mcs.build_metadata_cloud_url("2034600", "ladybird").to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2034600"
     end
 
     it "can take an oid and build a metadata cloud bib-based Voyager url" do
-      expect(mcs.build_metadata_cloud_url("2034600", "ils").to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/ils/bib/752400?mediaType=json"
+      expect(mcs.build_metadata_cloud_url("2034600", "ils").to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/ils/bib/752400"
     end
 
     context "with a Voyager record with a barcode" do
@@ -76,7 +76,7 @@ RSpec.describe MetadataCloudService do
       let(:metadata_source) { "ils" }
 
       it "can take an oid and build a metadata cloud barcode-based Voyager url" do
-        expect(mcs.build_metadata_cloud_url(oid, metadata_source).to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/ils/barcode/39002113596465/bib/3577942?mediaType=json"
+        expect(mcs.build_metadata_cloud_url(oid, metadata_source).to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/ils/barcode/39002113596465?bib=3577942"
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe MetadataCloudService do
       let(:oid_without_aspace) { "2034600" }
 
       it "can take an oid and build a metadata cloud ArchiveSpace url" do
-        expect(mcs.build_metadata_cloud_url(oid_with_aspace, "aspace").to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305?mediaType=json"
+        expect(mcs.build_metadata_cloud_url(oid_with_aspace, "aspace").to_s).to eq "https://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305"
       end
 
       it "does not try to retrieve a metadata cloud record if there is no ArchiveSpace record" do


### PR DESCRIPTION
- Don't need to explicitly request json, automatically provided
- Correct URL for Voyager records with barcode
- Subsequent updates to fixture objects

Co-authored by: Martin Lovell <martin.lovell@yale.edu>