### PR TITLE
Make parent object edit form more usable

### DIFF
--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -10,79 +10,71 @@
       </ul>
     </div>
   <% end %>
+  <div class="form-row">
+    <div class="col-med-3">
+      <%= form.label :oid %>
+      <%= self.action_name == "edit" ? form.text_field(:oid, disabled: true) : form.text_field(:oid, disabled: false) %>
+    </div>
 
-  <div class="field">
-    <%= form.label :oid %>
-    <%= form.text_field :oid %>
+    <div class="col-med-3">
+      <%= form.label "Metadata Source" %>
+      <%= form.select(:authoritative_metadata_source_id, [['Ladybird', 1], ['Voyager', 2], ['ArchiveSpace', 3]]) %>
+    </div>
+
+    <div class="col-med-3">
+      <%= form.label :visibility %>
+      <%= form.select(:visibility, ParentObject.visibilities) %>
+    </div>
+  </div>
+  <br>
+  <h6 class="form-subgroup-title">Voyager identifiers</h6>
+  <div class="voyager_identifiers, form-row">
+    <div class="col-med-3">
+      <%= form.label :bib %>
+      <%= form.text_field :bib %>
+    </div>
+
+    <div class="col-med-3">
+      <%= form.label "Holding (optional)" %>
+      <%= form.text_field :holding %>
+    </div>
+
+    <div class="col-med-3">
+      <%= form.label "Item (optional)" %>
+      <%= form.text_field :item %>
+    </div>
   </div>
 
-  <div class="form-group">
-    <%= form.label :authoritative_metadata_source %>
-    <%= form.select(:authoritative_metadata_source_id, [['Ladybird', 1], ['Voyager', 2], ['ArchiveSpace', 3]]) %>
-  </div>
+  <br>
+  <h6 class="form-subgroup-title">Other identifiers</h6>
+  <div class="other_identifiers, form-row">
+    <div class="col-med-3">
+      <%= form.label :barcode %>
+      <%= form.text_field :barcode %>
+    </div>
 
-  <div class="field">
-    <%= form.label :bib %>
-    <%= form.text_field :bib %>
+    <div class="col-med-3">
+      <%= form.label "ASpace URI"%>
+      <%= form.text_field :aspace_uri %>
+    </div>
   </div>
+  <br>
 
-  <div class="field">
-    <%= form.label :holding %>
-    <%= form.text_field :holding %>
+  <h6 class="form-subgroup-title">IIIF Values</h6>
+  <div class="other_identifiers, form-row">
+    <div class="col-med-3">
+      <%= form.label :viewing_direction %>
+      <%= link_to("IIIF viewing direction details", "https://iiif.io/api/presentation/2.1/#viewingdirection") %><br>
+      <%= form.select(:viewing_direction, ParentObject.viewing_directions) %>
+    </div>
+
+    <div class="col-med-3">
+      <%= form.label :display_layout %>
+      <%= link_to("IIIF viewing hints details", "https://iiif.io/api/presentation/2.1/#viewinghint") %><br>
+      <%= form.select(:display_layout, ParentObject.viewing_hints) %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= form.label :item %>
-    <%= form.text_field :item %>
-  </div>
-
-  <div class="field">
-    <%= form.label :barcode %>
-    <%= form.text_field :barcode %>
-  </div>
-
-  <div class="field">
-    <%= form.label :aspace_uri %>
-    <%= form.text_field :aspace_uri %>
-  </div>
-
-  <div class="field">
-    <%= form.label :last_ladybird_update %>
-    <%= form.text_field :last_ladybird_update %>
-  </div>
-
-  <div class="field">
-    <%= form.label :last_voyager_update %>
-    <%= form.text_field :last_voyager_update %>
-  </div>
-
-  <div class="field">
-    <%= form.label :last_aspace_update %>
-    <%= form.text_field :last_aspace_update %>
-  </div>
-
-  <div class="field">
-    <%= form.label :visibility %>
-    <%= form.select(:visibility, ParentObject.visibilities) %>
-  </div>
-
-  <div class="field">
-    <%= form.label :viewing_direction %>
-    <%= link_to("IIIF viewing direction details", "https://iiif.io/api/presentation/2.1/#viewingdirection") %><br>
-    <%= form.select(:viewing_direction, ParentObject.viewing_directions) %>
-  </div>
-
-  <div class="field">
-    <%= form.label :display_layout %>
-    <%= link_to("IIIF viewing hints details", "https://iiif.io/api/presentation/2.1/#viewinghint") %><br>
-    <%= form.select(:display_layout, ParentObject.viewing_hints) %>
-  </div>
-
-  <div class="field">
-    <%= form.label :last_id_update %>
-    <%= form.text_field :last_id_update %>
-  </div>
-
+  <br>
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -61,11 +61,6 @@
 </p>
 
 <p>
-  <strong>Last id update:</strong>
-  <%= @parent_object.last_id_update %>
-</p>
-
-<p>
   <strong>Authoritative Metadata source:</strong>
   <%= @parent_object.authoritative_metadata_source.display_name %>
 </p>

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         expect(page).to have_link("IIIF viewing hints details", href: "https://iiif.io/api/presentation/2.1/#viewinghint")
       end
 
+      it "includes fields that are not editable" do
+        expect(page).to have_field("Oid", disabled: false)
+      end
+
       it "can set iiif values via the UI" do
         page.select("left-to-right", from: "Viewing direction")
         page.select("continuous", from: "Display layout")
@@ -196,6 +200,19 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
           expect(ParentObject.find_by(oid: "20000016189097")["visibility"]).to eq "Yale Community Only"
         end
       end
+    end
+  end
+
+  context "editing a ParentObject" do
+    let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036) }
+    before do
+      stub_metadata_cloud("2012036")
+      parent_object
+      visit edit_parent_object_path(2_012_036)
+    end
+
+    it "can see non-editable fields" do
+      expect(page).to have_field("Oid", disabled: true)
     end
   end
 end


### PR DESCRIPTION
- Make Oid disabled on edit
- Remove for-debugging date fields
- Create more logical ordering and groupings

Before:
![image](https://user-images.githubusercontent.com/45948126/102666479-0bbea080-4155-11eb-8497-45a8167c3432.png)

After:
![image](https://user-images.githubusercontent.com/45948126/102666341-a66aaf80-4154-11eb-8661-24a69d434897.png)

Connected to https://github.com/yalelibrary/YUL-DC/issues/700