### PR TITLE
Fix issue with null exitstatus on PDF run

### DIFF
--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -10,8 +10,8 @@ module PdfRepresentable
     temp_json_file.close
     temp_pdf_file = "#{temp_json_file.path}.pdf"
     cmd = "java -jar jpegs2pdf-1.0.jar #{temp_json_file.path} #{temp_pdf_file}"
-    _, stderr, status = Open3.capture3(cmd)
-    success = status.exitstatus.zero?
+    stdout, stderr, status = Open3.capture3(cmd)
+    success = status.success?
     temp_json_file.delete
     if success
       raise "Java app did not create PDF file for #{oid}" unless File.exist? temp_pdf_file
@@ -19,7 +19,7 @@ module PdfRepresentable
       File.delete temp_pdf_file
     else
       File.delete temp_pdf_file if File.exist?(temp_pdf_file)
-      raise "PDF Java app returned non zero response code for #{oid}: #{stderr}"
+      raise "PDF Java app returned non zero response code for #{oid}: #{stderr} #{stdout}"
     end
   end
 


### PR DESCRIPTION
This updates the process handling code in Ruby to avoid null pointer exceptions when exit code is nil.
It also updates the JAR so that it calls System.exit() after completing the PDF write to help prevent the app from hanging.