### PR TITLE
Expand dateStructured to array of dates when range is in JSON value

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -146,19 +146,18 @@ module SolrIndexable
 
   def expand_date_structured(date_structured)
     return nil unless date_structured&.is_a?(Array)
-    date_structured.reduce([]) do |accumulator, date|
+    date_structured.each_with_object(SortedSet.new) do |date, set|
       if date.include? '/'
         dates = date.split('/')
         if dates.count == 2
           date1 = dates[0].to_i
           date2 = dates[1].to_i
           date2 = Time.now.utc.year if date2 == 9999
-          (date1..date2).each { |range_date| accumulator << range_date }
+          (date1..date2).each { |range_date| set << range_date }
         end
       else
-        accumulator << date
+        set << date.to_i
       end
-      accumulator.map(&:to_i).uniq
-    end
+    end.to_a
   end
 end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -53,7 +53,8 @@ module SolrIndexable
       creatorDisplay_tsim: json_to_index["creatorDisplay"],
       date_ssim: json_to_index["date"],
       dateDepicted_ssim: json_to_index["dateDepicted"],
-      dateStructured_ssim: expand_date_structured(json_to_index["dateStructured"]), # keeping as ssim for now, dtsi suffix errors out, have invalid values from MC
+      year_isim: expand_date_structured(json_to_index["dateStructured"]),
+      dateStructured_ssim: json_to_index["dateStructured"],
       dependentUris_ssim: json_to_index["dependentUris"],
       description_tesim: json_to_index["description"],
       digital_ssim: json_to_index["digital"],
@@ -144,20 +145,20 @@ module SolrIndexable
   end
 
   def expand_date_structured(date_structured)
-    return date_structured unless date_structured&.is_a?(Array)
+    return nil unless date_structured&.is_a?(Array)
     date_structured.reduce([]) do |accumulator, date|
       if date.include? '/'
         dates = date.split('/')
         if dates.count == 2
           date1 = dates[0].to_i
           date2 = dates[1].to_i
-          date2 = Time.now.utc.year + 20 if date2 == 9999
+          date2 = Time.now.utc.year if date2 == 9999
           (date1..date2).each { |range_date| accumulator << range_date }
         end
       else
         accumulator << date
       end
-      accumulator.map(&:to_s).uniq
+      accumulator.map(&:to_i).uniq
     end
   end
 end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -53,7 +53,7 @@ module SolrIndexable
       creatorDisplay_tsim: json_to_index["creatorDisplay"],
       date_ssim: json_to_index["date"],
       dateDepicted_ssim: json_to_index["dateDepicted"],
-      dateStructured_ssim: json_to_index["dateStructured"], # keeping as ssim for now, dtsi suffix errors out, have invalid values from MC
+      dateStructured_ssim: expand_date_structured(json_to_index["dateStructured"]), # keeping as ssim for now, dtsi suffix errors out, have invalid values from MC
       dependentUris_ssim: json_to_index["dependentUris"],
       description_tesim: json_to_index["description"],
       digital_ssim: json_to_index["digital"],
@@ -141,5 +141,23 @@ module SolrIndexable
       subject_topic_tsim: json_to_index["subjectTopic"], # replaced by subjectTopic_tesim and subjectTopic_ssim
       title_tsim: json_to_index["title"] # replaced by title_tesim
     }
+  end
+
+  def expand_date_structured(date_structured)
+    return date_structured unless date_structured&.is_a?(Array)
+    date_structured.reduce([]) do |accumulator, date|
+      if date.include? '/'
+        dates = date.split('/')
+        if dates.count == 2
+          date1 = dates[0].to_i
+          date2 = dates[1].to_i
+          date2 = Time.now.utc.year + 20 if date2 == 9999
+          (date1..date2).each { |range_date| accumulator << range_date }
+        end
+      else
+        accumulator << date
+      end
+      accumulator.map(&:to_s).uniq
+    end
   end
 end

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -213,14 +213,14 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
     let(:oid) { "2034600" }
     let(:parent_object) { described_class.new }
     it "expands dates with explicit ranges" do
-      expect(parent_object.expand_date_structured(["2000/2005"])).to eq ["2000", "2001", "2002", "2003", "2004", "2005"]
+      expect(parent_object.expand_date_structured(["2000/2005"])).to eq [2000, 2001, 2002, 2003, 2004, 2005]
     end
     it "expands dates with open ended ranges" do
-      expected_result = (2000..Time.now.utc.year + 20).to_a.map(&:to_s)
+      expected_result = (2000..Time.now.utc.year).to_a
       expect(parent_object.expand_date_structured(["2000/9999"])).to eq expected_result
     end
     it "expands dates without ranges" do
-      expect(parent_object.expand_date_structured(["2000", "2010"])).to eq ["2000", "2010"]
+      expect(parent_object.expand_date_structured(["2000", "2010"])).to eq [2000, 2010]
     end
     it "expands empty array to empty array" do
       expect(parent_object.expand_date_structured([])).to eq []
@@ -228,24 +228,25 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
     it "expands nil to nil" do
       expect(parent_object.expand_date_structured(nil)).to eq nil
     end
-    it "returns value if not an array" do
-      expect(parent_object.expand_date_structured("non-array")).to eq "non-array"
-      expect(parent_object.expand_date_structured("1995")).to eq "1995"
+    it "returns nil if not an array" do
+      expect(parent_object.expand_date_structured("non-array")).to eq nil
+      expect(parent_object.expand_date_structured("1995")).to eq nil
+      expect(parent_object.expand_date_structured(parent_object)).to eq nil
     end
     it "expands range and non-ranges combined" do
