### PR TITLE
Refactor tests to make more readable

### DIFF
--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -205,22 +205,15 @@ RSpec.describe ActivityStreamReader, prep_metadata_sources: true do
     # Part of ActiveSupport, see support/time_helpers.rb, behaves similarly to old TimeCop gem
     freeze_time
     # OID 2004628
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2004628.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2004628.json")).read)
+    stub_metadata_cloud("2004628", "ladybird")
+    stub_metadata_cloud("V-2004628", "ils")
     # OID 2003431
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2003431.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2003431.json")).read)
-    stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/api/ils/barcode/39002091549668?bib=9734763")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2003431.json")).read)
+    stub_metadata_cloud("2003431", "ladybird")
+    stub_metadata_cloud("V-2003431", "ils")
     # OID 16854285
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16854285.json")).read)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16854285.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16854285.json")).read)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-16854285.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-16854285.json")).read)
+    stub_metadata_cloud("16854285", "ladybird")
+    stub_metadata_cloud("V-16854285", "ils")
+    stub_metadata_cloud("AS-16854285", "aspace")
     # Activity Stream - stub requests to MetadataCloud activity stream with fixture objects that represent single activity_stream json pages
     stub_request(:get, "https://#{MetadataCloudService.metadata_cloud_host}/metadatacloud/streams/activity")
       .to_return(status: 200, body: File.open(File.join(fixture_path, "activity_stream", "page-3.json")).read)

--- a/spec/lib/iiif_manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest_factory_spec.rb
@@ -16,10 +16,8 @@ RSpec.describe IiifManifestFactory, prep_metadata_sources: true do
       .to_return(status: 200, body: File.open(File.join(fixture_path, "manifests", "2012315.json")).read)
     stub_request(:put, "https://yul-development-samples.s3.amazonaws.com/manifests/2012315.json")
       .to_return(status: 200)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012315.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012315.json")).read)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2107188.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2107188.json")).read)
+    stub_metadata_cloud("2012315")
+    stub_metadata_cloud("2107188")
     stub_info
     parent_object
     xml_import

--- a/spec/models/concerns/json_file_spec.rb
+++ b/spec/models/concerns/json_file_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe JsonFile, prep_metadata_sources: true do
   let(:parent_object) { FactoryBot.create(:parent_object, oid: '100001') }
   let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "ladybird", "100001.json") }
   before do
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/100001.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "100001.json")).read)
+    stub_metadata_cloud("100001")
   end
 
   it "can save a ParentObject to json" do

--- a/spec/models/goobi_xml_import_spec.rb
+++ b/spec/models/goobi_xml_import_spec.rb
@@ -4,11 +4,9 @@ require 'rails_helper'
 
 RSpec.describe GoobiXmlImport, type: :model, prep_metadata_sources: true do
   let(:goobi_import) { described_class.new }
-  let(:metadata_cloud_response_body_1) { File.open(File.join(fixture_path, "ladybird", "2012315.json")).read }
 
   before do
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012315.json")
-      .to_return(status: 200, body: metadata_cloud_response_body_1)
+    stub_metadata_cloud("2012315")
   end
 
   it "has an oid associated with it" do

--- a/spec/models/metadata_source_spec.rb
+++ b/spec/models/metadata_source_spec.rb
@@ -63,12 +63,9 @@ RSpec.describe MetadataSource, type: :model, prep_metadata_sources: true do
     before do
       stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/000000.json")
         .to_return(status: 404)
-      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16797069.json")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16797069.json")).read)
-      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16797069.json")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16797069.json")).read)
-      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-16797069.json")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-16797069.json")).read)
+      stub_metadata_cloud("16797069", 'ladybird')
+      stub_metadata_cloud("V-16797069", 'ils')
+      stub_metadata_cloud("AS-16797069", 'aspace')
     end
 
     around do |example|

--- a/spec/models/oid_import_spec.rb
+++ b/spec/models/oid_import_spec.rb
@@ -4,23 +4,13 @@ require 'rails_helper'
 
 RSpec.describe OidImport, type: :model, prep_metadata_sources: true do
   subject(:oid_import) { described_class.new }
-  let(:metadata_cloud_response_body_1) { File.open(File.join(fixture_path, "ladybird", "2034600.json")).read }
-  let(:metadata_cloud_response_body_2) { File.open(File.join(fixture_path, "ladybird", "2046567.json")).read }
-  let(:metadata_cloud_response_body_3) { File.open(File.join(fixture_path, "ladybird", "16414889.json")).read }
-  let(:metadata_cloud_response_body_4) { File.open(File.join(fixture_path, "ladybird", "14716192.json")).read }
-  let(:metadata_cloud_response_body_5) { File.open(File.join(fixture_path, "ladybird", "16854285.json")).read }
 
   before do
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2034600.json")
-      .to_return(status: 200, body: metadata_cloud_response_body_1)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2046567.json")
-      .to_return(status: 200, body: metadata_cloud_response_body_2)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16414889.json")
-      .to_return(status: 200, body: metadata_cloud_response_body_3)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/14716192.json")
-      .to_return(status: 200, body: metadata_cloud_response_body_4)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
-      .to_return(status: 200, body: metadata_cloud_response_body_5)
+    stub_metadata_cloud("2034600")
+    stub_metadata_cloud("2046567")
+    stub_metadata_cloud("16414889")
+    stub_metadata_cloud("14716192")
+    stub_metadata_cloud("16854285")
   end
 
   describe "csv file import" do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -8,10 +8,8 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
   let(:aspace) { 3 }
   let(:unexpected_metadata_source) { 4 }
   before do
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2004628.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2004628.json")).read)
+    stub_metadata_cloud("2004628", "ladybird")
+    stub_metadata_cloud("V-2004628", "ils")
   end
 
   context "a newly created ParentObject with an unexpected authoritative_metadata_source" do
