### PR TITLE
Refactor tests to use tag for prepping metadata sources

### DIFF
--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 require "support/time_helpers"
 
-RSpec.describe ActivityStreamReader do
+RSpec.describe ActivityStreamReader, prep_metadata_sources: true do
   let(:asr) { described_class.new }
   let(:relevant_parent_object) do
     FactoryBot.create(
@@ -204,23 +204,22 @@ RSpec.describe ActivityStreamReader do
   before do
     # Part of ActiveSupport, see support/time_helpers.rb, behaves similarly to old TimeCop gem
     freeze_time
-    prep_metadata_call
     # OID 2004628
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2004628")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/bib/3163155")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2004628.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2004628.json")).read)
     # OID 2003431
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2003431")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2003431.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2003431.json")).read)
     stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002091549668?bib=9734763")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2003431.json")).read)
     # OID 16854285
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16854285")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16854285.json")).read)
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002102340669?bib=12307100")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16854285.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16854285.json")).read)
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/aspace/repositories/11/archival_objects/515305")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-16854285.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-16854285.json")).read)
     # Activity Stream - stub requests to MetadataCloud activity stream with fixture objects that represent single activity_stream json pages
     stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/streams/activity")

--- a/spec/models/concerns/json_file_spec.rb
+++ b/spec/models/concerns/json_file_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe JsonFile do
+RSpec.describe JsonFile, prep_metadata_sources: true do
   let(:parent_object) { FactoryBot.create(:parent_object, oid: '100001') }
   let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "ladybird", "100001.json") }
   before do
-    prep_metadata_call
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/100001")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/100001.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "100001.json")).read)
   end
 

--- a/spec/models/goobi_xml_import_spec.rb
+++ b/spec/models/goobi_xml_import_spec.rb
@@ -2,14 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe GoobiXmlImport, type: :model do
+RSpec.describe GoobiXmlImport, type: :model, prep_metadata_sources: true do
   let(:goobi_import) { described_class.new }
   let(:metadata_cloud_response_body_1) { File.open(File.join(fixture_path, "ladybird", "2012315.json")).read }
 
   before do
     stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012315.json")
       .to_return(status: 200, body: metadata_cloud_response_body_1)
-    prep_metadata_call
   end
 
   it "evaluates a valid Goobi METs file as valid" do

--- a/spec/models/metadata_source_spec.rb
+++ b/spec/models/metadata_source_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MetadataSource, type: :model do
+RSpec.describe MetadataSource, type: :model, prep_metadata_sources: true do
   context "with vpn on" do
     it "uses the correct url type method" do
       {
@@ -19,7 +19,6 @@ RSpec.describe MetadataSource, type: :model do
       let(:ladybird_source) { FactoryBot.build(:metadata_source) }
 
       before do
-        prep_metadata_call
         stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16797069")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16797069.json")).read)
         stub_request(:put, "https://yul-development-samples.s3.amazonaws.com/ladybird/16797069.json").to_return(status: 200)

--- a/spec/models/oid_import_spec.rb
+++ b/spec/models/oid_import_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe OidImport, type: :model do
+RSpec.describe OidImport, type: :model, prep_metadata_sources: true do
   subject(:oid_import) { described_class.new }
   let(:metadata_cloud_response_body_1) { File.open(File.join(fixture_path, "ladybird", "2034600.json")).read }
   let(:metadata_cloud_response_body_2) { File.open(File.join(fixture_path, "ladybird", "2046567.json")).read }
@@ -11,17 +11,16 @@ RSpec.describe OidImport, type: :model do
   let(:metadata_cloud_response_body_5) { File.open(File.join(fixture_path, "ladybird", "16854285.json")).read }
 
   before do
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2034600")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2034600.json")
       .to_return(status: 200, body: metadata_cloud_response_body_1)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2046567")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2046567.json")
       .to_return(status: 200, body: metadata_cloud_response_body_2)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/16414889")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16414889.json")
       .to_return(status: 200, body: metadata_cloud_response_body_3)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/14716192")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/14716192.json")
       .to_return(status: 200, body: metadata_cloud_response_body_4)
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/16854285")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
       .to_return(status: 200, body: metadata_cloud_response_body_5)
-    prep_metadata_call
   end
 
   describe "csv file import" do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -2,13 +2,16 @@
 
 require 'rails_helper'
 
-RSpec.describe ParentObject, type: :model do
+RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
   let(:ladybird) { 1 }
   let(:voyager) { 2 }
   let(:aspace) { 3 }
   let(:unexpected_metadata_source) { 4 }
   before do
-    prep_metadata_call
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
+      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2004628.json")
+      .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2004628.json")).read)
   end
 
   context "a newly created ParentObject with an unexpected authoritative_metadata_source" do
