### PR TITLE
Save objects from activity stream

### DIFF
--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe ActivityStreamReader do
       expect(ActivityStreamLog.last.object_count).to eq 4
     end
 
-    it "adds relevant oids for update to an array" do
+    it "adds relevant oids for update to a set" do
       expect(asr.oids_for_update.size).to eq 0
       asr.process_item(relevant_item)
       expect(asr.oids_for_update.size).to eq 1

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -5,7 +5,8 @@ require "support/time_helpers"
 RSpec.describe ActivityStreamReader do
   let(:asr) { described_class.new }
   let(:asl_new_success) { FactoryBot.create(:successful_activity_stream_log, run_time: 2.hours.ago) }
-  let(:relevant_parent_object) { FactoryBot.create(:parent_object_with_bib_id, oid: "2004628") }
+  let(:relevant_parent_object) { FactoryBot.create(:parent_object_with_bib_id, oid: "2004628", last_mc_update: "2020-06-10 17:38:27".to_datetime) }
+  let(:relevant_parent_object_two) { FactoryBot.create(:parent_object_with_bib_id, oid: "2003431", last_mc_update: "2020-06-10 17:38:27".to_datetime) }
   let(:asl_failed) { FactoryBot.create(:failed_activity_stream_log, run_time: 1.hour.ago) }
   let(:asl_old_success) { FactoryBot.create(:successful_activity_stream_log, run_time: "2020-06-12T21:05:53.000+0000".to_datetime) }
   let(:latest_activity_stream_page) { File.open(File.join(fixture_path, "activity_stream", "page-3.json")).read }
@@ -13,6 +14,76 @@ RSpec.describe ActivityStreamReader do
   let(:page_1_activity_stream_page) { File.open(File.join(fixture_path, "activity_stream", "page-1.json")).read }
   let(:page_0_activity_stream_page) { File.open(File.join(fixture_path, "activity_stream", "page-0.json")).read }
   let(:json_parsed_page) { JSON.parse(latest_activity_stream_page) }
+  let(:relevant_oid) { "2004628" }
+  let(:relevant_oid_two) { "2003431" }
+  let(:irrelevant_oid) { "not_in_db" }
+  # This is likely to change very soon
+  let(:relevant_metadata_source) { "/ladybird/oid" }
+  let(:irrelevant_metadata_source) { "/ils/bib" }
+  let(:relevant_time) { "2020-06-12T21:06:53.000+0000" }
+  let(:irrelevant_time) { "2020-06-12T21:04:53.000+0000" }
+  let(:relevant_activity_type) { "Update" }
+  let(:irrelevant_activity_type) { "Create" }
+  let(:relevant_item) do
+    {
+      "endTime" => relevant_time,
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{relevant_oid}",
+        "type" => "Document"
+      },
+      "type" => relevant_activity_type
+    }
+  end
+  let(:relevant_item_two) do
+    {
+      "endTime" => relevant_time,
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{relevant_oid_two}",
+        "type" => "Document"
+      },
+      "type" => relevant_activity_type
+    }
+  end
+  let(:irrelevant_item_not_ladybird) do
+    {
+      "endTime" => relevant_time,
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{irrelevant_metadata_source}/#{relevant_oid}",
+        "type" => "Document"
+      },
+      "type" => relevant_activity_type
+    }
+  end
+  let(:irrelevant_item_not_in_db) do
+    {
+      "endTime" => relevant_time,
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{irrelevant_oid}",
+        "type" => "Document"
+      },
+      "type" => relevant_activity_type
+    }
+  end
+  let(:irrelevant_item_too_old) do
+    {
+      "endTime" => irrelevant_time,
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{relevant_oid}",
+        "type" => "Document"
+      },
+      "type" => relevant_activity_type
+    }
+  end
+  let(:irrelevant_not_an_update) do
+    {
+      "endTime" => "2020-06-12T21:06:53.000+0000",
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{relevant_oid}",
+        "type" => "Document"
+      },
+      "type" => irrelevant_activity_type
+    }
+  end
 
   before do
     # Part of ActiveSupport, see support/time_helpers.rb, behaves similarly to old TimeCop gem
@@ -34,19 +105,27 @@ RSpec.describe ActivityStreamReader do
         .to_return(status: 200, body: page_1_activity_stream_page)
       stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/streams/activity/page-0")
         .to_return(status: 200, body: page_0_activity_stream_page)
+      stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628")
+        .to_return(status: 200, body: relevant_mc_response_1)
+      stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2003431")
+        .to_return(status: 200, body: relevant_mc_response_2)
     end
