### PR TITLE
I542 csv with multiple sources

### DIFF
--- a/app/models/mets_xml_import.rb
+++ b/app/models/mets_xml_import.rb
@@ -25,6 +25,6 @@ class MetsXmlImport < ApplicationRecord
   end
 
   def refresh_metadata_cloud
-    MetadataCloudService.create_parent_objects_from_oids([mets_doc.oid], 'ladybird') # TODO: make 'ladybird' a metadata source attribute on this object
+    MetadataCloudService.create_parent_objects_from_oids([mets_doc.oid], ['ladybird']) # TODO: make 'ladybird' a metadata source attribute on this object
   end
 end

--- a/app/models/oid_import.rb
+++ b/app/models/oid_import.rb
@@ -21,6 +21,7 @@ class OidImport < ApplicationRecord
 
   def refresh_metadata_cloud
     oids = parsed_csv.entries.map { |r| r['oid'] }
-    MetadataCloudService.create_parent_objects_from_oids(oids, 'ladybird') # TODO: make 'ladybird' a metadata source attribute on this object
+    metadata_source = parsed_csv.entries.map { |r| r['Source'] }
+    MetadataCloudService.create_parent_objects_from_oids(oids, metadata_source) # TODO: make 'ladybird' a metadata source attribute on this object
   end
 end

--- a/app/models/oid_import.rb
+++ b/app/models/oid_import.rb
@@ -22,6 +22,6 @@ class OidImport < ApplicationRecord
   def refresh_metadata_cloud
     oids = parsed_csv.entries.map { |r| r['oid'] }
     metadata_source = parsed_csv.entries.map { |r| r['Source'] }
-    MetadataCloudService.create_parent_objects_from_oids(oids, metadata_source) # TODO: make 'ladybird' a metadata source attribute on this object
+    MetadataCloudService.create_parent_objects_from_oids(oids, metadata_source)
   end
 end

--- a/app/models/oid_import.rb
+++ b/app/models/oid_import.rb
@@ -21,7 +21,7 @@ class OidImport < ApplicationRecord
 
   def refresh_metadata_cloud
     oids = parsed_csv.entries.map { |r| r['oid'] }
-    metadata_source = parsed_csv.entries.map { |r| r['Source'] }
-    MetadataCloudService.create_parent_objects_from_oids(oids, metadata_source)
+    metadata_sources = parsed_csv.entries.map { |r| r['Source'] }
+    MetadataCloudService.create_parent_objects_from_oids(oids, metadata_sources)
   end
 end

--- a/app/services/metadata_cloud_service.rb
+++ b/app/services/metadata_cloud_service.rb
@@ -3,19 +3,19 @@
 class MetadataCloudService
   ##
   # This is the method that is called from the yale:refresh_fixture_data rake task
-  def self.refresh_fixture_data(oid_path, metadata_source)
+  def self.refresh_fixture_data(oid_path, metadata_sources)
     oids = MetadataCloudService.list_of_oids(oid_path)
-    create_parent_objects_from_oids(oids, metadata_source)
+    create_parent_objects_from_oids(oids, metadata_sources)
     oids.each do |oid|
       ParentObject.where(oid: oid).first.to_json_file
     end
   end
 
-  def self.create_parent_objects_from_oids(oids, metadata_source)
-    oids.zip(metadata_source).each do |oid, source|
+  def self.create_parent_objects_from_oids(oids, metadata_sources)
+    oids.zip(metadata_sources).each do |oid, metadata_source|
       ParentObject.where(oid: oid).first_or_create do |parent_object|
-        parent_object.authoritative_metadata_source = if source.present?
-                                                        MetadataSource.find_by(metadata_cloud_name: source)
+        parent_object.authoritative_metadata_source = if metadata_source.present?
+                                                        MetadataSource.find_by(metadata_cloud_name: metadata_source)
                                                       else
                                                         MetadataSource.find_by(metadata_cloud_name: 'ladybird')
                                                       end

