### PR TITLE
Restore old migrations and remove tables in reversible way

### DIFF
--- a/db/migrate/20200630194202_create_oid_imports.rb
+++ b/db/migrate/20200630194202_create_oid_imports.rb
@@ -1,0 +1,9 @@
+class CreateOidImports < ActiveRecord::Migration[6.0]
+  def change
+    create_table :oid_imports do |t|
+      t.text :csv
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200703144145_create_metadata_samples.rb
+++ b/db/migrate/20200703144145_create_metadata_samples.rb
@@ -1,0 +1,11 @@
+class CreateMetadataSamples < ActiveRecord::Migration[6.0]
+  def change
+    create_table :metadata_samples do |t|
+      t.string :metadata_source
+      t.integer :number_of_samples
+      t.decimal :seconds_elapsed
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200703144638_create_sample_fields.rb
+++ b/db/migrate/20200703144638_create_sample_fields.rb
@@ -1,0 +1,12 @@
+class CreateSampleFields < ActiveRecord::Migration[6.0]
+  def change
+    create_table :sample_fields do |t|
+      t.string :field_name
+      t.integer :field_count
+      t.decimal :field_percent_of_total
+      t.references :metadata_sample, null: false, foreign_key: true, on_delete: :cascade
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200706132234_cascade_delete_sample_fields.rb
+++ b/db/migrate/20200706132234_cascade_delete_sample_fields.rb
@@ -1,0 +1,6 @@
+class CascadeDeleteSampleFields < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :sample_fields, :metadata_samples
+    add_foreign_key  :sample_fields, :metadata_samples, on_delete: :cascade
+  end
+end

--- a/db/migrate/20201024162006_remove_outdated_tables.rb
+++ b/db/migrate/20201024162006_remove_outdated_tables.rb
@@ -1,0 +1,31 @@
+class RemoveOutdatedTables < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :sample_fields do |t|
+      t.string :field_name
+      t.integer :field_count
+      t.decimal :field_percent_of_total
+      t.references :metadata_sample, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    drop_table :metadata_samples do |t|
+      t.string :metadata_source
+      t.integer :number_of_samples
+      t.decimal :seconds_elapsed
+
+      t.timestamps
+    end
+    drop_table :oid_imports do |t|
+      t.text :csv
+
+      t.timestamps
+    end
+    drop_table :mets_xml_imports do |t|
+      t.xml "mets_xml"
+      t.datetime "created_at", precision: 6, null: false
+      t.datetime "updated_at", precision: 6, null: false
+      t.bigint "oid"
+      t.index ["oid"], name: "index_mets_xml_imports_on_oid"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_16_192716) do
+ActiveRecord::Schema.define(version: 2020_10_24_162006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,28 +87,12 @@ ActiveRecord::Schema.define(version: 2020_10_16_192716) do
     t.index ["parent_object_id"], name: "index_dependent_objects_on_parent_object_id"
   end
 
-  create_table "metadata_samples", force: :cascade do |t|
-    t.string "metadata_source"
-    t.integer "number_of_samples"
-    t.decimal "seconds_elapsed"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "metadata_sources", force: :cascade do |t|
     t.string "metadata_cloud_name"
     t.string "display_name"
     t.string "file_prefix"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "mets_xml_imports", force: :cascade do |t|
-    t.xml "mets_xml"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.bigint "oid"
-    t.index ["oid"], name: "index_mets_xml_imports_on_oid"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -120,12 +104,6 @@ ActiveRecord::Schema.define(version: 2020_10_16_192716) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["recipient_type", "recipient_id"], name: "index_notifications_on_recipient_type_and_recipient_id"
-  end
-
-  create_table "oid_imports", force: :cascade do |t|
-    t.text "csv"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "parent_objects", id: false, force: :cascade do |t|
@@ -155,16 +133,6 @@ ActiveRecord::Schema.define(version: 2020_10_16_192716) do
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true
   end
 
-  create_table "sample_fields", force: :cascade do |t|
-    t.string "field_name"
-    t.integer "field_count"
-    t.decimal "field_percent_of_total"
-    t.bigint "metadata_sample_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["metadata_sample_id"], name: "index_sample_fields_on_metadata_sample_id"
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -181,5 +149,4 @@ ActiveRecord::Schema.define(version: 2020_10_16_192716) do
   add_foreign_key "batch_connections", "batch_processes"
   add_foreign_key "batch_processes", "users"
   add_foreign_key "child_objects", "parent_objects", column: "parent_object_oid", primary_key: "oid"
-  add_foreign_key "sample_fields", "metadata_samples", on_delete: :cascade
 end


### PR DESCRIPTION
When I auto-removed the models for these, the migrations were also deleted. Removing them in a more consistent way, which will also take effect on the production systems.