### PR TITLE
Determine if an item from the activity stream is relevant

### DIFF
--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -26,11 +26,10 @@ class ActivityStreamReader
     process_page(previous_page_link(page)) if previous_page_link(page)
   end
 
-  def relevant?(_item)
-    oid = _item[:object][:id].match(/\/api\/ladybird\/oid\/(\S*)/)
-    byebug
+  def relevant?(item)
+    oid = /\/api\/ladybird\/oid\/(\S*)/.match(item["object"]["id"])&.captures
+    true if ParentObject.find_by(oid: oid)
   end
-
 
   def process_item(_item)
     @tally += 1
@@ -67,5 +66,4 @@ class ActivityStreamReader
   rescue
     false
   end
-
 end

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -26,6 +26,12 @@ class ActivityStreamReader
     process_page(previous_page_link(page)) if previous_page_link(page)
   end
 
+  def relevant?(_item)
+    oid = _item[:object][:id].match(/\/api\/ladybird\/oid\/(\S*)/)
+    byebug
+  end
+
+
   def process_item(_item)
     @tally += 1
   end
@@ -61,4 +67,5 @@ class ActivityStreamReader
   rescue
     false
   end
+
 end

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -27,17 +27,18 @@ class ActivityStreamReader
   end
 
   ##
-  # It takes an item from the activity stream and returns either True or nil (falsey) depending on whether that object
+  # It takes an item from the activity stream and returns either true or false depending on whether that object
   # - Is in the database, based on its Ladybird OID (this will have to be extended for non-ladybird objects)
   # - Was updated within the timeframe we're interested in (either the entire activity stream if it has not been
   # previously successfully run, or after the last_run_time)
   # - Is an update (for now - will probably want to include deletions and creations in the future)
   def relevant?(item)
+    return false unless item["type"] == "Update"
+    return false unless last_run_time.nil? || item["endTime"].to_datetime.after?(last_run_time)
     oid = /\/api\/ladybird\/oid\/(\S*)/.match(item["object"]["id"])&.captures
-    is_in_database = ParentObject.find_by(oid: oid)
-    from_relevant_time = last_run_time.nil? || item["endTime"].to_datetime.after?(last_run_time)
-    is_an_update = TRUE if item["type"] == "Update"
-    true if is_in_database && from_relevant_time && is_an_update
+    return false if oid.nil?
+    return false unless ParentObject.find_by(oid: oid)
+    true
   end
 
   def process_item(_item)

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "rails_helper"
 require "support/time_helpers"
-WebMock.allow_net_connect!
 
 RSpec.describe ActivityStreamReader do
   let(:asr) { described_class.new }
@@ -34,6 +33,10 @@ RSpec.describe ActivityStreamReader do
         .to_return(status: 200, body: page_1_activity_stream_page)
       stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/streams/activity/page-0")
         .to_return(status: 200, body: page_0_activity_stream_page)
+    end
+
+    it "can get a page from the MetadataCloud activity stream" do
+      expect(asr.fetch_and_parse_page("https://metadata-api-test.library.yale.edu/metadatacloud/streams/activity")["type"]).to eq "OrderedCollectionPage"
     end
 
     it "processes the entire activity stream if it has never been run before" do
@@ -144,9 +147,5 @@ RSpec.describe ActivityStreamReader do
     asl_new_success
     asl_failed
     expect(asr.last_run_time).to eq asl_new_success.run_time
-  end
-
-  it "can get a page from the MetadataCloud activity stream" do
-    expect(asr.fetch_and_parse_page("https://metadata-api-test.library.yale.edu/metadatacloud/streams/activity")["type"]).to eq "OrderedCollectionPage"
   end
 end

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 require "support/time_helpers"
-# WebMock.allow_net_connect!
+WebMock.allow_net_connect!
 
 RSpec.describe ActivityStreamReader do
   let(:asr) { described_class.new }
@@ -20,37 +20,47 @@ RSpec.describe ActivityStreamReader do
         "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
         "type" => "Document"
       },
-      "type" => "Create"
+      "type" => "Update"
     }
   end
   let(:irrelevant_item_not_ladybird) do
     {
-      "endTime": "2020-06-12T21:06:15.000+0000",
-      "object": {
-        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/ils/bib/2004628",
-        "type": "Document"
+      "endTime" => "2020-06-12T21:06:53.000+0000",
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api/ils/bib/2004628",
+        "type" => "Document"
       },
-      "type": "Create"
+      "type" => "Update"
     }
   end
   let(:irrelevant_item_not_in_db) do
     {
-      "endTime": "2020-06-12T21:06:15.000+0000",
-      "object": {
-        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/not_in_db",
-        "type": "Document"
+      "endTime" => "2020-06-12T21:06:53.000+0000",
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/not_in_db",
+        "type" => "Document"
       },
-      "type": "Create"
+      "type" => "Update"
     }
   end
   let(:irrelevant_item_too_old) do
     {
-      "endTime": "2020-06-12T20:06:15.000+0000",
-      "object": {
-        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
-        "type": "Document"
+      "endTime" => "2020-06-12T21:04:53.000+0000",
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
+        "type" => "Document"
       },
-      "type": "Create"
+      "type" => "Update"
+    }
+  end
+  let(:irrelevant_not_an_update) do
+    {
+      "endTime" => "2020-06-12T21:06:53.000+0000",
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
+        "type" => "Document"
+      },
+      "type" => "Create"
     }
   end
 
@@ -132,13 +142,22 @@ RSpec.describe ActivityStreamReader do
     end
   end
 
-  it "can determine whether an item is relevant" do
-    relevant_parent_object
-    asl_old_success
-    expect(asr.relevant?(relevant_item)).to be_truthy
-    expect(asr.relevant?(irrelevant_item_not_ladybird)).to be_falsey
-    expect(asr.relevant?(irrelevant_item_not_in_db)).to be_falsey
-    expect(asr.relevant?(irrelevant_item_too_old)).to be_falsey
+  context "determining whether a ladybird item is relevant" do
+    before do
+      relevant_parent_object
+      asl_old_success
+    end
+
+    it "can confirm that an item is relevant" do
+      expect(asr.relevant?(relevant_item)).to be_truthy
+    end
+
+    it "does not confirm that an irrelevant item is relevant" do
+      expect(asr.relevant?(irrelevant_item_not_ladybird)).to be_falsey
+      expect(asr.relevant?(irrelevant_item_not_in_db)).to be_falsey
+      expect(asr.relevant?(irrelevant_item_too_old)).to be_falsey
+      expect(asr.relevant?(irrelevant_not_an_update)).to be_falsey
+    end
   end
 
   it "can get the uri for the previous page" do


### PR DESCRIPTION
- Adds a `relevant?` method to determine whether or not an item from the activity stream is relevant for our application
- Refactors tests - stub requests do not require headers for these tests

Connected to https://github.com/yalelibrary/YUL-DC/issues/245 