--- a/app/services/metadata_cloud_service.rb
+++ b/app/services/metadata_cloud_service.rb
@@ -15,6 +15,7 @@ class MetadataCloudService
     oids.each do |oid|
       ParentObject.where(oid: oid).first_or_create do |parent_object|
         parent_object.authoritative_metadata_source = MetadataSource.find_by(metadata_cloud_name: metadata_source)
+        byebug
       end
     end
   end

--- a/app/services/metadata_cloud_service.rb
+++ b/app/services/metadata_cloud_service.rb
@@ -12,10 +12,13 @@ class MetadataCloudService
   end
 
   def self.create_parent_objects_from_oids(oids, metadata_source)
-    oids.each do |oid|
+    oids.zip(metadata_source).each do |oid, source|
       ParentObject.where(oid: oid).first_or_create do |parent_object|
-        parent_object.authoritative_metadata_source = MetadataSource.find_by(metadata_cloud_name: metadata_source)
-        byebug
+        parent_object.authoritative_metadata_source = if source.present?
+                                                        MetadataSource.find_by(metadata_cloud_name: source)
+                                                      else
+                                                        MetadataSource.find_by(metadata_cloud_name: 'ladybird')
+                                                      end
       end
     end
   end

--- a/spec/fixtures/short_fixture_ids_with_source.csv
+++ b/spec/fixtures/short_fixture_ids_with_source.csv
@@ -1,0 +1,7 @@
+oid,Source
+2034600,ladybird
+2046567,ils
+14716192,aspace
+16414889,ils
+16854285,ladybird
+30000016189097,

--- a/spec/models/oid_import_spec.rb
+++ b/spec/models/oid_import_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OidImport, type: :model, prep_metadata_sources: true do
 
   before do
     stub_metadata_cloud("2034600")
-    stub_metadata_cloud("2005512")
+    stub_metadata_cloud("2046567")
     stub_metadata_cloud("16414889")
     stub_metadata_cloud("14716192")
     stub_metadata_cloud("16854285")
@@ -36,5 +36,15 @@ RSpec.describe OidImport, type: :model, prep_metadata_sources: true do
       oid_import.refresh_metadata_cloud
       expect(ParentObject.count).to eq 5
     end
+
+    it "can identify the metadata source" do
+      oid_import.file = File.new(fixture_path + '/short_fixture_ids_with_source.csv')
+      oid_import.refresh_metadata_cloud
+      byebug
+      expect(ParentObject.first.authoritative_metadata_source_id).to eq 1
+      expect(ParentObject.second.authoritative_metadata_source_id).to eq 2
+      expect(ParentObject.third.authoritative_metadata_source_id).to eq 3
+    end
+
   end
 end

--- a/spec/models/oid_import_spec.rb
+++ b/spec/models/oid_import_spec.rb
@@ -40,11 +40,17 @@ RSpec.describe OidImport, type: :model, prep_metadata_sources: true do
     it "can identify the metadata source" do
       oid_import.file = File.new(fixture_path + '/short_fixture_ids_with_source.csv')
       oid_import.refresh_metadata_cloud
-      byebug
       expect(ParentObject.first.authoritative_metadata_source_id).to eq 1
       expect(ParentObject.second.authoritative_metadata_source_id).to eq 2
       expect(ParentObject.third.authoritative_metadata_source_id).to eq 3
+      expect(ParentObject.fourth.authoritative_metadata_source_id).to eq 2
+      expect(ParentObject.fifth.authoritative_metadata_source_id).to eq 1
     end
 
+    it 'defaults to ladybird if no metadata source is provided' do
+      oid_import.file = File.new(fixture_path + '/short_fixture_ids_with_source.csv')
+      oid_import.refresh_metadata_cloud
+      expect(ParentObject.last.authoritative_metadata_source_id).to eq 1
+    end
   end
 end

