### PR TITLE
Add viewing direction

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -110,6 +110,6 @@ class ParentObjectsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def parent_object_params
       params.require(:parent_object).permit(:oid, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
-                                            :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id)
+                                            :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction, :display_layout)
     end
 end

--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -51,6 +51,8 @@ class IiifPresentation
     @sequence = IIIF::Presentation::Sequence.new
     @sequence["@id"] = "#{ENV['IIIF_MANIFESTS_BASE_URL']}/sequence/#{oid}"
     @sequence["rendering"] = rendering
+    @sequence["viewingDirection"] = @parent_object.viewing_direction unless @parent_object.viewing_direction.nil? || @parent_object.viewing_direction.empty?
+    @sequence["viewingHint"] = @parent_object.display_layout unless @parent_object.display_layout.nil? || @parent_object.display_layout.empty?
     @sequence
   end
 
@@ -58,17 +60,14 @@ class IiifPresentation
     values = []
     METADATA_FIELDS.each do |m_field|
       value = @parent_object&.authoritative_json&.[](m_field[:field])
-      values <<  metadata_pair(m_field[:label], value) if value
+      values << metadata_pair(m_field[:label], value) if value
     end
     values
   end
 
   def metadata_pair(label, value)
     value = [value] if value.is_a? String
-    {
-      'label' => label,
-      'value' => value
-    }
+    { 'label' => label, 'value' => value }
   end
 
   def rendering

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -26,6 +26,16 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     ['Private', 'Public', 'Yale Community Only']
   end
 
+  # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewingdirection
+  def self.viewing_directions
+    [nil, "left-to-right", "right-to-left", "top-to-bottom", "bottom-to-top"]
+  end
+
+  # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewinghint
+  def self.viewing_hints
+    [nil, "individuals", "paged", "continuous", "multi-part", "non-paged", "top", "facing-pages"]
+  end
+
   validates :visibility, inclusion: { in: visibilities,
                                       message: "%{value} is not a valid value" }
 

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -67,6 +67,16 @@
   </div>
 
   <div class="field">
+    <%= form.label :viewing_direction %>
+    <%= form.select(:viewing_direction, ParentObject.viewing_directions) %>
+  </div>
+
+  <div class="field">
+    <%= form.label :display_layout %>
+    <%= form.select(:display_layout, ParentObject.viewing_hints) %>
+  </div>
+
+  <div class="field">
     <%= form.label :last_id_update %>
     <%= form.text_field :last_id_update %>
   </div>

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -68,11 +68,13 @@
 
   <div class="field">
     <%= form.label :viewing_direction %>
+    <%= link_to("IIIF viewing direction details", "https://iiif.io/api/presentation/2.1/#viewingdirection") %><br>
     <%= form.select(:viewing_direction, ParentObject.viewing_directions) %>
   </div>
 
   <div class="field">
     <%= form.label :display_layout %>
+    <%= link_to("IIIF viewing hints details", "https://iiif.io/api/presentation/2.1/#viewinghint") %><br>
     <%= form.select(:display_layout, ParentObject.viewing_hints) %>
   </div>
 

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -6,6 +6,16 @@
 </p>
 
 <p>
+  <strong>Viewing Direction:</strong>
+  <%= @parent_object.viewing_direction %>
+</p>
+
+<p>
+  <strong>Display Layout / Viewing Hint:</strong>
+  <%= @parent_object.display_layout %>
+</p>
+
+<p>
   <strong>Bib:</strong>
   <%= @parent_object.bib %>
 </p>
@@ -66,7 +76,7 @@
 </p>
 
 <div class="child-objects">
-  <strong>Children:</strong>  
+  <strong>Children:</strong>
     <div class="child-list">
       <ol>
         <% @parent_object.child_objects.map{|child| %>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -6,16 +6,6 @@
 </p>
 
 <p>
-  <strong>Viewing Direction:</strong>
-  <%= @parent_object.viewing_direction %>
-</p>
-
-<p>
-  <strong>Display Layout / Viewing Hint:</strong>
-  <%= @parent_object.display_layout %>
-</p>
-
-<p>
   <strong>Bib:</strong>
   <%= @parent_object.bib %>
 </p>
@@ -58,6 +48,16 @@
 <p>
   <strong>Visibility:</strong>
   <%= @parent_object.visibility %>
+</p>
+
+<p>
+  <strong>Viewing Direction:</strong>
+  <%= @parent_object.viewing_direction %>
+</p>
+
+<p>
+  <strong>Display Layout / Viewing Hint:</strong>
+  <%= @parent_object.display_layout %>
 </p>
 
 <p>

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
   let(:oid) { 16_172_421 }
   let(:iiif_presentation) { described_class.new(parent_object) }
   let(:logger_mock) { instance_double("Rails.logger").as_null_object }
-  let(:parent_object) { FactoryBot.create(:parent_object, oid: oid) }
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: oid, viewing_direction: "left-to-right", display_layout: "individuals") }
   let(:first_canvas) { iiif_presentation.manifest.sequences.first.canvases.first }
   let(:third_to_last_canvas) { iiif_presentation.manifest.sequences.first.canvases.third_to_last }
   before do
