### PR TITLE
Show failures on parent object detail page

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -2,7 +2,7 @@
 
 class BatchProcessesController < ApplicationController
   before_action :set_batch_process, only: [:show, :edit, :update, :destroy, :download, :download_csv, :download_xml, :show_parent]
-  before_action :set_parent_object, :find_notes, only: [:show_parent]
+  before_action :set_parent_object, :find_notes, :find_failures, only: [:show_parent]
 
   def index
     @batch_process = BatchProcess.new
@@ -65,6 +65,10 @@ class BatchProcessesController < ApplicationController
 
     def find_notes
       @notes = @parent_object.notes_for_batch_process(@batch_process.id)
+    end
+
+    def find_failures
+      @failures = @parent_object.failures_for_batch_process(@batch_process.id)
     end
 
     def batch_process_params

--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -6,8 +6,8 @@ class SetupMetadataJob < ApplicationJob
   def perform(parent_object, current_batch_process)
     parent_object.current_batch_process = current_batch_process
     parent_object.generate_manifest = true
-    parent_object.default_fetch
-    parent_object.create_child_records
+    parent_object.default_fetch(current_batch_process)
+    parent_object.create_child_records(current_batch_process)
     parent_object.save!
     parent_object.processing_event("Child object records have been created", "child-records-created")
     parent_object.child_objects.each do |c|

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -33,4 +33,24 @@ module Statable
       "n/a"
     end
   end
+
+  def note_records(batch_process_id)
+    Notification.where(["params->>'batch_process_id' = :id and
+    params->>'parent_object_id' = :oid", { id: batch_process_id.to_s, oid:
+    oid.to_s }])
+  end
+
+  def failures_for_batch_process(batch_process_id)
+    return if self.class == Integer
+    failures = []
+    note_records(batch_process_id).each do |failure|
+      next unless failure.params[:status] == "failed"
+      failure_note = {}
+      failure_note["reason"] = failure.params[:reason]
+      failure_note["time"] = failure.created_at
+      failures << failure_note
+    end
+    return nil if failures.empty?
+    failures
+  end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -31,7 +31,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.use_ladybird = true
   end
 
-  def create_child_records
+  def create_child_records(_current_batch_process)
     return unless ladybird_json
     ladybird_json["children"].map.with_index(1) do |child_record, index|
       next if child_object_ids.include?(child_record["oid"])
@@ -47,7 +47,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   # Fetches the record from the authoritative_metadata_source
-  def default_fetch
+  def default_fetch(current_batch_process = self.current_batch_process)
     case authoritative_metadata_source&.metadata_cloud_name
     when "ladybird"
       self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self)
@@ -61,7 +61,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     processing_event("Metadata has been fetched", "metadata-fetched") if current_batch_process
   end
 
-  def processing_event(message, status = 'info')
+  def processing_event(message, status = 'info', current_batch_process = self.current_batch_process)
     IngestNotification.with(parent_object_id: id, status: status, reason: message, batch_process_id: current_batch_process&.id).deliver_all
   end
 

--- a/app/views/batch_processes/show_parent.html.erb
+++ b/app/views/batch_processes/show_parent.html.erb
@@ -73,4 +73,19 @@
       <td colspan="2">Parent object deleted, child objects cascade deleted</td>
     </tr>
   <% end %>
+  <% if @failures %>
+  <table class="table table-bordered table-striped">
+    <thead class="thead-dark">
+      <tr>
+        <th scope="col"> Message </th>
+        <th scope="col"> Time </th>
+      </tr>
+    </thead>
+    <% @failures.each do |failure| %>
+    <tr>
+      <td class="reason"><%= failure["reason"] %></td>
+      <td class="time"><%= failure["time"] %></td>
+    </tr>
+    <% end %>
+  <% end %>
 </table>

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     it "receives a check for whether it's ready for manifests 4 times, one for each child" do
       allow_any_instance_of(ChildObject).to receive(:parent_object).and_return(parent_of_four)
       VCR.use_cassette("process csv") do
-        parent_of_four.current_batch_process = batch_process
         expect(parent_of_four).to receive(:needs_a_manifest?).exactly(4).times
         parent_of_four.setup_metadata_job
       end
@@ -83,7 +82,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "short_fixture_ids.csv")) }
 
     it 'returns a processing_event message' do
-      parent_object.current_batch_process = batch_process
       expect do
         batch_process.file = csv_upload
         batch_process.run_callbacks :create

--- a/spec/system/batch_process_parent_detail_spec.rb
+++ b/spec/system/batch_process_parent_detail_spec.rb
@@ -3,58 +3,84 @@ require 'rails_helper'
 
 RSpec.describe "Batch Process Parent detail page", type: :system, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:user, uid: "johnsmith2530") }