--- a/spec/services/metadata_cloud_service_spec.rb
+++ b/spec/services/metadata_cloud_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe MetadataCloudService, prep_metadata_sources: true do
     end
     it "can create a parent_object from an array of oids" do
       expect(ParentObject.count).to eq 0
-      described_class.create_parent_objects_from_oids(["16371253"], "ladybird")
+      described_class.create_parent_objects_from_oids(["16371253"], ["ladybird"])
       expect(ParentObject.count).to eq 1
       expect(ParentObject.where(oid: "16371253").first.ladybird_json).not_to be nil
       expect(ParentObject.where(oid: "16371253").first.ladybird_json).not_to be_empty
@@ -38,7 +38,7 @@ RSpec.describe MetadataCloudService, prep_metadata_sources: true do
 
   context "it gets called from a rake task" do
     let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "ladybird", "2034600.json") }
-    let(:metadata_source) { "ladybird" }
+    let(:metadata_source) { ["ladybird"] }
 
     it "is easy to invoke" do
       time_stamp_before = File.mtime(path_to_example_file.to_s)
@@ -50,7 +50,7 @@ RSpec.describe MetadataCloudService, prep_metadata_sources: true do
 
   context "saving a Voyager record" do
     let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "ils", "V-2034600.json") }
-    let(:metadata_source) { "ils" }
+    let(:metadata_source) { ["ils"] }
 
     before do
       stub_metadata_cloud("V-2034600", "ils")
@@ -70,11 +70,11 @@ RSpec.describe MetadataCloudService, prep_metadata_sources: true do
 
   context "saving an ArchiveSpace record" do
     let(:oid_with_aspace) { "16854285" }
-    let(:metadata_source) { "aspace" }
+    let(:metadata_source) { ["aspace"] }
     let(:oid_without_aspace) { "2034600" }
 
     let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "aspace", "AS-16854285.json") }
-    let(:metadata_source) { "aspace" }
+    let(:metadata_source) { ["aspace"] }
 
     before do
       stub_metadata_cloud("AS-16854285", "aspace")
@@ -92,7 +92,7 @@ RSpec.describe MetadataCloudService, prep_metadata_sources: true do
       time_stamp_before = File.mtime(path_to_example_file.to_s)
       described_class.refresh_fixture_data(short_oid_path, metadata_source)
       time_stamp_after = File.mtime(path_to_example_file.to_s)
-      expect(time_stamp_before).to be < time_stamp_after
+      expect(time_stamp_before).to be <= time_stamp_after
     end
   end
 

--- a/spec/services/metadata_cloud_service_spec.rb
+++ b/spec/services/metadata_cloud_service_spec.rb
@@ -70,11 +70,10 @@ RSpec.describe MetadataCloudService, prep_metadata_sources: true do
 
   context "saving an ArchiveSpace record" do
     let(:oid_with_aspace) { "16854285" }
-    let(:metadata_source) { ["aspace"] }
+    let(:metadata_source) { ["aspace", "aspace", "aspace", "aspace", "aspace"] }
     let(:oid_without_aspace) { "2034600" }
 
     let(:path_to_example_file) { Rails.root.join("spec", "fixtures", "aspace", "AS-16854285.json") }
-    let(:metadata_source) { ["aspace"] }
 
     before do
       stub_metadata_cloud("AS-16854285", "aspace")
@@ -92,7 +91,7 @@ RSpec.describe MetadataCloudService, prep_metadata_sources: true do
       time_stamp_before = File.mtime(path_to_example_file.to_s)
       described_class.refresh_fixture_data(short_oid_path, metadata_source)
       time_stamp_after = File.mtime(path_to_example_file.to_s)
-      expect(time_stamp_before).to be <= time_stamp_after
+      expect(time_stamp_before).to be < time_stamp_after
     end
   end
 


### PR DESCRIPTION
Allows CSV to declare the source in a column with header "Source" (ladybird, ils, aspace) and sets the authoritative metadata source when the OID is ingested. The default authoritative metadata source is ladybird.