### PR TITLE
remove sourcemaps from Webpack

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
-module.exports = environment.toWebpackConfig()
+const config = environment.toWebpackConfig()
+config.devtool = 'none'
+
+module.exports = config


### PR DESCRIPTION
This PR removes sourcemaps from Webpack. This eliminates the following warning when building the Docker image.

```
WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  js/application-0ffc8d2b51469b2431da.js.map.gz (268 KiB)
```