### PR TITLE
Safe search to address bug

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -42,7 +42,7 @@ class BatchProcess < ApplicationRecord
   end
 
   def oid
-    return self[:oid] = mets_doc.oid.to_i unless self[:oid]
+    return self[:oid] = mets_doc&.oid&.to_i unless self[:oid]
     self[:oid]
   end
 

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true do
         expect do
           post parent_objects_url, params: { parent_object: valid_attributes }
         end.to change(ParentObject, :count).by(1)
+          .and change(BatchProcess, :count).by(1)
       end
 
       it "redirects to the created parent_object" do
@@ -134,6 +135,13 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true do
       expect do
         delete parent_object_url(parent_object)
       end.to change(ParentObject, :count).by(-1)
+        .and change(BatchProcess, :count).by(0)
+    end
+
+    it "can still access the BatchProcess page" do
+      parent_object = ParentObject.create! valid_attributes
+      delete parent_object_url(parent_object)
+      expect(get(batch_processes_url)).to eq 200
     end
 
     it "redirects to the parent_objects list" do

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
     it "can still successfully see the batch_process page" do
       visit batch_processes_path
       click_on("View")
+      expect(page.body).to have_link('View', href: "/batch_processes/#{BatchProcess.last.id}")
+    end
+    context "deleting a parent object" do
+      it "can still load the batch_process page" do
+        po = ParentObject.find(16_057_779)
+        po.delete
+        expect(po.destroyed?).to be true
+        visit batch_processes_path
+        click_on("View")
+        expect(page.body).to have_link('View', href: "/batch_processes/#{BatchProcess.last.id}")
+      end
     end
   end
 
@@ -68,6 +79,21 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
       expect(BatchProcess.count).to eq 1
       expect(page).to have_content("Your records have been retrieved from the MetadataCloud. PTIFF generation, manifest generation and indexing happen in the background.")
       expect(BatchProcess.last.file_name).to eq "meta.xml"
+    end
+
+    context "deleting a parent object" do
+      before do
+        page.attach_file("batch_process_file", fixture_path + '/goobi/metadata/16172421/meta.xml')
+        click_button("Import")
+      end
+      it "can still load the batch_process page" do
+        po = ParentObject.find(16_172_421)
+        po.delete
+        expect(po.destroyed?).to be true
+        visit batch_processes_path
+        click_on("View")
+        expect(page.body).to have_link('View', href: "/batch_processes/#{BatchProcess.last.id}")
+      end
     end
   end
 end


### PR DESCRIPTION
Haven't been able to write a test to duplicate it, think it might be old parent objects?

When I deployed master of Management to collections-test earlier, the Batch Processes data table did not load, and got this error - https://app.honeybadger.io/projects/72674/faults/69213887 

I think this should hopefully address the bug, but I haven't been able to write a test that replicates the error yet. My best guess is that it is from old parent objects that were connected to Batch Processes, but not via the batch connection? I'm not entirely sure.