### PR TITLE
Add script to run multiple DJs in a container for Docker

### DIFF
--- a/bin/delayed_job_blocking
+++ b/bin/delayed_job_blocking
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Variable DELAYED_JOB_ARGS contains the arguments for delayed jobs for, e.g. defining queues and worker pools.
+
+# function that is called when the docker container should stop. It stops the delayed job processes
+_term() {
+  echo "Caught SIGTERM signal! Stopping delayed jobs !"
+  # unbind traps
+  trap - SIGTERM
+  trap - TERM
+  trap - SIGINT
+  trap - INT
+  # end delayed jobs
+  bundle exec "./bin/delayed_job ${DELAYED_JOB_ARGS} stop"
+
+  exit
+}
+
+# register handler for selected signals
+trap _term SIGTERM
+trap _term TERM
+trap _term INT
+trap _term SIGINT
+
+echo "Starting delayed jobs ... with ARGs \"$*\""
+
+# restart delayed jobs on script execution
+bundle exec "./bin/delayed_job $* restart"
+
+echo "Finished starting delayed jobs... Waiting for SIGTERM / CTRL C"
+
+# sleep forever until exit
+while true; do sleep 86400; done


### PR DESCRIPTION
Needs to be merged and deployed before Camerata gets updated use it.  By it self this doesn't change anything, just gets the script in place for future use.