### PR TITLE
Queue PDF job whenever manifest is changed.

### DIFF
--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -12,7 +12,7 @@ class GenerateManifestJob < ApplicationJob
     parent_object.current_batch_connection = current_batch_connection
     generate_manifest(parent_object, current_batch_process, current_batch_connection)
     index_to_solr(parent_object, current_batch_process, current_batch_connection)
-    GeneratePdfJob.perform_later(parent_object, current_batch_process)
+    GeneratePdfJob.perform_later(parent_object, current_batch_process, current_batch_connection)
   end
 
   def generate_manifest(parent_object, current_batch_process = parent_object.current_batch_process, current_batch_connection = parent_object.current_batch_connection)

--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -11,6 +11,7 @@ class GenerateManifestJob < ApplicationJob
     parent_object.current_batch_process = current_batch_process
     generate_manifest(parent_object)
     index_to_solr(parent_object)
+    GeneratePdfJob.perform_later(parent_object, current_batch_process)
   end
 
   def generate_manifest(parent_object)

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -7,8 +7,9 @@ class GeneratePdfJob < ApplicationJob
     50
   end
 
-  def perform(parent_object, current_batch_process)
+  def perform(parent_object, current_batch_process = parent_object.current_batch_process, current_batch_connection = child_object.parent_object.current_batch_connection)
     parent_object.current_batch_process = current_batch_process
+    parent_object.current_batch_connection = current_batch_connection
     parent_object.generate_pdf
   rescue => e
     parent_object.processing_event("Unable to generate PDF, #{e.message}", "failed")

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -7,7 +7,7 @@ class GeneratePdfJob < ApplicationJob
     50
   end
 
-  def perform(parent_object, current_batch_process = parent_object.current_batch_process, current_batch_connection = child_object.parent_object.current_batch_connection)
+  def perform(parent_object, current_batch_process = parent_object.current_batch_process, current_batch_connection = parent_object.current_batch_connection)
     parent_object.current_batch_process = current_batch_process
     parent_object.current_batch_connection = current_batch_connection
     parent_object.generate_pdf

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
       .to_return(status: 200)
     stub_metadata_cloud("16172421")
     stub_ptiffs
+    stub_pdfs
     parent_object
     # The parent object gets its metadata populated via a background job, and we can't assume that has run,
     # so stub the part of the metadata we need for the iiif_presentation

--- a/spec/support/stub_requests_helper.rb
+++ b/spec/support/stub_requests_helper.rb
@@ -16,6 +16,7 @@ module StubRequestHelper
   def stub_ptiffs_and_manifests
     stub_ptiffs
     stub_manifests
+    stub_pdfs
   end
 
   # rubocop:disable RSpec/AnyInstance
@@ -31,6 +32,10 @@ module StubRequestHelper
     allow_any_instance_of(IiifPresentation).to receive(:save).and_return(true)
     allow_any_instance_of(IiifPresentation).to receive(:save).and_return(true)
     allow_any_instance_of(ParentObject).to receive(:manifest_completed?).and_return(true)
+  end
+
+  def stub_pdfs
+    allow_any_instance_of(PdfRepresentable).to receive(:generate_pdf).and_return(true)
   end
   # rubocop:enable RSpec/AnyInstance
 end


### PR DESCRIPTION
Queues PDF Job whenever manifest is generated.  (Relies on the fact that the manifest is only generated when necessary.  Manifest should be regenerated in the same situations when the PDF should be regenerated.)