@@ -100,6 +100,12 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
       expect(iiif_presentation.manifest.sequences.first["rendering"].first["@id"]).to eq "#{ENV['PDF_BASE_URL']}/#{oid}.pdf"
       expect(iiif_presentation.manifest.sequences.first["rendering"].first["format"]).to eq "application/pdf"
       expect(iiif_presentation.manifest.sequences.first["rendering"].first["label"]).to eq "Download as PDF"
+    end
+
+    it "includes viewingDirection when included on parent_object" do
+      expect(iiif_presentation.manifest.sequences.first["viewingDirection"].class).to eq String
+      expect(iiif_presentation.manifest.sequences.first["viewingDirection"]).to eq "left-to-right"
+      expect(iiif_presentation.manifest.sequences.first["viewingHint"]).to eq "individuals"
     end
 
     it "has a sequence with an id" do

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -18,6 +18,27 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
       click_on("New Parent Object")
     end
 
+    context "setting non-required values" do
+      before do
+        stub_metadata_cloud("2012036")
+        fill_in('Oid', with: "2012036")
+      end
+
+      it "includes reference to documentation for IIIF values" do
+        expect(page).to have_link("IIIF viewing direction details", href: "https://iiif.io/api/presentation/2.1/#viewingdirection")
+        expect(page).to have_link("IIIF viewing hints details", href: "https://iiif.io/api/presentation/2.1/#viewinghint")
+      end
+
+      it "can set iiif values via the UI" do
+        page.select("left-to-right", from: "Viewing direction")
+        page.select("facing-pages", from: "Display layout")
+        click_on("Create Parent object")
+        expect(page.body).to include "Parent object was successfully created"
+        expect(page.body).to include "left-to-right"
+        expect(page.body).to include "facing-pages"
+      end
+    end
+
     context "with a ParentObject whose authoritative_metadata_source is Ladybird" do
       before do
         stub_metadata_cloud("2012036")
@@ -63,6 +84,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
       it "can create a new parent object" do
         expect(page.body).to include "Parent object was successfully created"
         expect(page.body).to include "Voyager"
+        expect(page.body).to include "Public"
       end
 
       it "has the correct authoritative_metadata_source in the database" do
@@ -76,6 +98,10 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         expect(po.voyager_json).not_to be_empty
         expect(po.holding).to eq "7397126"
         expect(po.item).to eq "8200460"
+      end
+
+      it "adds the visibility for public objects" do
+        expect(ParentObject.find_by(oid: "2012036")["visibility"]).to eq "Public"
       end
     end
 
@@ -119,25 +145,6 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
       it "still fills in non-empty values" do
         expect(ParentObject.find_by(oid: "2004628")["bib"]).to eq "3163155"
-      end
-    end
-
-    context "with a ParentObject whose authoritative_metadata_source is Voyager" do
-      before do
-        stub_metadata_cloud("2012036", "ladybird")
-        stub_metadata_cloud("V-2012036", "ils")
-        fill_in('Oid', with: "2012036")
-        select('Public')
-        click_on("Create Parent object")
-      end
-
-      it "can create a new parent object" do
-        expect(page.body).to include "Parent object was successfully created"
-        expect(page.body).to include "Public"
-      end
-
-      it "adds the visibility for public objects" do
-        expect(ParentObject.find_by(oid: "2012036")["visibility"]).to eq "Public"
       end
     end
 


### PR DESCRIPTION
Connected to https://github.com/yalelibrary/YUL-DC/issues/420 

- Allows us to edit viewing direction and display layout via UI, using only IIIF valid fields, on the ParentObject
- Add to the iiifpresentation sequence if present and not set to an empty string (do we have a favorite way to make sure empty strings aren't set in the DB, instead of NULL, from form parameters?) 
- Future work: Allow similar for individual child objects

before for 2012315
![image](https://user-images.githubusercontent.com/45948126/101216267-37b62e00-364d-11eb-99d9-e2a81c59510e.png)

After defining it as "paged" and "right-to-left"
![image](https://user-images.githubusercontent.com/45948126/101216539-ad21fe80-364d-11eb-8bb7-96f3df2f8f3a.png)

![image](https://user-images.githubusercontent.com/45948126/101371198-767bfc00-3878-11eb-9707-b977ca8651c3.png)
