### PR TITLE
Remove expectation of User.email (#297)

### DIFF
--- a/db/migrate/20200922185416_remove_user_email_index.rb
+++ b/db/migrate/20200922185416_remove_user_email_index.rb
@@ -1,0 +1,8 @@
+class RemoveUserEmailIndex < ActiveRecord::Migration[6.0]
+  # Although devise adds an email field to the User model, that field is not
+  # populated by CAS. Since this field will (almost?) always be blank, we can't
+  # define an index on it. 
+  def change
+    remove_index :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_151511) do
+ActiveRecord::Schema.define(version: 2020_09_22_185416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,7 +151,6 @@ ActiveRecord::Schema.define(version: 2020_09_22_151511) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "provider"
     t.string "uid"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,5 @@ FactoryBot.define do
   factory :user do
     uid { FFaker::Internet.user_name }
     provider { "cas" }
-    email { FFaker::Internet.email }
   end
 end


### PR DESCRIPTION
The User email field is not populated by CAS, so remove it from the User 
FactoryBot factory, and remove the database index for that field.