@@ -20,10 +23,6 @@ RSpec.describe ParentObject, type: :model do
   end
   context "a newly created ParentObject with just the oid and default authoritative_metadata_source (Ladybird for now)" do
     let(:parent_object) { described_class.create(oid: "2004628") }
-    before do
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2004628")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
-    end
 
     it "pulls from the MetadataCloud for Ladybird and not Voyager or ArchiveSpace" do
       expect(parent_object.authoritative_metadata_source_id).to eq ladybird
@@ -36,12 +35,6 @@ RSpec.describe ParentObject, type: :model do
 
   context "a newly created ParentObject with Voyager as authoritative_metadata_source" do
     let(:parent_object) { described_class.create(oid: "2004628", authoritative_metadata_source_id: voyager) }
-    before do
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2004628")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/bib/3163155")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2004628.json")).read)
-    end
 
     it "pulls from the MetadataCloud for Ladybird and Voyager and not ArchiveSpace" do
       expect(parent_object.authoritative_metadata_source_id).to eq voyager
@@ -60,9 +53,9 @@ RSpec.describe ParentObject, type: :model do
   context "a newly created ParentObject with ArchiveSpace as authoritative_metadata_source" do
     let(:parent_object) { described_class.create(oid: "2012036", authoritative_metadata_source_id: aspace) }
     before do
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2012036")
+      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
         .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/aspace/repositories/11/archival_objects/555049")
+      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-2012036.json")
         .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-2012036.json")).read)
     end
 

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -13,12 +13,11 @@ require 'rails_helper'
 # of tools you can use to make these specs even more expressive, but we're
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
-RSpec.describe "/parent_objects", type: :request do
+RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true do
   # ParentObject. As you add validations to ParentObject, be sure to
   # adjust the attributes here as well.
   before do
-    prep_metadata_call
-    stub_request(:get, "https://metadata-api-test.library.yale.edu/metadatacloud/api/ladybird/oid/2004628")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
   end
 

--- a/spec/services/fixture_indexing_service_spec.rb
+++ b/spec/services/fixture_indexing_service_spec.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe FixtureIndexingService, clean: true do
-  before do
-    prep_metadata_call
-  end
-
+RSpec.describe FixtureIndexingService, clean: true, prep_metadata_sources: true do
   context "indexing to Solr from the database with Ladybird ParentObjects" do
     let(:parent_object_1) { FactoryBot.create(:parent_object, oid: "2034600") }
     let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2046567") }
@@ -19,15 +15,15 @@ RSpec.describe FixtureIndexingService, clean: true do
     let(:metadata_cloud_response_body_4) { File.open(File.join(fixture_path, "ladybird", "14716192.json")).read }
     let(:metadata_cloud_response_body_5) { File.open(File.join(fixture_path, "ladybird", "16854285.json")).read }
     before do
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2034600")
+      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2034600.json")
         .to_return(status: 200, body: metadata_cloud_response_body_1)
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2046567")
+      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2046567.json")
         .to_return(status: 200, body: metadata_cloud_response_body_2)
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16414889")
+      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16414889.json")
         .to_return(status: 200, body: metadata_cloud_response_body_3)
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/14716192")
+      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/14716192.json")
         .to_return(status: 200, body: metadata_cloud_response_body_4)
-      stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16854285")
+      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
         .to_return(status: 200, body: metadata_cloud_response_body_5)
       parent_object_1
       parent_object_2
@@ -107,11 +103,11 @@ RSpec.describe FixtureIndexingService, clean: true do
       let(:parent_object_with_public_visibility) { FactoryBot.create(:parent_object, oid: oid, visibility: "Public") }
 
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2012036")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002091459793?bib=6805375")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2012036.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/aspace/repositories/11/archival_objects/555049")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-2012036.json")).read)
       end
 
@@ -128,9 +124,9 @@ RSpec.describe FixtureIndexingService, clean: true do
       let(:parent_object_without_visibility) { FactoryBot.create(:parent_object, oid: no_vis_oid) }
 
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16189097-no_vis")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-no_vis.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-no_vis.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002113593819?bib=8330740")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/V-16189097-no_vis.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-no_vis.json")).read)
       end
 
@@ -147,9 +143,9 @@ RSpec.describe FixtureIndexingService, clean: true do
       let(:priv_oid) { "16189097-priv" }
       let(:parent_object_with_private_visibility) { FactoryBot.create(:parent_object, oid: priv_oid, visibility: "Private") }
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16189097-priv")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-priv.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-priv.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002113593819?bib=8330740")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-priv.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-priv.json")).read)
       end
 

--- a/spec/services/fixture_parsing_service_spec.rb
+++ b/spec/services/fixture_parsing_service_spec.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe FixtureParsingService do
+RSpec.describe FixtureParsingService, prep_metadata_sources: true do
   let(:oid) { "2003431" }
   let(:metadata_source) { "ladybird" }
   let(:short_oid_path) { Rails.root.join("spec", "fixtures", "short_fixture_ids.csv") }
   before do
