### PR TITLE
Call method in controller to create ParentObject

### DIFF
--- a/app/controllers/goobi_xml_imports_controller.rb
+++ b/app/controllers/goobi_xml_imports_controller.rb
@@ -28,7 +28,6 @@ class GoobiXmlImportsController < ApplicationController
 
     respond_to do |format|
       if @goobi_xml_import.save
-        @goobi_xml_import.refresh_metadata_cloud
         format.html { redirect_to @goobi_xml_import, notice: 'Goobi xml import was successfully created.' }
         format.json { render :show, status: :created, location: @goobi_xml_import }
       else

--- a/app/controllers/goobi_xml_imports_controller.rb
+++ b/app/controllers/goobi_xml_imports_controller.rb
@@ -28,6 +28,7 @@ class GoobiXmlImportsController < ApplicationController
 
     respond_to do |format|
       if @goobi_xml_import.save
+        @goobi_xml_import.refresh_metadata_cloud
         format.html { redirect_to @goobi_xml_import, notice: 'Goobi xml import was successfully created.' }
         format.json { render :show, status: :created, location: @goobi_xml_import }
       else

--- a/app/controllers/oid_imports_controller.rb
+++ b/app/controllers/oid_imports_controller.rb
@@ -13,7 +13,6 @@ class OidImportsController < ApplicationController
     @oid_import = OidImport.new(oid_import_params)
     respond_to do |format|
       if @oid_import.save
-        @oid_import.refresh_metadata_cloud
         format.html { redirect_to oid_imports_path, notice: "Your records have been retrieved from the MetadataCloud and are ready to be indexed to Solr." }
       else
         format.html { render :new }

--- a/app/models/goobi_xml_import.rb
+++ b/app/models/goobi_xml_import.rb
@@ -2,8 +2,8 @@
 
 class GoobiXmlImport < ApplicationRecord
   attr_reader :file
-  before_create :file
   validate :validate_upload
+  after_create :refresh_metadata_cloud
 
   def file=(value)
     @file = value

--- a/app/models/oid_import.rb
+++ b/app/models/oid_import.rb
@@ -2,6 +2,7 @@
 
 class OidImport < ApplicationRecord
   attr_reader :file
+  after_create :refresh_metadata_cloud
   validate :check_file_type
 
   def check_file_type

--- a/spec/models/oid_import_spec.rb
+++ b/spec/models/oid_import_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe OidImport, type: :model do
   let(:metadata_cloud_response_body_5) { File.open(File.join(fixture_path, "ladybird", "16854285.json")).read }
 
   before do
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2034600")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2034600.json")
       .to_return(status: 200, body: metadata_cloud_response_body_1)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2046567")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2046567.json")
       .to_return(status: 200, body: metadata_cloud_response_body_2)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/16414889")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16414889.json")
       .to_return(status: 200, body: metadata_cloud_response_body_3)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/14716192")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/14716192.json")
       .to_return(status: 200, body: metadata_cloud_response_body_4)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/16854285")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
       .to_return(status: 200, body: metadata_cloud_response_body_5)
     prep_metadata_call
   end

--- a/spec/system/goobi_xml_imports_spec.rb
+++ b/spec/system/goobi_xml_imports_spec.rb
@@ -5,17 +5,20 @@ RSpec.describe "Goobi Xml Imports", type: :system do
   let(:metadata_cloud_response_body_1) { File.open(File.join(fixture_path, "ladybird", "2012315.json")).read }
 
   before do
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2012315")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012315.json")
       .to_return(status: 200, body: metadata_cloud_response_body_1)
+    prep_metadata_call
   end
 
   context "when uploading a Goobi xml" do
-    it "uploads and increases GoobiImport count" do
+    it "uploads and increases GoobiImport and ParentObject count" do
       visit new_goobi_xml_import_path
       expect(GoobiXmlImport.count).to eq 0
+      expect(ParentObject.count).to eq 0
       page.attach_file("goobi_xml_import_file", fixture_path + "/goobi/metadata/2012315/meta.xml")
       click_button("Import")
       expect(GoobiXmlImport.count).to eq 1
+      expect(ParentObject.count).to eq 1
       expect(GoobiXmlImport.last.goobi_xml).not_to eq nil
       expect(GoobiXmlImport.last.goobi_xml).not_to be_empty
     end


### PR DESCRIPTION
An xml import should create a ParentObject, calling the method in the controller that does this.