### PR TITLE
Use separate environment variable for thumbnail host

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -150,7 +150,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def representative_thumbnail
     oid = child_objects.where(order: 1)&.first&.oid
-    "#{ENV['IIIF_IMAGE_BASE_URL']}/2/#{oid}/full/!200,200/0/default.jpg"
+    image_host = ENV['THUMBNAIL_BASE_URL'] || ENV['IIIF_IMAGE_BASE_URL']
+    "#{image_host}/2/#{oid}/full/!200,200/0/default.jpg"
   end
 
   def child_captions

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -48,7 +48,12 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
 
     context "with a public item" do
       let(:parent_object_with_public_visibility) { FactoryBot.create(:parent_object, oid: oid, source_name: 'ils', visibility: "Public") }
-
+      around do |example|
+        original_thumbnail_url = ENV['THUMBNAIL_BASE_URL']
+        ENV['THUMBNAIL_BASE_URL'] = "http://iiif_image:8182/iiif"
+        example.run
+        ENV['THUMBNAIL_BASE_URL'] = original_thumbnail_url
+      end
       before do
         stub_metadata_cloud(oid.to_s)
         stub_metadata_cloud("V-#{oid}", "ils")
@@ -68,7 +73,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
 
       it "can index a thumbnail path to Solr" do
         solr_document = parent_object_with_public_visibility.reload.to_solr
-        expect(solr_document[:thumbnail_path_ss]).to eq "#{ENV['IIIF_IMAGE_BASE_URL']}/2/1052760/full/!200,200/0/default.jpg"
+        expect(solr_document[:thumbnail_path_ss]).to eq "http://iiif_image:8182/iiif/2/1052760/full/!200,200/0/default.jpg"
       end
     end
 


### PR DESCRIPTION
- In development, the internal image host can't be resolved outside the container and vise versa. So that thumbnails show in local dev for Blacklight, save the internal host to Solr