-    prep_metadata_call
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16854285")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16854285.json")).read)
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002102340669?bib=12307100")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16854285.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16854285.json")).read)
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/aspace/repositories/11/archival_objects/515305")
+    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-16854285.json")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-16854285.json")).read)
   end
 
@@ -38,13 +37,13 @@ RSpec.describe FixtureParsingService do
       let(:yale_only_oid) { "16189097-yale" }
       let(:yale_only_object) { FactoryBot.create(:parent_object, oid: yale_only_oid) }
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16189097-priv")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-priv.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-priv.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002113593819?bib=8330740")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-priv.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-priv.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16189097-yale")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-yale.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-yale.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002113593819?bib=8330740")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-yale.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-yale.json")).read)
       end
 

--- a/spec/services/metadata_cloud_service_spec.rb
+++ b/spec/services/metadata_cloud_service_spec.rb
@@ -4,15 +4,11 @@ require "webmock"
 
 WebMock.allow_net_connect!
 
-RSpec.describe MetadataCloudService do
+RSpec.describe MetadataCloudService, prep_metadata_sources: true do
   let(:mcs) { described_class.new }
   let(:oid) { "16371272" }
   let(:oid_url) { "https://#{described_class.metadata_cloud_host}/metadatacloud/api/ladybird/oid/#{oid}?mediaType=json" }
   let(:short_oid_path) { Rails.root.join("spec", "fixtures", "short_fixture_ids.csv") }
-
-  before do
-    prep_metadata_call
-  end
 
   context "creating a ParentObject from an import" do
     before do

--- a/spec/support/metadata_call_helper.rb
+++ b/spec/support/metadata_call_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module MetdataCallHelper
-  def prep_metadata_call
-    FactoryBot.create(:metadata_source)
-    FactoryBot.create(:metadata_source_voyager)
-    FactoryBot.create(:metadata_source_aspace)
-  end
-end

--- a/spec/support/metadata_sources_helper.rb
+++ b/spec/support/metadata_sources_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module MetdataCallHelper
+  # Setup rspec
+  RSpec.configure do |config|
+    config.before(prep_metadata_sources: true) do
+      FactoryBot.create(:metadata_source)
+      FactoryBot.create(:metadata_source_voyager)
+      FactoryBot.create(:metadata_source_aspace)
+    end
+  end
+end

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "ParentObjects", type: :system do
-  before do
-    prep_metadata_call
-  end
+RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
   context "creating a new ParentObject based on oid" do
     before do
       visit parent_objects_path
@@ -13,7 +10,7 @@ RSpec.describe "ParentObjects", type: :system do
 
     context "with a ParentObject whose authoritative_metadata_source is Ladybird" do
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2012036")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
         fill_in('Oid', with: "2012036")
         click_on("Create Parent object")
@@ -40,9 +37,9 @@ RSpec.describe "ParentObjects", type: :system do
 
     context "with a ParentObject whose authoritative_metadata_source is Voyager" do
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2012036")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002091459793?bib=6805375")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2012036.json")).read)
 
         fill_in('Oid', with: "2012036")
@@ -70,9 +67,9 @@ RSpec.describe "ParentObjects", type: :system do
 
     context "with a ParentObject whose authoritative_metadata_source is ArchiveSpace" do
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2012036")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/aspace/repositories/11/archival_objects/555049")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-2012036.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-2012036.json")).read)
         fill_in('Oid', with: "2012036")
         select('ArchiveSpace')
@@ -92,9 +89,9 @@ RSpec.describe "ParentObjects", type: :system do
 
     context "with a ParentObject with only some relevant identifiers" do
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/2004628")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/bib/3163155")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2004628.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2004628.json")).read)
         fill_in('Oid', with: "2004628")
         click_on("Create Parent object")
@@ -116,9 +113,9 @@ RSpec.describe "ParentObjects", type: :system do
 
     context "with a Private fixture object" do
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16189097-priv")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-priv.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-priv.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002113593819?bib=8330740")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-priv.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-priv.json")).read)
         fill_in('Oid', with: "16189097-priv")
         click_on("Create Parent object")
@@ -130,9 +127,9 @@ RSpec.describe "ParentObjects", type: :system do
 
     context "with a Yale only fixture object" do
       before do
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ladybird/oid/16189097-yale")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-yale.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-yale.json")).read)
-        stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002113593819?bib=8330740")
+        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-yale.json")
           .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-yale.json")).read)
         fill_in('Oid', with: "16189097-yale")
         click_on("Create Parent object")


### PR DESCRIPTION
- Another thing step Rob and I discussed was to create a helper method for stub requests to outside services (MetadataCloud and S3 bucket). That might nullify all the changes to what urls are called, but I think should probably be a separate PR.