### PR TITLE
Refactor child objects to use "oid"

### DIFF
--- a/app/controllers/child_objects_controller.rb
+++ b/app/controllers/child_objects_controller.rb
@@ -70,6 +70,6 @@ class ChildObjectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def child_object_params
-      params.require(:child_object).permit(:child_oid, :caption, :width, :height, :order, :parent_object_oid)
+      params.require(:child_object).permit(:oid, :caption, :width, :height, :order, :parent_object_oid)
     end
 end

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -2,5 +2,5 @@
 
 class ChildObject < ApplicationRecord
   belongs_to :parent_object, foreign_key: 'parent_object_oid', class_name: "ParentObject"
-  self.primary_key = 'child_oid'
+  self.primary_key = 'oid'
 end

--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -40,13 +40,13 @@ class IiifPresentation
   def add_image_to_canvas(child, canvas)
     images = canvas.images
     image = IIIF::Presentation::Resource.new
-    image['@id'] = "#{@manifest_base_url}/oid/#{oid}/canvas/#{child.child_oid}/image/1"
+    image['@id'] = "#{@manifest_base_url}/oid/#{oid}/canvas/#{child.oid}/image/1"
     image['@type'] = "oa:Annotation"
     image["motivation"] = "sc:painting"
-    image["on"] = "#{@manifest_base_url}/oid/#{oid}/canvas/#{child.child_oid}"
+    image["on"] = "#{@manifest_base_url}/oid/#{oid}/canvas/#{child.oid}"
 
     image_resource = IIIF::Presentation::ImageResource.create_image_api_image_resource(
-      service_id: "#{@image_base_url}/2/#{child.child_oid}"
+      service_id: "#{@image_base_url}/2/#{child.oid}"
     )
     image["resource"] = image_resource
     images << image
@@ -57,7 +57,7 @@ class IiifPresentation
     child_objects = ChildObject.where(parent_object: parent_object).order(:order)
     child_objects.map do |child|
       canvas = IIIF::Presentation::Canvas.new
-      canvas['@id'] = "#{@manifest_base_url}/oid/#{oid}/canvas/#{child.child_oid}"
+      canvas['@id'] = "#{@manifest_base_url}/oid/#{oid}/canvas/#{child.oid}"
       canvas['label'] = child.label
       add_image_to_canvas(child, canvas)
       canvas['height'] = canvas.images.first["resource"]["height"]

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -18,7 +18,7 @@ class ParentObject < ApplicationRecord
     ladybird_json["children"].map.with_index(1) do |child_record, index|
       next if child_object_ids.include?(child_record["oid"])
       child_objects.build(
-        child_oid: child_record["oid"],
+        oid: child_record["oid"],
         # Ladybird has only one field for both order label (7v, etc.), and descriptive captions ("Mozart at the Keyboard")
         # For the first iteration we will map this field to label
         label: child_record["caption"],

--- a/app/views/child_objects/_child_object.json.jbuilder
+++ b/app/views/child_objects/_child_object.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! child_object, :id, :child_oid, :caption, :width, :height, :order, :parent_object_oid, :created_at, :updated_at
+json.extract! child_object, :id, :oid, :caption, :width, :height, :order, :parent_object_oid, :created_at, :updated_at
 json.url child_object_url(child_object, format: :json)

--- a/app/views/child_objects/_form.html.erb
+++ b/app/views/child_objects/_form.html.erb
@@ -12,8 +12,8 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :child_oid %>
-    <%= form.text_field :child_oid %>
+    <%= form.label :oid %>
+    <%= form.text_field :oid %>
   </div>
 
   <div class="field">

--- a/app/views/child_objects/index.html.erb
+++ b/app/views/child_objects/index.html.erb
@@ -5,7 +5,7 @@
 <table>
   <thead>
     <tr>
-      <th>Child oid</th>
+      <th>Oid</th>
       <th>Caption</th>
       <th>Width</th>
       <th>Height</th>
@@ -18,7 +18,7 @@
   <tbody>
     <% @child_objects.each do |child_object| %>
       <tr>
-        <td><%= child_object.child_oid %></td>
+        <td><%= child_object.oid %></td>
         <td><%= child_object.caption %></td>
         <td><%= child_object.width %></td>
         <td><%= child_object.height %></td>

--- a/app/views/child_objects/show.html.erb
+++ b/app/views/child_objects/show.html.erb
@@ -1,8 +1,8 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Child oid:</strong>
-  <%= @child_object.child_oid %>
+  <strong>Oid:</strong>
+  <%= @child_object.oid %>
 </p>
 
 <p>

--- a/db/migrate/20200828132403_rename_column_child_objects_child_oid_to_oid.rb
+++ b/db/migrate/20200828132403_rename_column_child_objects_child_oid_to_oid.rb
@@ -1,0 +1,5 @@
+class RenameColumnChildObjectsChildOidToOid < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :child_objects, :child_oid, :oid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_20_125838) do
+ActiveRecord::Schema.define(version: 2020_08_28_132403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2020_08_20_125838) do
   end
 
   create_table "child_objects", id: false, force: :cascade do |t|
-    t.integer "child_oid"
+    t.integer "oid"
     t.string "caption"
     t.integer "width"
     t.integer "height"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2020_08_20_125838) do
     t.string "label"
     t.string "checksum"
     t.string "viewing_hint"