-      expect(parent_object.expand_date_structured(["2000/2004", "1945"])).to eq ["2000", "2001", "2002", "2003", "2004", "1945"]
+      expect(parent_object.expand_date_structured(["2000/2004", "1945"])).to eq [2000, 2001, 2002, 2003, 2004, 1945]
     end
     it "expands overlapping ranges with dedup" do
-      expect(parent_object.expand_date_structured(["2000/2004", "1945", "2002/2006"])).to eq ["2000", "2001", "2002", "2003", "2004", "1945", "2005", "2006"]
+      expect(parent_object.expand_date_structured(["2000/2004", "1945", "2002/2006"])).to eq [2000, 2001, 2002, 2003, 2004, 1945, 2005, 2006]
     end
     it "dedups non-range values" do
-      expect(parent_object.expand_date_structured(["1945", "2002", "1945"])).to eq ["1945", "2002"]
+      expect(parent_object.expand_date_structured(["1945", "2002", "1945"])).to eq [1945, 2002]
     end
     it "responds correctly with invalid ranges" do
       expect(parent_object.expand_date_structured(["1945/1935"])).to eq []
       expect(parent_object.expand_date_structured(["9999/1935"])).to eq []
-      expect(parent_object.expand_date_structured(["9999/1935", "1955"])).to eq ["1955"]
-      expect(parent_object.expand_date_structured(["1935/2021/1953", "1975"])).to eq ["1975"]
+      expect(parent_object.expand_date_structured(["9999/1935", "1955"])).to eq [1955]
+      expect(parent_object.expand_date_structured(["1935/2021/1953", "1975"])).to eq [1975]
     end
   end
 end

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -208,4 +208,44 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       end
     end
   end
+
+  describe "expand_date_structured" do
+    let(:oid) { "2034600" }
+    let(:parent_object) { described_class.new }
+    it "expands dates with explicit ranges" do
+      expect(parent_object.expand_date_structured(["2000/2005"])).to eq ["2000", "2001", "2002", "2003", "2004", "2005"]
+    end
+    it "expands dates with open ended ranges" do
+      expected_result = (2000..Time.now.utc.year + 20).to_a.map(&:to_s)
+      expect(parent_object.expand_date_structured(["2000/9999"])).to eq expected_result
+    end
+    it "expands dates without ranges" do
+      expect(parent_object.expand_date_structured(["2000", "2010"])).to eq ["2000", "2010"]
+    end
+    it "expands empty array to empty array" do
+      expect(parent_object.expand_date_structured([])).to eq []
+    end
+    it "expands nil to nil" do
+      expect(parent_object.expand_date_structured(nil)).to eq nil
+    end
+    it "returns value if not an array" do
+      expect(parent_object.expand_date_structured("non-array")).to eq "non-array"
+      expect(parent_object.expand_date_structured("1995")).to eq "1995"
+    end
+    it "expands range and non-ranges combined" do
+      expect(parent_object.expand_date_structured(["2000/2004", "1945"])).to eq ["2000", "2001", "2002", "2003", "2004", "1945"]
+    end
+    it "expands overlapping ranges with dedup" do
+      expect(parent_object.expand_date_structured(["2000/2004", "1945", "2002/2006"])).to eq ["2000", "2001", "2002", "2003", "2004", "1945", "2005", "2006"]
+    end
+    it "dedups non-range values" do
+      expect(parent_object.expand_date_structured(["1945", "2002", "1945"])).to eq ["1945", "2002"]
+    end
+    it "responds correctly with invalid ranges" do
+      expect(parent_object.expand_date_structured(["1945/1935"])).to eq []
+      expect(parent_object.expand_date_structured(["9999/1935"])).to eq []
+      expect(parent_object.expand_date_structured(["9999/1935", "1955"])).to eq ["1955"]
+      expect(parent_object.expand_date_structured(["1935/2021/1953", "1975"])).to eq ["1975"]
+    end
+  end
 end

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -234,10 +234,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       expect(parent_object.expand_date_structured(parent_object)).to eq nil
     end
     it "expands range and non-ranges combined" do
-      expect(parent_object.expand_date_structured(["2000/2004", "1945"])).to eq [2000, 2001, 2002, 2003, 2004, 1945]
+      expect(parent_object.expand_date_structured(["2000/2004", "1945"])).to eq [1945, 2000, 2001, 2002, 2003, 2004]
     end
     it "expands overlapping ranges with dedup" do
-      expect(parent_object.expand_date_structured(["2000/2004", "1945", "2002/2006"])).to eq [2000, 2001, 2002, 2003, 2004, 1945, 2005, 2006]
+      expect(parent_object.expand_date_structured(["2000/2004", "1945", "2002/2006"])).to eq [1945, 2000, 2001, 2002, 2003, 2004, 2005, 2006]
     end
     it "dedups non-range values" do
       expect(parent_object.expand_date_structured(["1945", "2002", "1945"])).to eq [1945, 2002]


### PR DESCRIPTION
This is backward compatible and will prepare us for MC updated range format in dateStructured.

Added new year_isim solr field to store dates as integers.
dateStructured_ssim will contain value returned in JSON (which will be single years or slash ranges.  May contain multiple values.)
Open ended date range will be set to current year.