### PR TITLE
Change default expectations for parent objects based on conversations

### DIFF
--- a/db/migrate/20200925130212_change_parent_object_defaults_for_manifests.rb
+++ b/db/migrate/20200925130212_change_parent_object_defaults_for_manifests.rb
@@ -1,0 +1,7 @@
+class ChangeParentObjectDefaultsForManifests < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default(:parent_objects, :reading_direction, from: "ltr", to: nil)
+    change_column_default(:parent_objects, :pagination, from: "individuals", to: nil)
+    change_column_default(:parent_objects, :visibility, from: "Private", to: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_185416) do
+ActiveRecord::Schema.define(version: 2020_09_25_130212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,13 +119,13 @@ ActiveRecord::Schema.define(version: 2020_09_22_185416) do
     t.datetime "last_id_update"
     t.datetime "last_voyager_update"
     t.datetime "last_aspace_update"
-    t.string "visibility", default: "Private"
+    t.string "visibility"
     t.bigint "authoritative_metadata_source_id", default: 1, null: false
     t.jsonb "ladybird_json"
     t.jsonb "voyager_json"
     t.jsonb "aspace_json"
-    t.string "reading_direction", default: "ltr"
-    t.string "pagination", default: "individuals"
+    t.string "reading_direction"
+    t.string "pagination"
     t.integer "child_object_count"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
       last_ladybird_update: Time.zone.parse('2020-06-10 17:38:27.000000000 +0000'),
       last_voyager_update: nil,
       oid: 16_854_285,
-      visibility: "Private"
+      visibility: nil
     )
   end
 end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -16,6 +16,30 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     stub_ptiffs_and_manifests
   end
 
+  context "a new ParentObject with no info" do
+    it "has the expected defaults" do
+      po = described_class.new
+      expect(po.oid).to be nil
+      expect(po.bib).to be nil
+      expect(po.holding).to be nil
+      expect(po.item).to be nil
+      expect(po.barcode).to be nil
+      expect(po.aspace_uri).to be nil
+      expect(po.last_ladybird_update).to be nil
+      expect(po.last_id_update).to be nil
+      expect(po.last_voyager_update).to be nil
+      expect(po.last_aspace_update).to be nil
+      expect(po.visibility).to be nil
+      expect(po.ladybird_json).to be nil
+      expect(po.voyager_json).to be nil
+      expect(po.aspace_json).to be nil
+      expect(po.reading_direction).to be nil
+      expect(po.pagination).to be nil
+      expect(po.child_object_count).to be nil
+      expect(po.authoritative_metadata_source_id).to eq ladybird
+    end
+  end
+
   context "a newly created ParentObject with an unexpected authoritative_metadata_source" do
     let(:unexpected_metadata_source) { FactoryBot.create(:metadata_source, id: 4, metadata_cloud_name: "foo", display_name: "Foo", file_prefix: "F-") }
     let(:parent_object) { FactoryBot.create(:parent_object, oid: "2004628", authoritative_metadata_source: unexpected_metadata_source) }


### PR DESCRIPTION
- Basically, we don't want to make assumptions about our parent objects, and only want to record things in the model that we know for sure. 
- Leaving the assumption of Ladybird right now, because I think we'll need a larger pass & more information to change that assumption