### PR TITLE
Indices for the delayed_job_table

### DIFF
--- a/db/migrate/20201029191359_dj_index.rb
+++ b/db/migrate/20201029191359_dj_index.rb
@@ -1,0 +1,11 @@
+class DjIndex < ActiveRecord::Migration[6.0]
+  def change
+	  #indices as indicated by dj query patterns & random googling
+	  add_index :delayed_jobs, :failed_at
+	  add_index :delayed_jobs, :queue
+	  add_index :delayed_jobs, :last_error
+	  add_index :delayed_jobs, :locked_at
+	  add_index :delayed_jobs, :priority
+	  add_index :delayed_jobs, [:locked_at, :failed_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_24_170510) do
+ActiveRecord::Schema.define(version: 2020_10_29_191359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,13 @@ ActiveRecord::Schema.define(version: 2020_10_24_170510) do
     t.string "queue"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.index ["failed_at"], name: "index_delayed_jobs_on_failed_at"
+    t.index ["last_error"], name: "index_delayed_jobs_on_last_error"
+    t.index ["locked_at", "failed_at"], name: "index_delayed_jobs_on_locked_at_and_failed_at"
+    t.index ["locked_at"], name: "index_delayed_jobs_on_locked_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+    t.index ["priority"], name: "index_delayed_jobs_on_priority"
+    t.index ["queue"], name: "index_delayed_jobs_on_queue"
   end
 
   create_table "dependent_objects", force: :cascade do |t|


### PR DESCRIPTION
* added a number of indices to speed up job acquisition & status
reporting when queues get large, as indicated by examining dj query patterns