### PR TITLE
Revert "Sanitize branch name in CI (#158)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,18 +68,13 @@ jobs:
       - docker/check
       - docker/pull:
           images: yalelibraryit/dc-management:$CIRCLE_SHA1
-      # Dockerhub tags allow alphanumeric characters, periods, underscores, and hyphens.
-      # This run step makes CLEAN_BRANCH, the branch name with all forbidden characters removed,
-      # available to subsequent steps.
-      - run: |
-          echo "export CLEAN_BRANCH=`echo $CIRCLE_BRANCH |sed 's#[^[:alnum:]._-]##g'`" >> $BASH_ENV
       - docker-tag:
           image: yalelibraryit/dc-management
           from_tag: $CIRCLE_SHA1
-          to_tag: $CLEAN_BRANCH
+          to_tag: $CIRCLE_BRANCH
       - docker/push:
           image: yalelibraryit/dc-management
-          tag: $CLEAN_BRANCH
+          tag: $CIRCLE_BRANCH
   publish-github-release:
     executor: docker/docker
     steps:


### PR DESCRIPTION
This reverts commit ec204f95ce6d67b1798438521c2e32981b89faa3.

This appears to be making it so that some branch names do not report back to github correctly, breaking CI for those branches. Reverting until that is sorted out.