### PR TITLE
Order datatables by first column descending

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -40,6 +40,8 @@ $( document ).on('turbolinks:load', function() {
       },
       "pagingType": "full_numbers",
       "columns": JSON.parse($(".datatable-data").text()),
+      // This will order all datatables by the first column descending
+      "order": [[0, "desc"]],
       "lengthMenu": [[50, 100, 500, -1], [50, 100, 500, "All"]]
       // pagingType is optional, if you want full pagination controls.
       // Check dataTables documentation to learn more about


### PR DESCRIPTION
Default sort - 
![image](https://user-images.githubusercontent.com/45948126/101209946-af329000-3642-11eb-8a2f-feef3e368938.png) 

I would guess there might be a more targeted way to do this that we might need in future, but I can't seem to find it right now, and it doesn't seem to be a problem for any of the existing datatables.
