### PR TITLE
Read ArchiveSpace and Voyager non-bib updates from activity stream

### DIFF
--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -41,11 +41,11 @@ class ActivityStreamReader
     true
   end
 
-##
-# It takes an activity stream item and returns true or false based on whether that item is in the database.
-# If the item is in the database, it adds the item's oid and metadata source to the oids_for_update set.
-# In order to do so, it parses the metadata source (Ladybird, Voyager ("ils"), or ArchiveSpace),
-# source id type (whether an oid, bib, holding, etc.), and the source id itself.
+  ##
+  # It takes an activity stream item and returns true or false based on whether that item is in the database.
+  # If the item is in the database, it adds the item's oid and metadata source to the oids_for_update set.
+  # In order to do so, it parses the metadata source (Ladybird, Voyager ("ils"), or ArchiveSpace),
+  # source id type (whether an oid, bib, holding, etc.), and the source id itself.
   def find_by_id(item)
     match_data = /\/api\/(\w*)\/(\w*)\/(\S*)/.match(item["object"]["id"])&.captures
     metadata_source = match_data[0]
@@ -122,7 +122,7 @@ class ActivityStreamReader
 
   ##
   # Takes a MetadataCloud url as a string and returns a parsed JSON object
-  # containing the body of the response 
+  # containing the body of the response
   def fetch_and_parse_page(page_url)
     mcs = MetadataCloudService.new
     latest_page = mcs.mc_get(page_url).body.to_s

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -36,9 +36,9 @@ class ActivityStreamReader
     return false unless item["type"] == "Update"
     return false unless last_run_time.nil? || item["endTime"].to_datetime.after?(last_run_time)
     oid = /\/api\/ladybird\/oid\/(\S*)/.match(item["object"]["id"])&.captures&.first
-    bib_id = /\/api\/ils\/bib\/(\S*)/.match(item["object"]["id"])&.captures&.first
-    return false if oid.nil? && bib_id.nil?
-    return false unless ParentObject.find_by(oid: oid) || ParentObject.find_by(bib_id: bib_id)
+    bib = /\/api\/ils\/bib\/(\S*)/.match(item["object"]["id"])&.captures&.first
+    return false if oid.nil? && bib.nil?
+    return false unless ParentObject.find_by(oid: oid) || ParentObject.find_by(bib: bib)
     true
   end
 
@@ -46,9 +46,9 @@ class ActivityStreamReader
     @tally += 1
     oid = /\/api\/ladybird\/oid\/(\S*)/.match(item["object"]["id"])&.captures&.first
     return oids_for_update.add([oid, "ladybird"]) if oid
-    bib_id = /\/api\/ils\/bib\/(\S*)/.match(item["object"]["id"])&.captures&.first
-    if bib_id
-      oid = ParentObject.find_by(bib_id: bib_id).oid
+    bib = /\/api\/ils\/bib\/(\S*)/.match(item["object"]["id"])&.captures&.first
+    if bib
+      oid = ParentObject.find_by(bib: bib).oid
       return oids_for_update.add([oid, "ils"])
     end
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -5,9 +5,9 @@
 class ParentObject < ApplicationRecord
   # t.string "oid" - Unique identifier for a ParentObject, currently from Ladybird, eventually will be minted by this application
   # t.index ["oid"], name: "index_parent_objects_on_oid", unique: true
-  # t.string "bib_id" - Identifier from Voyager, the integrated library system ("ils"). Short for Bibliographic record.
-  # t.string "holding_id" - Identifier from Voyager
-  # t.string "item_id" - Identifier from Voyager
+  # t.string "bib" - Identifier from Voyager, the integrated library system ("ils"). Short for Bibliographic record.
+  # t.string "holding" - Identifier from Voyager
+  # t.string "item" - Identifier from Voyager
   # t.string "barcode"
   # t.string "aspace_uri" - Identifier from ArchiveSpace
   # t.datetime "created_at", precision: 6, null: false

--- a/db/migrate/20200610173827_create_parent_objects.rb
+++ b/db/migrate/20200610173827_create_parent_objects.rb
@@ -2,9 +2,9 @@ class CreateParentObjects < ActiveRecord::Migration[6.0]
   def change
     create_table :parent_objects do |t|
       t.string :oid
