### PR TITLE
Add Solr JSON to Parent Object show page

### DIFF
--- a/app/views/parent_objects/_solr_document.html.erb
+++ b/app/views/parent_objects/_solr_document.html.erb
@@ -1,0 +1,3 @@
+<div class="pre-scrollable">
+    <%= formatted_json(@parent_object.to_solr) %>
+</div>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -65,5 +65,10 @@
   <%= render 'authoritative_json', parent_object: @parent_object %>
 </p>
 
+<p>
+    <strong>Solr Record:</strong>
+    <%= render 'solr_document', parent_object: @parent_object %>
+</p>
+
 <%= link_to 'Edit', edit_parent_object_path(@parent_object) %> |
 <%= link_to 'Back', parent_objects_path %>


### PR DESCRIPTION
Simply show the generated Solr json on the PO show page. Makes evaluating what is getting indexed a snap.