### PR TITLE
use same db configuration as blacklight

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,10 +30,6 @@ module YulDcManagement
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-    config.hosts << "localhost"
-    config.hosts << ".library.yale.edu"
-    config.hosts << ".curationexperts.com"
-    config.hosts << ".elb.amazonaws.com"
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/database.yml
+++ b/config/database.yml
@@ -83,5 +83,3 @@ test:
 production:
   <<: *default
   database: yul_dc_management_production
-  username: yul_dc_management
-  password: <%= ENV['YUL_DC_MANAGEMENT_DATABASE_PASSWORD'] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root to: 'management#index'
   get 'management/index'
   get 'management/', to: 'management#index'
 


### PR DESCRIPTION
Changes in support of running in production
- Use the same database username and password in production - matches Blacklight configuration
- Remove whitelisted hosts - allow any host for now in production
- Send / to management path (supports load balancer health checks)