+    let(:relevant_mc_response_1) { File.open(File.join(fixture_path, "ladybird", "2004628.json")).read }
+    let(:relevant_mc_response_2) { File.open(File.join(fixture_path, "ladybird", "2003431.json")).read }
+    let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "ladybird", "2004628.json") }
+    let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "ladybird", "2004628.json") }
 
     it "can get a page from the MetadataCloud activity stream" do
       expect(asr.fetch_and_parse_page("https://metadata-api-test.library.yale.edu/metadatacloud/streams/activity")["type"]).to eq "OrderedCollectionPage"
     end
-    # There are 4000 total items, but only 4 of them are Ladybird updates with the oid of the relevant_parent_object
-    # that has been added to the database in our before block
-    it "processes the entire activity stream if it has never been run before" do
-      expect(ActivityStreamLog.count).to eq 0
+
+    it "saves a Ladybird fixture object to the filesystem" do
+      mc_update_before = relevant_parent_object.last_mc_update
       described_class.update
-      expect(ActivityStreamLog.count).to eq 1
-      expect(ActivityStreamLog.last.object_count).to eq 4
+      mc_update_after = ParentObject.find_by(oid: relevant_oid).last_mc_update
+      expect(mc_update_before).to be < mc_update_after
     end
+
     # There are 1837 total items from the relevant time period, but only 2 of them are Ladybird updates
     # with the oid of the relevant_parent_object that has been added to the database in our before block
     it "can process the partial activity stream if there is a previous successful run" do
@@ -57,69 +136,26 @@ RSpec.describe ActivityStreamReader do
       expect(ActivityStreamLog.count).to eq 2
       expect(ActivityStreamLog.last.object_count).to eq 2
     end
+
+    # There are 4000 total items, but only 4 of them are Ladybird updates with the oid of the relevant_parent_object
+    # that has been added to the database in our before block
+    it "processes the entire activity stream if it has never been run before" do
+      expect(ActivityStreamLog.count).to eq 0
+      described_class.update
+      expect(ActivityStreamLog.count).to eq 1
+      expect(ActivityStreamLog.last.object_count).to eq 4
+    end
+
+    it "adds relevant oids for update to an array" do
+      expect(asr.oids_for_update.size).to eq 0
+      asr.process_item(relevant_item)
+      expect(asr.oids_for_update.size).to eq 1
+      asr.process_item(relevant_item_two)
+      expect(asr.oids_for_update.size).to eq 2
+    end
   end
 
   context "determining whether an item from the activity stream is relevant" do
-    let(:relevant_oid) { "2004628" }
-    let(:irrelevant_oid) { "not_in_db" }
-    # This is likely to change very soon
-    let(:relevant_metadata_source) { "/ladybird/oid" }
-    let(:irrelevant_metadata_source) { "/ils/bib" }
-    let(:relevant_time) { "2020-06-12T21:06:53.000+0000" }
-    let(:irrelevant_time) { "2020-06-12T21:04:53.000+0000" }
-    let(:relevant_activity_type) { "Update" }
-    let(:irrelevant_activity_type) { "Create" }
-    let(:relevant_item) do
-      {
-        "endTime" => relevant_time,
-        "object" => {
-          "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{relevant_oid}",
-          "type" => "Document"
-        },
-        "type" => relevant_activity_type
-      }
-    end
-    let(:irrelevant_item_not_ladybird) do
-      {
-        "endTime" => relevant_time,
-        "object" => {
-          "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{irrelevant_metadata_source}/#{relevant_oid}",
-          "type" => "Document"
-        },
-        "type" => relevant_activity_type
-      }
-    end
-    let(:irrelevant_item_not_in_db) do
-      {
-        "endTime" => relevant_time,
-        "object" => {
-          "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{irrelevant_oid}",
-          "type" => "Document"
-        },
-        "type" => relevant_activity_type
-      }
-    end
-    let(:irrelevant_item_too_old) do
-      {
-        "endTime" => irrelevant_time,
-        "object" => {
-          "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{relevant_oid}",
-          "type" => "Document"
-        },
-        "type" => relevant_activity_type
-      }
-    end
-    let(:irrelevant_not_an_update) do
-      {
-        "endTime" => "2020-06-12T21:06:53.000+0000",
-        "object" => {
-          "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source}/#{relevant_oid}",
-          "type" => "Document"
-        },
-        "type" => irrelevant_activity_type
-      }
-    end
-
     before do
       relevant_parent_object
       asl_old_success


### PR DESCRIPTION
- Creates a set that contains relevant oids from the activity stream
- Updates those objects from the MetadataCloud

Connected to https://github.com/yalelibrary/YUL-DC/issues/245 

Co-authored by: Michael Appleby <michael.appleby@yale.edu>
Co-authored by: Lakeisha Robinson <lakeisha.robinson@yale.edu>
Co-authored by: Yue Ji <yue.ji@yale.edu>
Co-authored by: Dylan Salay <dylan@notch8.com>
Co-authored by: JP Engstrom <jp@notch8.com>