### PR TITLE
Only log errors for test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   ENV["SOLR_CORE"] = "blacklight-test"
-
+  
+  config.log_level = :error
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   ENV["SOLR_CORE"] = "blacklight-test"
-  
+
   config.log_level = :error
   config.cache_classes = false
   config.action_view.cache_template_loading = true


### PR DESCRIPTION
- When everything is output to stdout it can be hard to see where the problems are actually occurring, this also matches the Blacklight application