### PR TITLE
Include PDF link in top level of manifest for interoperability

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -39,6 +39,7 @@ class IiifPresentation
   def manifest
     return @manifest if @manifest
     @manifest = IIIF::Presentation::Manifest.new(seed)
+    @manifest["rendering"] = rendering
     @manifest.sequences << sequence
     add_canvases_to_sequence(@manifest.sequences.first)
     @manifest

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
       expect(iiif_presentation.manifest.sequences.class).to eq Array
     end
 
+    it "has a rendering in the manifest" do
+      expect(iiif_presentation.manifest["rendering"].class).to eq Array
+      expect(iiif_presentation.manifest["rendering"].first.class).to eq Hash
+      expect(iiif_presentation.manifest["rendering"].first["@id"]).to eq "#{ENV['PDF_BASE_URL']}/#{oid}.pdf"
+      expect(iiif_presentation.manifest["rendering"].first["format"]).to eq "application/pdf"
+      expect(iiif_presentation.manifest["rendering"].first["label"]).to eq "Download as PDF"
+    end
+
     it "has a rendering in the sequence" do
       expect(iiif_presentation.manifest.sequences.first["rendering"].class).to eq Array
       expect(iiif_presentation.manifest.sequences.first["rendering"].first.class).to eq Hash


### PR DESCRIPTION
- Mirador shows if in top level
- Universal Viewer shows if in Sequence level

![image](https://user-images.githubusercontent.com/45948126/98589520-6bdf3e80-229b-11eb-97c1-d56bdaded74e.png)

![image](https://user-images.githubusercontent.com/45948126/98589564-76013d00-229b-11eb-986f-8da3e78d3422.png)