@@ -53,10 +51,8 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
   context "a newly created ParentObject with ArchiveSpace as authoritative_metadata_source" do
     let(:parent_object) { described_class.create(oid: "2012036", authoritative_metadata_source_id: aspace) }
     before do
-      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
-      stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-2012036.json")
-        .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-2012036.json")).read)
+      stub_metadata_cloud("2012036", "ladybird")
+      stub_metadata_cloud("AS-2012036", "aspace")
     end
 
     it "pulls from the MetadataCloud for Ladybird and ArchiveSpace and not Voyager" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,13 +45,6 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  # Clear out solr before test
-  config.before(clean: true) do
-    solr = SolrService.connection
-    solr.delete_by_query '*:*'
-    solr.commit
-  end
-
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true do
   # ParentObject. As you add validations to ParentObject, be sure to
   # adjust the attributes here as well.
   before do
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
+    stub_metadata_cloud("2004628")
   end
 
   let(:valid_attributes) do

--- a/spec/services/fixture_parsing_service_spec.rb
+++ b/spec/services/fixture_parsing_service_spec.rb
@@ -6,12 +6,9 @@ RSpec.describe FixtureParsingService, prep_metadata_sources: true do
   let(:metadata_source) { "ladybird" }
   let(:short_oid_path) { Rails.root.join("spec", "fixtures", "short_fixture_ids.csv") }
   before do
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16854285.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16854285.json")).read)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16854285.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16854285.json")).read)
-    stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-16854285.json")
-      .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-16854285.json")).read)
+    stub_metadata_cloud("16854285", "ladybird")
+    stub_metadata_cloud("V-16854285", "ils")
+    stub_metadata_cloud("AS-16854285", "aspace")
   end
 
   it "can return a hash from a fixture file" do
@@ -37,14 +34,10 @@ RSpec.describe FixtureParsingService, prep_metadata_sources: true do
       let(:yale_only_oid) { "16189097-yale" }
       let(:yale_only_object) { FactoryBot.create(:parent_object, oid: yale_only_oid) }
       before do
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-priv.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-priv.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-priv.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-priv.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-yale.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-yale.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-yale.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-yale.json")).read)
+        stub_metadata_cloud("16189097-priv", "ladybird")
+        stub_metadata_cloud("V-16189097-priv", "ils")
+        stub_metadata_cloud("16189097-yale", "ladybird")
+        stub_metadata_cloud("V-16189097-yale", "ils")
       end
 
       it "finds the dependent uris for a ladybird object" do

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
     context "with a ParentObject whose authoritative_metadata_source is Ladybird" do
       before do
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
+        stub_metadata_cloud("2012036")
         fill_in('Oid', with: "2012036")
         click_on("Create Parent object")
       end
@@ -37,11 +36,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
     context "with a ParentObject whose authoritative_metadata_source is Voyager" do
       before do
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2012036.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2012036.json")).read)
-
+        stub_metadata_cloud("2012036", "ladybird")
+        stub_metadata_cloud("V-2012036", "ils")
         fill_in('Oid', with: "2012036")
         select('Voyager')
         click_on("Create Parent object")
@@ -67,10 +63,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
     context "with a ParentObject whose authoritative_metadata_source is ArchiveSpace" do
       before do
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2012036.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2012036.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/aspace/AS-2012036.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "aspace", "AS-2012036.json")).read)
+        stub_metadata_cloud("2012036", "ladybird")
+        stub_metadata_cloud("AS-2012036", "aspace")
         fill_in('Oid', with: "2012036")
         select('ArchiveSpace')
         click_on("Create Parent object")
@@ -89,10 +83,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
     context "with a ParentObject with only some relevant identifiers" do
       before do
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/2004628.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "2004628.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-2004628.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-2004628.json")).read)
+        stub_metadata_cloud("2004628", "ladybird")
+        stub_metadata_cloud("V-2004628", "ils")
         fill_in('Oid', with: "2004628")
         click_on("Create Parent object")
       end
@@ -113,10 +105,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
     context "with a Private fixture object" do
       before do
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-priv.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-priv.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-priv.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-priv.json")).read)
+        stub_metadata_cloud("16189097-priv", "ladybird")
+        stub_metadata_cloud("V-16189097-priv", "ils")
         fill_in('Oid', with: "16189097-priv")
         click_on("Create Parent object")
       end
@@ -127,10 +117,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
     context "with a Yale only fixture object" do
       before do
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ladybird/16189097-yale.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ladybird", "16189097-yale.json")).read)
-        stub_request(:get, "https://yul-development-samples.s3.amazonaws.com/ils/V-16189097-yale.json")
-          .to_return(status: 200, body: File.open(File.join(fixture_path, "ils", "V-16189097-yale.json")).read)
+        stub_metadata_cloud("16189097-yale", "ladybird")
+        stub_metadata_cloud("V-16189097-yale", "ils")
         fill_in('Oid', with: "16189097-yale")
         click_on("Create Parent object")
       end


### PR DESCRIPTION
- Remove superceded spec helper
- Use new stub helper to make tests more readable