### PR TITLE
Make sure batch process & child object notes are connected

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -11,9 +11,9 @@ class SetupMetadataJob < ApplicationJob
     parent_object.create_child_records(current_batch_process, current_batch_connection)
     parent_object.save!
     parent_object.processing_event("Child object records have been created", "child-records-created", current_batch_process, current_batch_connection)
-    parent_object.child_objects.each do |c|
-      GeneratePtiffJob.perform_later(c, current_batch_process, current_batch_connection)
-      c.processing_event("Ptiff Queued", "ptiff-queued", current_batch_process, current_batch_connection)
+    parent_object.child_objects.each do |child|
+      GeneratePtiffJob.perform_later(child, current_batch_process, current_batch_connection)
+      child.processing_event("Ptiff Queued", "ptiff-queued", current_batch_process, current_batch_connection)
     end
   rescue => e
     parent_object.processing_event("Setup job failed to save: #{e.message}", "failed", current_batch_process, current_batch_connection)

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -15,7 +15,7 @@ class ChildObject < ApplicationRecord
   end
 
   def finished_states
-    ['ptiff-ready', 'ptiff-ready-skipped']
+    ['ptiff-ready-skipped', 'ptiff-ready']
   end
 
   def check_for_size_and_file

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -5,6 +5,8 @@ class ChildObject < ApplicationRecord
   belongs_to :parent_object, foreign_key: 'parent_object_oid', class_name: "ParentObject"
   self.primary_key = 'oid'
   paginates_per 50
+  attr_accessor :current_batch_process
+  attr_accessor :current_batch_connection
 
   before_create :check_for_size_and_file
 
@@ -20,8 +22,8 @@ class ChildObject < ApplicationRecord
     width_and_height(remote_metadata)
   end
 
-  def processing_event(message, status = 'info', _current_batch_process = parent_object&.current_batch_process, _current_batch_connection = parent_object&.current_batch_connection)
-    IngestNotification.with(parent_object_id: parent_object&.id, child_object_id: id, status: status, reason: message, batch_process_id: parent_object&.current_batch_process&.id).deliver(User.first)
+  def processing_event(message, status = 'info', current_batch_process = parent_object&.current_batch_process, _current_batch_connection = parent_object&.current_batch_connection)
+    IngestNotification.with(parent_object_id: parent_object&.id, child_object_id: id, status: status, reason: message, batch_process_id: current_batch_process&.id).deliver(User.first)
   end
 
   def remote_ptiff_exists?

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -7,11 +7,11 @@ module Statable
   end
 
   def start_note(notes)
-    @start_note ||= start_states.map { |state| notes[state] }.first
+    @start_note ||= start_states.map { |state| notes[state] }.compact.first
   end
 
   def finished_note(notes)
-    @finished_note ||= finished_states.map { |state| notes[state] }.first
+    @finished_note ||= finished_states.map { |state| notes[state] }.compact.first
   end
 
   def deleted_note(notes)

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -151,6 +151,10 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
           expect(po.visibility).to eq "Public"
           batch_process.file = csv_upload
           batch_process.save
+          child = po.child_objects.first
+          notes = child.notes_for_batch_process(batch_process.id)
+          expect(notes).to include("ptiff-ready")
+          expect(notes).to include("ptiff-queued")
           expect(po.status_for_batch_process(batch_process.id)).to eq "Complete"
           expect(po.batch_processes.first.id).to eq batch_process.id
           expect(po.visibility).to eq "Public"

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
           notes = child.notes_for_batch_process(batch_process.id)
           expect(notes).to include("ptiff-ready")
           expect(notes).to include("ptiff-queued")
+          expect(child.status_for_batch_process(batch_process.id)).to eq "Complete"
           expect(po.status_for_batch_process(batch_process.id)).to eq "Complete"
           expect(po.batch_processes.first.id).to eq batch_process.id
           expect(po.visibility).to eq "Public"


### PR DESCRIPTION
- Connect child object status to batch process notes
- Make sure either finished state will report out for child objects

Co-Authored-By: Max Kadel <max.kadel@curationexperts.com>