### PR TITLE
479 Add author_tesim and subject_topic_tesim fields

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -36,7 +36,6 @@ module SolrIndexable
       alternativeTitleDisplay_tesim: json_to_index["alternativeTitleDisplay"],
       archiveSpaceUri_ssi: json_to_index["archiveSpaceUri"],
       author_ssim: json_to_index["creator"],
-      author_tsim: json_to_index["creator"],
       author_tesim: json_to_index["creator"],
       box_ssim: extract_box_ssim(json_to_index),
       caption_tesim: json_to_index["caption"],
@@ -113,6 +112,7 @@ module SolrIndexable
       abstract_ssim: json_to_index["abstract"], # replaced by abstract_tesim
       alternativeTitle_ssim: json_to_index["alternativeTitle"], # replaced by alternativeTitle_tesim
       alternative_title_tsm: json_to_index["alternativeTitleDisplay"], # replaced by alternativeTitleDisplay_tesim
+      author_tsim: json_to_index["creator"], # replaced by author_tesim
       date_tsim: json_to_index["date"], # replaced by date_ssim
       geo_subject_ssim: json_to_index["geoSubject"], # replaced by geoSubject_ssim
       illustrative_matter_tsi: json_to_index["illustrativeMatter"], # replaced by illustrativeMatter_tesim
@@ -130,7 +130,6 @@ module SolrIndexable
       sourceNote_ssim: json_to_index["sourceNote"], # replaced by sourceNote_tesim
       sourceTitle_ssim: json_to_index["sourceTitle"], # repleaced by sourceTitle_tesim
       subject_topic_tsim: json_to_index["subjectTopic"], # replaced by subjectTopic_tesim and subjectTopic_ssim
-      subject_topic_tesim: json_to_index["subjectTopic"], # replaced by subjectTopic_tesim and subjectTopic_ssim
       title_tsim: json_to_index["title"] # replaced by title_tesim
     }
   end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -37,6 +37,7 @@ module SolrIndexable
       archiveSpaceUri_ssi: json_to_index["archiveSpaceUri"],
       author_ssim: json_to_index["creator"],
       author_tsim: json_to_index["creator"],
+      author_tesim: json_to_index["creator"],
       box_ssim: extract_box_ssim(json_to_index),
       caption_tesim: json_to_index["caption"],
       collectionId_ssim: json_to_index["collectionId"],
@@ -129,6 +130,7 @@ module SolrIndexable
       sourceNote_ssim: json_to_index["sourceNote"], # replaced by sourceNote_tesim
       sourceTitle_ssim: json_to_index["sourceTitle"], # repleaced by sourceTitle_tesim
       subject_topic_tsim: json_to_index["subjectTopic"], # replaced by subjectTopic_tesim and subjectTopic_ssim
+      subject_topic_tesim: json_to_index["subjectTopic"], # replaced by subjectTopic_tesim and subjectTopic_ssim
       title_tsim: json_to_index["title"] # replaced by title_tesim
     }
   end


### PR DESCRIPTION
This PR adds author_tesim and subject_topic_tesim fields to allow search on keywords within these fields from the search bar.
I've confirmed that both fields are showing up in Solr.