-    t.index ["child_oid"], name: "index_child_objects_on_child_oid", unique: true
+    t.index ["oid"], name: "index_child_objects_on_oid", unique: true
     t.index ["parent_object_oid"], name: "index_child_objects_on_parent_object_oid"
   end
 

--- a/spec/factories/child_objects.rb
+++ b/spec/factories/child_objects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :child_object do
-    child_oid { 1 }
+    oid { 1 }
     caption { "MyString" }
     width { 1 }
     height { 1 }

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
   let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_004_628) }
-  let(:child_object) { described_class.create(child_oid: "456789", parent_object: parent_object) }
+  let(:child_object) { described_class.create(oid: "456789", parent_object: parent_object) }
 
   before do
     stub_metadata_cloud("2004628")

--- a/spec/requests/child_objects_spec.rb
+++ b/spec/requests/child_objects_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe "/child_objects", type: :request, prep_metadata_sources: true do
   # adjust the attributes here as well.
   let(:valid_attributes) do
     {
-      child_oid: "12345",
+      oid: "12345",
       parent_object_oid: "2004628"
     }
   end
 
   let(:invalid_attributes) do
     {
-      child_oid: "12345",
+      oid: "12345",
       parent_object_oid: "6789"
     }
   end

--- a/spec/services/s3_service_spec.rb
+++ b/spec/services/s3_service_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe S3Service do
   end
 
   it "can download an image from a given image bucket" do
-    child_oid = "1014543"
-    remote_path = "originals/#{child_oid}.tif"
-    local_path = "spec/fixtures/access_masters/#{child_oid}.tif"
+    child_object_oid = "1014543"
+    remote_path = "originals/#{child_object_oid}.tif"
+    local_path = "spec/fixtures/access_masters/#{child_object_oid}.tif"
     expect(File.exist?(local_path)).to eq false
     described_class.download_image(remote_path, local_path)
     expect(File.exist?(local_path)).to eq true
@@ -44,9 +44,9 @@ RSpec.describe S3Service do
   end
 
   it "can upload an image to a given image bucket" do
-    child_oid = "1014543"
+    child_object_oid = "1014543"
     local_path = "spec/fixtures/ptiff_images/fake_ptiff.tif"
-    remote_path = "originals/#{child_oid}.tif"
+    remote_path = "originals/#{child_object_oid}.tif"
     expect(File.exist?(local_path)).to eq true
     expect(described_class.upload_image(local_path, remote_path).successful?).to eq true
   end

--- a/spec/views/child_objects/edit.html.erb_spec.rb
+++ b/spec/views/child_objects/edit.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "child_objects/edit", type: :view, prep_metadata_sources: true do
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2004628") }
   let(:child_object)  do
     assign(:child_object, ChildObject.create!(
-                            child_oid: 1,
+                            oid: 1,
                             caption: "10v",
                             width: 1,
                             height: 1,
@@ -24,7 +24,7 @@ RSpec.describe "child_objects/edit", type: :view, prep_metadata_sources: true do
     render
 
     assert_select "form[action=?][method=?]", child_object_path(child_object), "post" do
-      assert_select "input[name=?]", "child_object[child_oid]"
+      assert_select "input[name=?]", "child_object[oid]"
 
       assert_select "input[name=?]", "child_object[caption]"
 

--- a/spec/views/child_objects/index.html.erb_spec.rb
+++ b/spec/views/child_objects/index.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "child_objects/index", type: :view, prep_metadata_sources: true d
     parent_object
     assign(:child_objects, [
              ChildObject.create!(
-               child_oid: 111,
+               oid: 111,
                caption: "Caption",
                width: 2,
                height: 3,
@@ -18,7 +18,7 @@ RSpec.describe "child_objects/index", type: :view, prep_metadata_sources: true d
                parent_object_oid: "2004628"
              ),
              ChildObject.create!(
-               child_oid: 222,
+               oid: 222,
                caption: "Caption",
                width: 2,
                height: 3,

--- a/spec/views/child_objects/new.html.erb_spec.rb
+++ b/spec/views/child_objects/new.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe "child_objects/new", type: :view do
   before do
     assign(:child_object, ChildObject.new(
-                            child_oid: "MyString",
+                            oid: 1,
                             caption: "MyString",
                             width: 1,
                             height: 1,
@@ -18,7 +18,7 @@ RSpec.describe "child_objects/new", type: :view do
     render
 
     assert_select "form[action=?][method=?]", child_objects_path, "post" do
-      assert_select "input[name=?]", "child_object[child_oid]"
+      assert_select "input[name=?]", "child_object[oid]"
 
       assert_select "input[name=?]", "child_object[caption]"
 

--- a/spec/views/child_objects/show.html.erb_spec.rb
+++ b/spec/views/child_objects/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "child_objects/show", type: :view, prep_metadata_sources: true do
     stub_metadata_cloud("2004628")
     parent_object
     @child_object = assign(:child_object, ChildObject.create!(
-                                            child_oid: "Child Oid",
+                                            oid: 1,
                                             caption: "Caption",
                                             width: 2,
                                             height: 3,
@@ -20,7 +20,7 @@ RSpec.describe "child_objects/show", type: :view, prep_metadata_sources: true do
 
   it "renders attributes in <p>" do
     render
-    expect(rendered).to match(/Child oid/)
+    expect(rendered).to match(/Oid/)
     expect(rendered).to match(/Caption/)
     expect(rendered).to match(/2/)
     expect(rendered).to match(/3/)


### PR DESCRIPTION
- rather than "child oid" as identifier
- leads to more re-usable code