### PR TITLE
Does not try to fetch from MetadataCloud if VPN is set to empty string

### DIFF
--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -4,7 +4,8 @@ class MetadataSource < ApplicationRecord
   has_many :parent_objects, foreign_key: "authoritative_metadata_source_id"
 
   def fetch_record(parent_object)
-    raw_metadata = if ENV['VPN']
+    # The environment value has to be set as a string, real booleans do not work
+    raw_metadata = if ENV["VPN"] == "true"
                      fetch_record_on_vpn(parent_object)
                    else
                      S3Service.download("#{metadata_cloud_name}/#{file_name(parent_object)}")

--- a/spec/models/metadata_source_spec.rb
+++ b/spec/models/metadata_source_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe MetadataSource, type: :model do
 
     around do |example|
       original_vpn = ENV['VPN']
-      ENV['VPN'] = nil
+      ENV['VPN'] = ""
       example.run
       ENV['VPN'] = original_vpn
     end


### PR DESCRIPTION
- Setting to empty string seems to be default behavior for docker-compose (not nil)