### PR TITLE
Configure yarn correctly, set up volumes to boost dev speed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     ports:
       - '3001:3001'
     volumes:
-      - .:/home/app/webapp
+      - .:/home/app/webapp:cached
+      - node_modules:/home/app/webapp/node_modules
+      - rails_cache:/home/app/webapp/tmp/cache
     # Keep the stdin open, so we can attach to our app container's process
     # and do things such as byebug, etc:
     stdin_open: true
@@ -42,3 +44,5 @@ services:
 volumes:
   postgres:
   solr:
+  node_modules:
+  rails_cache:

--- a/ops/nginx.sh
+++ b/ops/nginx.sh
@@ -13,18 +13,19 @@ then
 fi
 
 rm -rf /home/app/webapp/.ruby*
+/bin/bash -l -c 'chown -R app:app /home/app/webapp/tmp/cache' # mounted volume may have wrong permissions
+/bin/bash -l -c 'chown -R app:app /home/app/webapp/public' # mounted volume may have wrong permissions
+/bin/bash -l -c 'chown app:app /home/app/webapp/node_modules' # mounted volume may have wrong permissions
 
 declare -p | grep -Ev 'BASHOPTS|PWD|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /container.env
 
 if [[ $PASSENGER_APP_ENV == "development" ]] || [[ $PASSENGER_APP_ENV == "test" ]]
 then
-    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && bundle exec rails db:migrate db:test:prepare'
+    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && yarn && bundle exec rails db:migrate db:test:prepare'
 fi
 
 if [[ $PASSENGER_APP_ENV == "production" ]] || [[ $PASSENGER_APP_ENV == "staging" ]]
 then
-    /bin/bash -l -c 'chown -R app:app /home/app/webapp/tmp' # mounted volume may have wrong permissions
-    /bin/bash -l -c 'chown -R app:app /home/app/webapp/public' # mounted volume may have wrong permissions
     /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && bundle exec rake db:migrate'
     if [ -d /home/app/webapp/public/assets-new ]; then
         /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && rsync -a public/assets-new/ public/assets/'


### PR DESCRIPTION
Node modules were not being installed properly, preventing webpacker from being present. If yarn install ever got run, it would be fine and Rails would update it as need it, but it has to happen one time so that webpack exists before it will run again.

Because I was configuring yarn / node_modules I brought in some volume logic which massively speeds up asset generation in Rails+Docker+Mac (or Windows).  It won't change how things work for Linux users, but it prevents an exponential slow down on other OS. (9s to 3s now for the little tiny set we have so far).  

I'll make sure this same change gets sync'd Blacklight during the Camerata work I'm doing this week.