### PR TITLE
Add rendering to iiif presentation

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -13,6 +13,10 @@ class IiifPresentation
     @manifest_base_url ||= (ENV["IIIF_MANIFESTS_BASE_URL"] || "http://localhost/manifests")
   end
 
+  def pdf_base_url
+    @pdf_base_url ||= (ENV["PDF_BASE_URL"] || "http://localhost/pdfs")
+  end
+
   def image_url(oid)
     "#{image_base_url}/2/#{oid}"
   end
@@ -44,7 +48,18 @@ class IiifPresentation
     return @sequence if @sequence
     @sequence = IIIF::Presentation::Sequence.new
     @sequence["@id"] = "#{ENV['IIIF_MANIFESTS_BASE_URL']}/sequence/#{oid}"
+    @sequence["rendering"] = rendering
     @sequence
+  end
+
+  def rendering
+    [
+      {
+        "@id" => "#{pdf_base_url}/#{@oid}.pdf",
+        "format" => "application/pdf",
+        "label" => "Download as PDF"
+      }
+    ]
   end
 
   def add_image_to_canvas(child, canvas)

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
   around do |example|
     original_manifests_base_url = ENV['IIIF_MANIFESTS_BASE_URL']
     original_image_base_url = ENV["IIIF_IMAGE_BASE_URL"]
+    original_pdf_url = ENV["PDF_BASE_URL"]
     ENV['IIIF_MANIFESTS_BASE_URL'] = "http://localhost/manifests"
     ENV['IIIF_IMAGE_BASE_URL'] = "http://localhost:8182/iiif"
+    ENV["PDF_BASE_URL"] = "http://localhost/pdfs"
     perform_enqueued_jobs do
       example.run
     end
     ENV['IIIF_MANIFESTS_BASE_URL'] = original_manifests_base_url
     ENV['IIIF_IMAGE_BASE_URL'] = original_image_base_url
+    ENV["PDF_BASE_URL"] = original_pdf_url
   end
   let(:oid) { 16_172_421 }
   let(:iiif_presentation) { described_class.new(parent_object) }
@@ -70,6 +73,14 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
 
     it "has a manifest with one or more sequences" do
       expect(iiif_presentation.manifest.sequences.class).to eq Array
+    end
+
+    it "has a rendering in the sequence" do
+      expect(iiif_presentation.manifest.sequences.first["rendering"].class).to eq Array
+      expect(iiif_presentation.manifest.sequences.first["rendering"].first.class).to eq Hash
+      expect(iiif_presentation.manifest.sequences.first["rendering"].first["@id"]).to eq "#{ENV['PDF_BASE_URL']}/#{oid}.pdf"
+      expect(iiif_presentation.manifest.sequences.first["rendering"].first["format"]).to eq "application/pdf"
+      expect(iiif_presentation.manifest.sequences.first["rendering"].first["label"]).to eq "Download as PDF"
     end
 
     it "has a sequence with an id" do


### PR DESCRIPTION
Adds link to not-yet-connected pdfs service in manifest, allowing it to display in Universal Viewer. 

Connected to https://github.com/yalelibrary/YUL-DC/issues/764

![image](https://user-images.githubusercontent.com/45948126/98569076-cff40980-227f-11eb-853d-4d832ed85fdd.png)