### PR TITLE
Use database upsert_all method to batch create child objects

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -9,7 +9,7 @@ class SetupMetadataJob < ApplicationJob
     parent_object.generate_manifest = true
     # Do not continue running the background jobs if the metadata has not been successfully fetched
     return unless parent_object.default_fetch(current_batch_process, current_batch_connection)
-    parent_object.create_child_records(current_batch_process, current_batch_connection)
+    parent_object.create_child_records
     parent_object.save!
     parent_object.processing_event("Child object records have been created", "child-records-created", current_batch_process, current_batch_connection)
     parent_object.child_objects.each do |child|

--- a/db/migrate/20201203205054_add_default_to_created_and_updated_time.rb
+++ b/db/migrate/20201203205054_add_default_to_created_and_updated_time.rb
@@ -1,0 +1,6 @@
+class AddDefaultToCreatedAndUpdatedTime < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default(:child_objects, :created_at, from: nil, to: Time.now)
+    change_column_default(:child_objects, :updated_at, from: nil, to: Time.now)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_211544) do
+ActiveRecord::Schema.define(version: 2020_12_03_205054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(version: 2020_11_16_211544) do
     t.integer "height"
     t.integer "order"
     t.bigint "parent_object_oid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", precision: 6, default: "2020-12-03 20:53:18", null: false
+    t.datetime "updated_at", precision: 6, default: "2020-12-03 20:53:19", null: false
     t.string "label"
     t.string "checksum"
     t.string "viewing_hint"

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SetupMetadataJob, type: :job do
     let(:user) { FactoryBot.create(:user) }
     let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
     let(:metadata_source) { FactoryBot.create(:metadata_source) }
-    let(:parent_object) { FactoryBot.build(:parent_object, authoritative_metadata_source: metadata_source) }
+    let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source: metadata_source) }
     before do
       allow(parent_object).to receive(:save!).and_raise('boom!')
     end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -56,6 +56,23 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     # rubocop:enable RSpec/AnyInstance
   end
 
+  context "with a parent object with many pages" do
+    let(:fixture_json) { JSON.parse(File.open(File.join(fixture_path, "ladybird", "2003431.json")).read) }
+    let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_003_431, ladybird_json: fixture_json) }
+
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
+
+    it "creates the child objects" do
+      expect do
+        parent_object.create_child_records
+      end.to change { ChildObject.count }.from(0).to(1366)
+    end
+  end
+
   context 'with a random notification' do
     let(:user_one) { FactoryBot.create(:user, uid: "human the first") }
     let(:user_two) { FactoryBot.create(:user, uid: "human the second") }


### PR DESCRIPTION
* When trying to create many objects locally, noticed that ChildObject creation seemed to be a blocker for fast import
* *Before* Used benchmark method on test of child object creation on ParentObject with 156 children and got total times of ~8 seconds. When tried on ParentObject with ~1300 children it would time out. 
* *After* With larger ParentObject it would not time out, and took < 1 second total. 
* I believe it is ok that for the batch creation of child objects (when first creating a parent object), we are not running callbacks on the individual child object, since the child object background jobs are called from within the parent object background jobs. Put in a reminder above the "upsert_all" call in case this changes in future.
* Added default values to creation_date and updated_date, which mirrors current functionality but moves it to the database, so that we would not have to put these timestamps in the upsert_all method, which would run the risk of overriding older creation dates for re-ingested ParentObject children.