### PR TITLE
493-import-file-exception-handling

### DIFF
--- a/app/views/oid_imports/_form.html.erb
+++ b/app/views/oid_imports/_form.html.erb
@@ -11,8 +11,9 @@
     </div>
   <% end %>
   <div class="field" >
-    <%= f.file_field :file %>
+    <%= f.file_field :file, accept: '.csv', required: true %>
   </div>
+  
   <br />
   <div class="actions">
     <%= f.submit "Import", class: "btn btn-primary" %>


### PR DESCRIPTION
This PR ensures that the user selects a file to upload and that the type is csv. If a file is not selected a message appears.

![Screen Shot 2020-08-27 at 1 02 15 PM](https://user-images.githubusercontent.com/50561476/91489348-8ccff000-e865-11ea-8eef-7f3c712e3780.png)

When selecting a file to upload, only csv's are permitted. Other file types can be added to be permitted as needed.

![Screen Shot 2020-08-27 at 1 04 21 PM](https://user-images.githubusercontent.com/50561476/91489549-d7ea0300-e865-11ea-9db1-35b57f592c1c.png)
