### PR TITLE
Add attribution to IIIF Manifest

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -41,7 +41,7 @@ class IiifPresentation
     @manifest = IIIF::Presentation::Manifest.new(seed)
     @manifest["rendering"] = rendering
     @manifest["metadata"] = metadata
-    @manifest["attribution"] = "Yale University Libraries Digital Collections"
+    @manifest["attribution"] = "Yale University Library"
     @manifest.sequences << sequence
     add_canvases_to_sequence(@manifest.sequences.first)
     @manifest

--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -40,7 +40,8 @@ class IiifPresentation
     return @manifest if @manifest
     @manifest = IIIF::Presentation::Manifest.new(seed)
     @manifest["rendering"] = rendering
-    @manifest['metadata'] = metadata
+    @manifest["metadata"] = metadata
+    @manifest["attribution"] = "Yale University Libraries Digital Collections"
     @manifest.sequences << sequence
     add_canvases_to_sequence(@manifest.sequences.first)
     @manifest

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["label"]).to eq "Strawberry Thief fabric, made by Morris and Company "
     end
 
+    it "has an attribution to Yale" do
+      expect(iiif_presentation.manifest["attribution"]).to eq "Yale University Libraries Digital Collections"
+    end
+
     it "can save a manifest to S3" do
       expect(iiif_presentation.save).to eq true
     end

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
     end
 
     it "has an attribution to Yale" do
-      expect(iiif_presentation.manifest["attribution"]).to eq "Yale University Libraries Digital Collections"
+      expect(iiif_presentation.manifest["attribution"]).to eq "Yale University Library"
     end
 
     it "can save a manifest to S3" do


### PR DESCRIPTION
Connected to https://github.com/yalelibrary/YUL-DC/issues/421

Displays the attribution within the viewer
![image](https://user-images.githubusercontent.com/45948126/102636231-64c11100-4122-11eb-8082-a93bc3ed3e8b.png)
