### PR TITLE
Fix filtering on VPN for case where VPN=false and not nil

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,7 +77,7 @@ RSpec.configure do |config|
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-  config.filter_run_excluding vpn_only: true if ENV['VPN'].nil?
+  config.filter_run_excluding vpn_only: true if ENV['VPN'] != 'true'
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
I was getting failing specs on the latest Camerata update.