### PR TITLE
Reapplying "Sanitize branch name in CI (#158)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,13 +68,18 @@ jobs:
       - docker/check
       - docker/pull:
           images: yalelibraryit/dc-management:$CIRCLE_SHA1
+      # Dockerhub tags allow alphanumeric characters, periods, underscores, and hyphens.
+      # This run step makes CLEAN_BRANCH, the branch name with all forbidden characters removed,
+      # available to subsequent steps.
+      - run: |
+          echo "export CLEAN_BRANCH=`echo $CIRCLE_BRANCH |sed 's#[^[:alnum:]._-]##g'`" >> $BASH_ENV
       - docker-tag:
           image: yalelibraryit/dc-management
           from_tag: $CIRCLE_SHA1
-          to_tag: $CIRCLE_BRANCH
+          to_tag: $CLEAN_BRANCH
       - docker/push:
           image: yalelibraryit/dc-management
-          tag: $CIRCLE_BRANCH
+          tag: $CLEAN_BRANCH
   publish-github-release:
     executor: docker/docker
     steps:


### PR DESCRIPTION
This reverts commit 618ed9f9a9a3cc9c62df2addc55f842b34913b9a on the
theory that the CI problem that day may have been unrelated.