+  let(:batch_process) do
+    FactoryBot.create(
+      :batch_process,
+      user: user,
+      csv: File.open(fixture_path + '/small_short_fixture_ids.csv').read,
+      file_name: "small_short_fixture_ids.csv",
+      created_at: "2020-10-08 14:17:01"
+    )
+  end
+
   before do
-    stub_metadata_cloud("2004628")
-    stub_metadata_cloud("2030006")
-    stub_metadata_cloud("2034600")
-    stub_metadata_cloud("16057779")
-    stub_metadata_cloud("15234629")
-    stub_ptiffs_and_manifests
     login_as user
   end
 
-  describe "with a csv import" do
-    around do |example|
-      perform_enqueued_jobs do
-        example.run
-      end
-    end
-    let(:batch_process) do
-      FactoryBot.create(
-        :batch_process,
-        user: user,
-        csv: File.open(fixture_path + '/small_short_fixture_ids.csv').read,
-        file_name: "small_short_fixture_ids.csv",
-        created_at: "2020-10-08 14:17:01"
-      )
-    end
+  around do |example|
+    vpn = ENV["VPN"]
+    ENV["VPN"] = "false"
+    example.run
+    ENV["VPN"] = vpn
+  end
 
-    it "has a link to the parent object page" do
+  describe "with a failure" do
+    before do
+      batch_process
+      # ugh, why is it so hard to fake a failure?
+    end
+    it "sees the failures on the parent object for that batch process" do
+      s3_double = class_double("S3Service")
+      allow(s3_double).to receive(:download).and_return(nil)
       visit show_parent_batch_process_path(batch_process, 16_057_779)
-      expect(page.body).to have_link('16057779', href: "/parent_objects/16057779")
+      expect(page.body).to include("failed")
+    end
+  end
+
+  describe "with expected success" do
+    before do
+      stub_metadata_cloud("2004628")
+      stub_metadata_cloud("2030006")
+      stub_metadata_cloud("2034600")
+      stub_metadata_cloud("16057779")
+      stub_metadata_cloud("15234629")
+      stub_ptiffs_and_manifests
     end
 
-    it "has a link to the batch process detail page" do
-      visit show_parent_batch_process_path(batch_process, 16_057_779)
-      expect(page.body).to have_link(batch_process&.id&.to_s, href: "/batch_processes/#{batch_process.id}")
-    end
-
-    describe "after running the background jobs" do
-      it "includes the notifications connected to this parent import" do
+    describe "with a csv import" do
+      it "has a link to the parent object page" do
         visit show_parent_batch_process_path(batch_process, 16_057_779)
-        expect(page.body).to include("Processing Queued")
-        expect(page).to have_css("td.submission_time")
-        st = page.find("td.submission_time").text
-        expect(st.to_datetime).to be_an_instance_of DateTime
-        expect(page).to have_css("td.processing_queued_time")
-        pqt = page.find("td.processing_queued_time").text
-        expect(pqt.to_datetime).to be_an_instance_of DateTime
-        expect(page).to have_css("td.metadata_fetched")
+        expect(page.body).to have_link('16057779', href: "/parent_objects/16057779")
       end
 
-      it "includes the child oids" do
+      it "has a link to the batch process detail page" do
         visit show_parent_batch_process_path(batch_process, 16_057_779)
-        expect(page).to have_css("td.child_oid", text: "16057781")
+        expect(page.body).to have_link(batch_process&.id&.to_s, href: "/batch_processes/#{batch_process.id}")
+      end
+
+      describe "after running the background jobs" do
+        around do |example|
+          perform_enqueued_jobs do
+            example.run
+          end
+        end
+
+        it "includes the notifications connected to this parent import" do
+          visit show_parent_batch_process_path(batch_process, 16_057_779)
+          expect(page.body).to include("Processing Queued")
+          expect(page).to have_css("td.submission_time")
+          st = page.find("td.submission_time").text
+          expect(st.to_datetime).to be_an_instance_of DateTime
+          expect(page).to have_css("td.processing_queued_time")
+          pqt = page.find("td.processing_queued_time").text
+          expect(pqt.to_datetime).to be_an_instance_of DateTime
+          expect(page).to have_css("td.metadata_fetched")
+        end
+
+        it "includes the child oids" do
+          visit show_parent_batch_process_path(batch_process, 16_057_779)
+          expect(page).to have_css("td.child_oid", text: "16057781")
+        end
       end
     end
   end


### PR DESCRIPTION
- ensure that batch_process is being passed along & avoid race conditions
- still may not be getting passed along correctly for singly generated parent objects

![image](https://user-images.githubusercontent.com/45948126/97510847-036b9580-195c-11eb-810d-beb3baf4ba7c.png)