-      t.string :bib_id
-      t.string :holding_id
-      t.string :item_id
+      t.string :bib
+      t.string :holding
+      t.string :item
       t.string :barcode
       t.string :aspace_uri
       t.datetime :last_mc_update

--- a/db/migrate/20200621104105_change_id_column_name.rb
+++ b/db/migrate/20200621104105_change_id_column_name.rb
@@ -1,7 +1,7 @@
 class ChangeIdColumnName < ActiveRecord::Migration[6.0]
   def change
-    rename_column :parent_objects, :bib, :bib
-    rename_column :parent_objects, :holding, :holding
-    rename_column :parent_objects, :item, :item
+    rename_column :parent_objects, :bib_id, :bib
+    rename_column :parent_objects, :holding_id, :holding
+    rename_column :parent_objects, :item_id, :item
   end
 end

--- a/db/migrate/20200621104105_change_id_column_name.rb
+++ b/db/migrate/20200621104105_change_id_column_name.rb
@@ -1,0 +1,7 @@
+class ChangeIdColumnName < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :parent_objects, :bib, :bib
+    rename_column :parent_objects, :holding, :holding
+    rename_column :parent_objects, :item, :item
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_234004) do
+ActiveRecord::Schema.define(version: 2020_06_21_104105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,9 +25,9 @@ ActiveRecord::Schema.define(version: 2020_06_18_234004) do
 
   create_table "parent_objects", force: :cascade do |t|
     t.string "oid"
-    t.string "bib_id"
-    t.string "holding_id"
-    t.string "item_id"
+    t.string "bib"
+    t.string "holding"
+    t.string "item"
     t.string "barcode"
     t.string "aspace_uri"
     t.datetime "last_ladybird_update"

--- a/spec/factories/parent_objects.rb
+++ b/spec/factories/parent_objects.rb
@@ -3,15 +3,15 @@
 FactoryBot.define do
   factory :parent_object do
     oid { "MyString" }
-    bib_id { "MyString" }
+    bib { "MyString" }
     last_ladybird_update { "2020-06-10 17:38:27" }
-    factory :parent_object_with_bib_id do
+    factory :parent_object_with_bib do
       oid { "2004628" }
-      bib_id { "3163155" }
+      bib { "3163155" }
     end
     factory :parent_object_with_aspace_uri do
       oid { "16854285" }
-      bib_id { "12307100" }
+      bib { "12307100" }
       barcode { "39002102340669" }
       aspace_uri { "/repositories/11/archival_objects/515305" }
     end

--- a/spec/fixtures/activity_stream/page-0.json
+++ b/spec/fixtures/activity_stream/page-0.json
@@ -11,6 +11,14 @@
     {
       "endTime": "2020-06-12T21:05:20.000+0000",
       "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:05:20.000+0000",
+      "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
         "type": "Document"
       },

--- a/spec/fixtures/activity_stream/page-1.json
+++ b/spec/fixtures/activity_stream/page-1.json
@@ -11,6 +11,14 @@
     {
       "endTime": "2020-06-12T21:05:51.000+0000",
       "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:05:51.000+0000",
+      "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
         "type": "Document"
       },

--- a/spec/fixtures/activity_stream/page-2.json
+++ b/spec/fixtures/activity_stream/page-2.json
@@ -11,6 +11,14 @@
     {
       "endTime": "2020-06-12T21:06:22.000+0000",
       "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:06:22.000+0000",
+      "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
         "type": "Document"
       },

--- a/spec/fixtures/activity_stream/page-3.json
+++ b/spec/fixtures/activity_stream/page-3.json
@@ -11,6 +11,14 @@
     {
       "endTime": "2020-06-12T21:06:53.000+0000",
       "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:06:53.000+0000",
+      "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628",
         "type": "Document"
       },

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe ActivityStreamReader do
     FactoryBot.create(
       :parent_object_with_bib,
       oid: "2003431",
+      bib: "9734763",
+      holding: "10050400",
+      item: "10763785",
+      barcode: "39002091549668",
       last_ladybird_update: "2020-06-10 17:38:27".to_datetime,
       last_voyager_update: "2020-06-10 17:38:27".to_datetime
     )
@@ -67,6 +71,26 @@ RSpec.describe ActivityStreamReader do
       "endTime" => relevant_time,
       "object" => {
         "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source_voyager}/#{relevant_bib}",
+        "type" => "Document"
+      },
+      "type" => relevant_activity_type
+    }
+  end
+  let(:relevant_item_from_voyager_holding) do
+    {
+      "endTime" => relevant_time,
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api/ils/holding/10050400",
+        "type" => "Document"
+      },
+      "type" => relevant_activity_type
+    }
+  end
+  let(:relevant_item_from_voyager_item) do
+    {
+      "endTime" => relevant_time,
+      "object" => {
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api/ils/item/10763785",
         "type" => "Document"
       },
       "type" => relevant_activity_type
@@ -194,6 +218,7 @@ RSpec.describe ActivityStreamReader do
   context "determining whether an item from the activity stream is relevant" do
     before do
       relevant_parent_object
+      relevant_parent_object_two
       asl_old_success
     end
 
@@ -203,6 +228,8 @@ RSpec.describe ActivityStreamReader do
 
     it "can confirm that a Voyager item is relevant" do
       expect(asr.relevant?(relevant_item_from_voyager)).to be_truthy
+      expect(asr.relevant?(relevant_item_from_voyager_holding)).to be_truthy
+      expect(asr.relevant?(relevant_item_from_voyager_item)).to be_truthy
     end
 
     it "does not confirm that an irrelevant item is relevant" do

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -200,7 +200,8 @@ RSpec.describe ActivityStreamReader do
       expect(aspace_update_before).to be < aspace_update_after
     end
 
-    # There are ~1837 total items from the relevant time period, but only 4 of them are Ladybird or Voyager updates
+    # There are ~1837 total items from the relevant time period, but only 6 of them
+    # are Ladybird, Voyager, or ArchiveSpace updates
     # with the oid that has been added to the database in our before block
     it "can process the partial activity stream if there is a previous successful run" do
       asl_old_success
@@ -211,8 +212,9 @@ RSpec.describe ActivityStreamReader do
       expect(ActivityStreamLog.last.object_count).to eq 6
     end
 
-    # There are ~4000 total items, but only 8 of them are Ladybird or Voyager updates with the oid of the relevant_parent_object
-    # that has been added to the database in our before block
+    # There are ~4000 total items, but only 12 of them are Ladybird, Voyager,
+    # or ArchiveSpace updates with the oid of the relevant_parent_object
+    # that have been added to the database in our before block
     it "processes the entire activity stream if it has never been run before" do
       expect(ActivityStreamLog.count).to eq 0
       described_class.update

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe ActivityStreamReader do
   let(:asl_new_success) { FactoryBot.create(:successful_activity_stream_log, run_time: 2.hours.ago) }
   let(:relevant_parent_object) do
     FactoryBot.create(
-      :parent_object_with_bib_id,
+      :parent_object_with_bib,
       oid: "2004628",
-      bib_id: "3163155",
+      bib: "3163155",
       last_ladybird_update: "2020-06-10 17:38:27".to_datetime,
       last_voyager_update: "2020-06-10 17:38:27".to_datetime
     )
   end
   let(:relevant_parent_object_two) do
     FactoryBot.create(
-      :parent_object_with_bib_id,
+      :parent_object_with_bib,
       oid: "2003431",
       last_ladybird_update: "2020-06-10 17:38:27".to_datetime,
       last_voyager_update: "2020-06-10 17:38:27".to_datetime
@@ -30,7 +30,7 @@ RSpec.describe ActivityStreamReader do
   let(:page_0_activity_stream_page) { File.open(File.join(fixture_path, "activity_stream", "page-0.json")).read }
   let(:json_parsed_page) { JSON.parse(latest_activity_stream_page) }
   let(:relevant_oid) { "2004628" }
-  let(:relevant_bib_id) { "3163155" }
+  let(:relevant_bib) { "3163155" }
   let(:relevant_aspace_uri) { "repositories/11/archival_objects/515305" }
   let(:relevant_oid_two) { "2003431" }
   let(:irrelevant_oid) { "not_in_db" }
@@ -66,7 +66,7 @@ RSpec.describe ActivityStreamReader do
     {
       "endTime" => relevant_time,
       "object" => {
-        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source_voyager}/#{relevant_bib_id}",
+        "id" => "http://metadata-api-test.library.yale.edu/metadatacloud/api#{relevant_metadata_source_voyager}/#{relevant_bib}",
         "type" => "Document"
       },
       "type" => relevant_activity_type

--- a/spec/services/metadata_cloud_service_spec.rb
+++ b/spec/services/metadata_cloud_service_spec.rb
@@ -96,29 +96,29 @@ RSpec.describe MetadataCloudService do
 
   context "a crosswalk maintained in the database", vpn_only: false do
     let(:oid) { "2004628" }
-    let(:bib_id) { "3163155" }
-    let(:po) { FactoryBot.create(:parent_object, oid: oid, bib_id: bib_id) }
+    let(:bib) { "3163155" }
+    let(:po) { FactoryBot.create(:parent_object, oid: oid, bib: bib) }
 
-    it "can update the bib_id" do
+    it "can update the bib" do
       po
       mcs.find_source_ids_for(oid)
-      expect(po["bib_id"]).to eq bib_id
+      expect(po["bib"]).to eq bib
     end
 
     context "with all the oids" do
       let(:oid_1) { "2057976" }
-      let(:bib_id_1) { "7039963" }
-      let(:po_1) { FactoryBot.create(:parent_object, oid: oid_1, bib_id: bib_id_1) }
+      let(:bib_1) { "7039963" }
+      let(:po_1) { FactoryBot.create(:parent_object, oid: oid_1, bib: bib_1) }
       let(:oid_2) { "2004628" }
-      let(:bib_id_2) { "3163155" }
-      let(:po_2) { FactoryBot.create(:parent_object, oid: oid_2, bib_id: bib_id_2) }
+      let(:bib_2) { "3163155" }
+      let(:po_2) { FactoryBot.create(:parent_object, oid: oid_2, bib: bib_2) }
 
       it "can crosswalk multiple oids" do
         po_1
         po_2
         described_class.find_source_ids
-        expect(po_1["bib_id"]).to eq bib_id_1
-        expect(po_2["bib_id"]).to eq bib_id_2
+        expect(po_1["bib"]).to eq bib_1
+        expect(po_2["bib"]).to eq bib_2
       end
     end
 
@@ -134,9 +134,9 @@ RSpec.describe MetadataCloudService do
     context "with an object with only an oid set that should have all other identifiers" do
       let(:oid) { "16854285" }
       let(:aspace_uri) { "/repositories/11/archival_objects/515305" }
-      let(:bib_id) { "12307100" }
-      let(:holding_id) { "12484205" }
-      let(:item_id) { "10996370" }
+      let(:bib) { "12307100" }
+      let(:holding) { "12484205" }
+      let(:item) { "10996370" }
       let(:po) { FactoryBot.create(:parent_object, oid: oid) }
 
       it "adds the aspace uri" do
@@ -144,9 +144,9 @@ RSpec.describe MetadataCloudService do
         mcs.find_source_ids_for(oid)
         expect(ParentObject.find_by(oid: oid)["aspace_uri"].nil?).to be false
         expect(ParentObject.find_by(oid: oid)["aspace_uri"]).to eq aspace_uri
-        expect(ParentObject.find_by(oid: oid)["bib_id"]).to eq bib_id
-        expect(ParentObject.find_by(oid: oid)["holding_id"]).to eq holding_id
-        expect(ParentObject.find_by(oid: oid)["item_id"]).to eq item_id
+        expect(ParentObject.find_by(oid: oid)["bib"]).to eq bib
+        expect(ParentObject.find_by(oid: oid)["holding"]).to eq holding
+        expect(ParentObject.find_by(oid: oid)["item"]).to eq item
       end
     end
   end


### PR DESCRIPTION
- Change names of IDs in model to match MetadataCloud so we can use values directly (bib_id vs. bib, etc.)
- Move database lookup into its own method so that we only have to do it once per ActivityStream item
- Add more test fixture objects (Voyager activity stream items for types other than bib, ArchiveSpace examples)