### PR TITLE
Pretty up OID import pages, bring OID flash message current

### DIFF
--- a/app/controllers/oid_imports_controller.rb
+++ b/app/controllers/oid_imports_controller.rb
@@ -3,6 +3,7 @@
 class OidImportsController < ApplicationController
   def index
     @oid_imports = OidImport.all
+    @oid_import = OidImport.new
   end
 
   def new
@@ -13,7 +14,7 @@ class OidImportsController < ApplicationController
     @oid_import = OidImport.new(oid_import_params)
     respond_to do |format|
       if @oid_import.save
-        format.html { redirect_to oid_imports_path, notice: "Your records have been retrieved from the MetadataCloud and are ready to be indexed to Solr." }
+        format.html { redirect_to oid_imports_path, notice: "Your records have been retrieved from the MetadataCloud. PTIFF generation, manifest generation and indexing happen in the background." }
       else
         format.html { render :new }
       end

--- a/app/views/oid_imports/_form.html.erb
+++ b/app/views/oid_imports/_form.html.erb
@@ -1,5 +1,5 @@
 <h1>Import CSV</h1>
-<%= form_for(@oid_import, class: 'btn', multipart: true) do |f| %>
+<%= form_for(@oid_import, multipart: true, html: { class: 'btn form form-inline' }) do |f| %>
   <% if @oid_import.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@oid_import.errors.count, "error") %> prohibited this event from being saved:</h2>
@@ -12,11 +12,6 @@
   <% end %>
   <div class="field" >
     <%= f.file_field :file, accept: '.csv', required: true %>
-  </div>
-  
-  <br />
-  <div class="actions">
     <%= f.submit "Import", class: "btn btn-primary" %>
-    <%= link_to "OID Imports Index", oid_imports_path, class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/oid_imports/index.html.erb
+++ b/app/views/oid_imports/index.html.erb
@@ -1,11 +1,12 @@
 <div class="container">
-<h1>Oid Imports</h1>
-<%= link_to "Management Index", root_path, class: 'btn btn-primary mb-2' %>
+  <h1>Oid Imports</h1>
+  <%= render partial: "oid_imports/form" %>
+
   <% if flash[:notice] %>
     <div class="notice"><%= flash[:notice] %></div>
   <% end %>
-<br />
-<table class="table table-bordered table-responsive table-striped">
+  <br />
+  <table class="table table-bordered table-striped">
     <thead class="thead-dark">
       <tr>
         <th scope="col"> ID </th>

--- a/spec/system/csv_import_spec.rb
+++ b/spec/system/csv_import_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Oid CSV Import", type: :system, prep_metadata_sources: true do
       page.attach_file("oid_import_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
       click_button("Import")
       expect(OidImport.count).to eq 1
-      expect(page).to have_content("Your records have been retrieved from the MetadataCloud and are ready to be indexed to Solr.")
+      expect(page).to have_content("Your records have been retrieved from the MetadataCloud. PTIFF generation, manifest generation and indexing happen in the background.")
     end
   end
 end


### PR DESCRIPTION
Cosmetic changes. Makes the form inline, corrects the table styling, adds the form to the OID index page so you can add them from the page you can view them.