### PR TITLE
Pdf gen preprocess

### DIFF
--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -37,7 +37,8 @@ module PdfRepresentable
       "title" => title,
       "header" => "Yale University Library Digital Collections",
       "properties" => properties,
-      "pages" => children
+      "pages" => children,
+      "imageProcessingCommand" => "convert -resize 2000x2000 %s[0] %s"
     }
     json_hash.to_json
   end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
         expect(parent_object.pdf_generator_json).to include("https://collections.library.yale.edu/catalog/#{parent_object.oid}")
       end
 
+      it "generates pdf json with the correct preprocessing command" do
+        expect(parent_object.pdf_generator_json).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] %s"')
+      end
+
       it "pdf path on S3" do
         expect(parent_object.remote_pdf_path).not_to be_nil
       end


### PR DESCRIPTION
Add imageProcessingCommand to json used for PDF generation. 
Updates jpegs2pdf jar so that it runs preprocessing command on images before adding to PDF and does not resize/resample images.


Co-Authored-By: Max Kadel <max@curationexperts.com>
Co-Authored-By: Mike Appleby <michael.appleby@yale.edu>