### PR TITLE
Limits IIIF viewing hints to those appropriate for the parent

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -33,7 +33,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewinghint
   def self.viewing_hints
-    [nil, "individuals", "paged", "continuous", "multi-part", "non-paged", "top", "facing-pages"]
+    [nil, "individuals", "paged", "continuous"]
   end
 
   validates :visibility, inclusion: { in: visibilities,

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
 
       it "can set iiif values via the UI" do
         page.select("left-to-right", from: "Viewing direction")
-        page.select("facing-pages", from: "Display layout")
+        page.select("continuous", from: "Display layout")
         click_on("Create Parent object")
         expect(page.body).to include "Parent object was successfully created"
         expect(page.body).to include "left-to-right"
-        expect(page.body).to include "facing-pages"
+        expect(page.body).to include "continuous"
       end
     end
 


### PR DESCRIPTION
Removes `multipart`, `top`, `facing-pages`, `non-paged` which apply to Collections (`multipart`), Ranges (`top`) or Canvases (others) and aren't appropriate for the parent object.