### PR TITLE
Refactor ParentObjects - Will not always have Ladybird record in future

### DIFF
--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -65,17 +65,7 @@ class MetadataSource < ApplicationRecord
   end
 
   def mc_get(mc_url)
-    # TODO: Do we still need the Honeybadger context part of this?
-    Honeybadger.context(
-      metadata_cloud_username: ENV["MC_USER"],
-      metadata_cloud_password: ENV["MC_PW"],
-      mc_host: MetadataSource.metadata_cloud_host,
-      mc_host_env: ENV['METADATA_CLOUD_HOST'],
-      mc_url: mc_url
-    )
-    metadata_cloud_username = ENV["MC_USER"]
-    metadata_cloud_password = ENV["MC_PW"]
-    HTTP.basic_auth(user: metadata_cloud_username, pass: metadata_cloud_password).get(mc_url)
+    HTTP.basic_auth(user: ENV.fetch("MC_USER"), pass: ENV.fetch("MC_PW")).get(mc_url)
   end
 
   # Hard coding the metadata cloud version because it is directly correlated with the solr indexing code

--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -65,7 +65,9 @@ class MetadataSource < ApplicationRecord
   end
 
   def mc_get(mc_url)
-    HTTP.basic_auth(user: ENV.fetch("MC_USER"), pass: ENV.fetch("MC_PW")).get(mc_url)
+    metadata_cloud_username = ENV["MC_USER"]
+    metadata_cloud_password = ENV["MC_PW"]
+    HTTP.basic_auth(user: metadata_cloud_username, pass: metadata_cloud_password).get(mc_url)
   end
 
   # Hard coding the metadata cloud version because it is directly correlated with the solr indexing code

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -18,6 +18,10 @@ class MetsDocument
     file_group.xpath("@ID").first.inner_text
   end
 
+  def metadata_source_path
+    @mets.xpath("//mods:identifier").inner_text
+  end
+
   def valid_mets?
     return false unless @mets.xml?
     return false unless @mets.collect_namespaces.include?("xmlns:mets")

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -22,6 +22,14 @@ class MetsDocument
     @mets.xpath("//mods:identifier").inner_text
   end
 
+  def metadata_source
+    metadata_source_path.match(/\/(\w*)\/(\w*)\/(\d*)\W(\w*)\W(\w*)/).captures.first
+  end
+
+  def bib
+    metadata_source_path.match(/\/(\w*)\/(\w*)\/(\d*)\W(\w*)\W(\w*)/).captures.last if metadata_source == "ils"
+  end
+
   def valid_mets?
     return false unless @mets.xml?
     return false unless @mets.collect_namespaces.include?("xmlns:mets")

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -41,6 +41,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def initialize(attributes = nil)
     super
+    self.use_ladybird = true
   end
 
   def start_states
@@ -141,12 +142,13 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     super(lb_record)
     return lb_record if lb_record.blank?
     self.last_ladybird_update = DateTime.current
-    return if ladybird_json_previously_changed?
+    return unless use_ladybird
     self.bib = lb_record["orbisBibId"]
     self.barcode = lb_record["orbisBarcode"]
     self.aspace_uri = lb_record["archiveSpaceUri"]
     self.visibility = lb_record["itemPermission"]
     self.rights_statement = lb_record["rights"]&.first
+    self.use_ladybird = false
   end
 
   def voyager_json=(v_record)

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
       item: nil,
       last_aspace_update: nil,
       last_id_update: nil,
-      last_ladybird_update: Time.zone.parse('2020-06-10 17:38:27.000000000 +0000'),
+      last_ladybird_update: nil,
       last_voyager_update: nil,
       oid: "<a href='/parent_objects/1'>1</a><br> <a class='btn btn-info btn-sm' href='#{ENV['BLACKLIGHT_BASE_URL'] || 'localhost:3000'}/catalog/16854285' target='_blank' > Public View</a>",
       visibility: "Private",

--- a/spec/factories/parent_objects.rb
+++ b/spec/factories/parent_objects.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :parent_object do
     oid { "2004628" }
     authoritative_metadata_source_id { "1" }
-    last_ladybird_update { "2020-06-10 17:38:27" }
     factory :parent_object_with_bib do
       oid { "2004628" }
       bib { "3163155" }

--- a/spec/fixtures/ils/V-2004628.json
+++ b/spec/fixtures/ils/V-2004628.json
@@ -56,7 +56,7 @@
     "Paul Kane Paintings. Yale Collection of Western Americana, Beinecke Rare Book and Manuscript Library."
   ],
   "dateStructured": [
-    "1846"
+    "1846/1848"
   ],
   "illustrativeMatter": "nnn ",
   "titleStatement": [

--- a/spec/fixtures/ils/V-30000317.json
+++ b/spec/fixtures/ils/V-30000317.json
@@ -1,0 +1,108 @@
+{
+  "jsonModelType": "BibSolrRecord",
+  "source": "ils",
+  "recordType": "bib",
+  "uri": "/ils/barcode/39002091118928?bib=8394689",
+  "callNumber": "11 1860A",
+  "title": [
+    "Di qiu quan tu",
+    "地球全圖"
+  ],
+  "alternativeTitle": [
+    "Shi jie di tu",
+    "世界地圖"
+  ],
+  "edition": [
+    "Tao yin ben."
+  ],
+  "creationPlace": [
+    "China",
+    "China",
+    "China"
+  ],
+  "publisher": [
+    "publisher not identified",
+    "publisher not identified"
+  ],
+  "date": [
+    "Xianfeng wu nian [1855]"
+  ],
+  "extent": [
+    "1 map : 93 x 170 cm"
+  ],
+  "material": [
+    "color ;"
+  ],
+  "language": [
+    "Chinese"
+  ],
+  "languageCode": [
+    "chi"
+  ],
+  "subjectTopic": [
+    "World maps",
+    "World maps"
+  ],
+  "scale": "Scale not determined.",
+  "coordinate": [
+    "-180.000000 180.000000 090.000000 -090.000000"
+  ],
+  "coordinateDisplay": [
+    "(W 180°--E 180°/N 90°--S 90°)."
+  ],
+  "genre": [
+    "World maps",
+    "Chinese rare maps"
+  ],
+  "itemType": [
+    "cartographic image"
+  ],
+  "orbisBibId": "8394689",
+  "orbisBarcode": "39002091118928",
+  "findingAid": [
+    "http://beinecke.library.yale.edu/dl_crosscollex/brbldl_getrec.asp?fld=img&id=16595618"
+  ],
+  "dateStructured": [
+    "1855"
+  ],
+  "illustrativeMatter": "    ",
+  "coordinateWest": "-180.000000",
+  "coordinateEast": "180.000000",
+  "coordinateNorth": "090.000000",
+  "coordinateSouth": "-090.000000",
+  "titleStatement": [
+    "Di qiu quan tu / Dechen zhi ; Chen Xiutang zhu zi.",
+    "地球全圖 / 德臣製 ; 陳修堂註字"
+  ],
+  "contributor": [
+    "Chen, Xiutang."
+  ],
+  "repository": "beingen",
+  "alternativeTitleDisplay": [
+    "Shi jie di tu",
+    "世界地圖"
+  ],
+  "relatedTitle": [
+    ""
+  ],
+  "relatedTitleDisplay": [
+    "Chen, Xiutang",
+    "陳修堂"
+  ],
+  "contributorDisplay": [
+    "Chen, Xiutang."
+  ],
+  "dependentUris": [
+    "/ils/holding/8833608",
+    "/ils/item/7599022",
+    "/ils/bib/8394689",
+    "/ils/barcode/39002091118928"
+  ],
+  "bibId": 8394689,
+  "suppressInOpac": false,
+  "createDate": "2008-10-15T15:01:44.000+0000",
+  "updateDate": "2018-11-28T16:47:49.000+0000",
+  "holdingId": 8833608,
+  "itemId": 7599022,
+  "children": []
+}

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
 
     describe "running the background jobs" do
       before do
-        stub_metadata_cloud("30000317", "ils")
+        stub_metadata_cloud("V-30000317", "ils")
       end
 
       around do |example|
@@ -115,6 +115,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   describe "with the metadata cloud mocked" do
     before do
       stub_metadata_cloud("2034600")
+      stub_metadata_cloud("2005512")
       stub_metadata_cloud("2046567")
       stub_metadata_cloud("16414889")
       stub_metadata_cloud("14716192")

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -86,15 +86,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
         stub_metadata_cloud("V-30000317", "ils")
       end
 
-      around do |example|
-        original_vpn = ENV['VPN']
-        ENV['VPN'] = 'true'
-        perform_enqueued_jobs do
-          example.run
-        end
-        ENV['VPN'] = original_vpn
-      end
-
       it "creates a new parent object" do
         expect do
           batch_process.file = xml_upload
@@ -107,7 +98,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
         batch_process.save
         po = ParentObject.find(30_000_317)
         expect(po.bib).to eq "8394689"
-        expect(IngestEvent.where("reason LIKE (?)", "%Metadata Cloud did not return json%")).to be_empty
       end
     end
   end

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -102,12 +102,11 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
         end.to change { ParentObject.count }.from(0).to(1)
       end
 
-      xit "does not try to get Ladybird data for new goobi objects" do
+      it "does not try to get Ladybird data for new Goobi objects" do
         batch_process.file = xml_upload
         batch_process.save
         po = ParentObject.find(30_000_317)
-        expect(po.bib).to eq 8_394_689
-        # expect(IngestEvent.where(reason: "S3 did not return json for ladybird/30000317.json")).to be_empty
+        expect(po.bib).to eq "8394689"
         expect(IngestEvent.where("reason LIKE (?)", "%Metadata Cloud did not return json%")).to be_empty
       end
     end

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -58,6 +58,61 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
     end
   end
 
+  describe 'xml file import' do
+    it "does not error out" do
+      batch_process.file = xml_upload
+      expect(batch_process).to be_valid
+    end
+
+    it "has an oid associated with it" do
+      batch_process.file = xml_upload
+      batch_process.save!
+      expect(batch_process.oid).to eq 30_000_317
+    end
+
+    it "has a mets document associated with it that is not saved to the database" do
+      batch_process.file = xml_upload
+      expect(batch_process.mets_doc.valid_mets?).to eq true
+    end
+
+    it "evaluates a valid METs file as valid" do
+      batch_process.file = xml_upload
+      expect(batch_process.mets_xml).to be_present
+      expect(batch_process).to be_valid
+    end
+
+    describe "running the background jobs" do
+      before do
+        stub_metadata_cloud("30000317", "ils")
+      end
+
+      around do |example|
+        original_vpn = ENV['VPN']
+        ENV['VPN'] = 'true'
+        perform_enqueued_jobs do
+          example.run
+        end
+        ENV['VPN'] = original_vpn
+      end
+
+      it "creates a new parent object" do
+        expect do
+          batch_process.file = xml_upload
+          batch_process.save
+        end.to change { ParentObject.count }.from(0).to(1)
+      end
+
+      xit "does not try to get Ladybird data for new goobi objects" do
+        batch_process.file = xml_upload
+        batch_process.save
+        po = ParentObject.find(30_000_317)
+        expect(po.bib).to eq 8_394_689
+        # expect(IngestEvent.where(reason: "S3 did not return json for ladybird/30000317.json")).to be_empty
+        expect(IngestEvent.where("reason LIKE (?)", "%Metadata Cloud did not return json%")).to be_empty
+      end
+    end
+  end
+
   describe "with the metadata cloud mocked" do
     before do
       stub_metadata_cloud("2034600")
@@ -80,10 +135,10 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
         stub_metadata_cloud("16371253")
       end
       it "can create a parent_object from an array of oids" do
-        expect(ParentObject.count).to eq 0
-        batch_process.save
-        batch_process.create_parent_objects_from_oids(["16371253"], ["ladybird"])
-        expect(ParentObject.count).to eq 1
+        expect do
+          batch_process.save
+          batch_process.create_parent_objects_from_oids(["16371253"], ["ladybird"])
+        end.to change { ParentObject.count }.from(0).to(1)
       end
     end
 
@@ -163,37 +218,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
           po_two = ParentObject.find(2_005_512)
           expect(po_two.visibility).to eq "Public"
         end
-      end
-    end
-
-    describe 'xml file import' do
-      it "does not error out" do
-        batch_process.file = xml_upload
-        expect(batch_process).to be_valid
-      end
-
-      it "has an oid associated with it" do
-        batch_process.file = xml_upload
-        batch_process.save!
-        expect(batch_process.oid).to eq 30_000_317
-      end
-
-      it "has a mets document associated with it that is not saved to the database" do
-        batch_process.file = xml_upload
-        expect(batch_process.mets_doc.valid_mets?).to eq true
-      end
-
-      it "evaluates a valid METs file as valid" do
-        batch_process.file = xml_upload
-        expect(batch_process.mets_xml).to be_present
-        expect(batch_process).to be_valid
-      end
-
-      it "can refresh the ParentObjects from the MetadataCloud" do
-        expect(ParentObject.count).to eq 0
-        batch_process.file = xml_upload
-        batch_process.save
-        expect(ParentObject.count).to eq 1
       end
     end
   end

--- a/spec/models/mets_document_spec.rb
+++ b/spec/models/mets_document_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true do
   let(:image_missing_file) { File.open(File.join(fixture_path, "goobi", "metadata", "16172421", "missing_image.xml")).read }
   let(:no_image_files_path) { File.join(fixture_path, "goobi", "metadata", "2012315", "no_image_files.xml") }
 
-  before do
-    stub_metadata_cloud("16172421")
-  end
-
   it "can be instantiated with xml from the DB instead of a file" do
     described_class.new(batch_process.mets_xml)
   end
@@ -58,6 +54,11 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true do
     expect(mets_doc.oid).to eq "30000317"
   end
 
+  it "can return the system of record API call" do
+    mets_doc = described_class.new(valid_goobi_xml)
+    expect(mets_doc.metadata_source_path)
+  end
+
   it "returns nil if there is no oid field in the METs document" do
     mets_doc = described_class.new(no_oid_file)
     expect(mets_doc.oid).to be_empty
@@ -79,7 +80,7 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true do
     expect(mets_doc.files.first[:id]).to eq "444d3360-bf78-4e35-9850-44ef7f832105"
   end
 
-  it "can return the ORDERLABEL, id for the physical structure, and file id" do
+  it "can return the ORDERLABEL, order, id for the physical structure, and file id" do
     mets_doc = described_class.new(valid_goobi_xml)
     expect(mets_doc.physical_divs.first[:order_label]).to eq " - "
     expect(mets_doc.physical_divs.first[:order]).to eq "1"

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -179,10 +179,12 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
         stub_metadata_cloud("2005512", "ladybird")
         stub_metadata_cloud("V-2005512", "ils")
       end
+
       it "pulls from the MetadataCloud for Ladybird and not Voyager or ArchiveSpace" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq ladybird
         expect(parent_object.ladybird_json).not_to be nil
         expect(parent_object.ladybird_json).not_to be_empty
+        expect(parent_object.visibility).to eq "Public"
         expect(parent_object.voyager_json).to be nil
         expect(parent_object.aspace_json).to be nil
       end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -146,6 +146,18 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     end
   end
 
+  context 'without ladybird_json or identifiers set' do
+    let(:parent_object) { FactoryBot.build(:parent_object, oid: '16797069') }
+
+    it 'raises an error when building a voyager url' do
+      expect { parent_object.voyager_cloud_url }.to raise_error(StandardError, "Bib id required to build Voyager url")
+    end
+
+    it 'returns an aspace url' do
+      expect { parent_object.aspace_cloud_url }.to raise_error(StandardError, "ArchiveSpace uri required to build ArchiveSpace url")
+    end
+  end
+
   context "a newly created ParentObject with an expected (ladybird, voyager, or aspace) authoritative_metadata_source" do
     let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", authoritative_metadata_source_id: ladybird) }
 
@@ -210,12 +222,11 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     end
 
     context "a newly created ParentObject with Voyager as authoritative_metadata_source" do
-      let(:parent_object) { described_class.create(oid: "2004628", authoritative_metadata_source_id: voyager) }
+      let(:parent_object) { described_class.create(oid: "2004628", bib: '3163155', authoritative_metadata_source_id: voyager) }
 
-      it "pulls from the MetadataCloud for Ladybird and Voyager and not ArchiveSpace" do
+      it "pulls from the MetadataCloud for Voyager" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq voyager
-        expect(parent_object.ladybird_json).not_to be nil
-        expect(parent_object.ladybird_json).not_to be_empty
+        expect(parent_object.ladybird_json).to be nil
         expect(parent_object.voyager_json).not_to be nil
         expect(parent_object.voyager_json).not_to be_empty
         expect(parent_object.aspace_json).to be nil
@@ -227,16 +238,15 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     end
 
     context "a newly created ParentObject with ArchiveSpace as authoritative_metadata_source" do
-      let(:parent_object) { described_class.create(oid: "2012036", authoritative_metadata_source_id: aspace) }
+      let(:parent_object) { described_class.create(oid: "2012036", aspace_uri: "/repositories/11/archival_objects/555049", authoritative_metadata_source_id: aspace) }
       before do
         stub_metadata_cloud("2012036", "ladybird")
         stub_metadata_cloud("AS-2012036", "aspace")
       end
 
-      it "pulls from the MetadataCloud for Ladybird and ArchiveSpace and not Voyager" do
+      it "pulls from the MetadataCloud for ArchiveSpace" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq aspace # 3 is ArchiveSpace
-        expect(parent_object.ladybird_json).not_to be nil
-        expect(parent_object.ladybird_json).not_to be_empty
+        expect(parent_object.ladybird_json).to be nil
         expect(parent_object.aspace_json).not_to be nil
         expect(parent_object.aspace_json).not_to be_empty
         expect(parent_object.voyager_json).to be nil
@@ -244,7 +254,8 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     end
 
     context "has a shortcut for the metadata_cloud_name" do
-      let(:parent_object) { described_class.create(oid: "2004628", authoritative_metadata_source_id: voyager) }
+      let(:parent_object) { described_class.create(oid: "2004628", bib: "6805375", barcode: "39002091459793", authoritative_metadata_source_id: voyager) }
+
       it 'returns source name when authoritative source is set' do
         expect(parent_object.source_name).to eq 'ils'
       end
@@ -255,7 +266,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     end
 
     context 'with ladybird_json' do
-      let(:parent_object) { FactoryBot.build(:parent_object, oid: '16797069', ladybird_json: JSON.parse(File.read(File.join(fixture_path, "ladybird", "16797069.json")))) }
+      let(:parent_object) do
+        FactoryBot.build(:parent_object, oid: '16797069', bib: '3435140', barcode: '39002075038423',
+                                         ladybird_json: JSON.parse(File.read(File.join(fixture_path, "ladybird", "16797069.json"))))
+      end
 
       it 'returns a ladybird url' do
         expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/16797069?include-children=1"
@@ -291,23 +305,11 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
       end
     end
 
-    context 'with ladybird_json but no orbisBarcode' do
-      let(:parent_object) { FactoryBot.build(:parent_object, oid: '16712419', ladybird_json: JSON.parse(File.read(File.join(fixture_path, "ladybird", "16712419.json")))) }
+    context 'with a bib but no barcode' do
+      let(:parent_object) { FactoryBot.build(:parent_object, oid: '16712419', bib: '1289001') }
 
       it 'returns a voyager url using the bib' do
         expect(parent_object.voyager_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ils/bib/1289001"
-      end
-    end
-
-    context 'without ladybird_json' do
-      let(:parent_object) { FactoryBot.build(:parent_object, oid: '16797069') }
-
-      it 'returns a voyager url' do
-        expect(parent_object.voyager_cloud_url).to eq nil
-      end
-
-      it 'returns an aspace url' do
-        expect(parent_object.aspace_cloud_url).to eq nil
       end
     end
 

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -80,10 +80,28 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         click_on("Create Parent object")
       end
 
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
+      end
+
       it "can create a new parent object" do
         expect(page.body).to include "Parent object was successfully created"
         expect(page.body).to include "Ladybird"
         expect(page.body).to include "Authoritative JSON"
+        expect(page.body).to include "Public"
+      end
+
+      it "can change the visibility via the UI" do
+        click_on("Edit")
+        select("Yale Community Only")
+        click_on("Update Parent object")
+        expect(page.body).to include "Yale Community Only"
+        click_on("Back")
+        click_on("Update Metadata")
+        visit parent_object_path(2_012_036)
+        expect(page.body).to include "Yale Community Only"
       end
 
       it "includes the rights statment" do

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -117,6 +117,9 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         stub_metadata_cloud("2012036", "ladybird")
         stub_metadata_cloud("V-2012036", "ils")
         fill_in('Oid', with: "2012036")
+        fill_in('Bib', with: "6805375")
+        fill_in('Barcode', with: "39002091459793")
+        select('Public')
         select('Voyager')
         click_on("Create Parent object")
       end
@@ -150,6 +153,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         stub_metadata_cloud("2012036", "ladybird")
         stub_metadata_cloud("AS-2012036", "aspace")
         fill_in('Oid', with: "2012036")
+        fill_in('parent_object_aspace_uri', with: "/repositories/11/archival_objects/555049")
         select('ArchiveSpace')
         click_on("Create Parent object")
       end


### PR DESCRIPTION
As we move toward ingesting new objects directly through Goobi, we need to change the software expectations, and not assume that there will be Ladybird metadata available.

This PR makes it so that we do not always first pull the Ladybird metadata prior to pulling Voyager or ArchiveSpace metadata. 

If the information needed to create a Voyager or ArchiveSpace url is not available, and the application tries to generate the URL in order to pull the metadata, it will raise an error. 

### Future work 
  - Add validation via the UI to make it clear that if the source of authority is not Ladybird, and the ParentObject isn't coming through Goobi, you have to include additional identifiers in order to fetch the metadata (ArchiveSpace URI or Voyager bib id and barcode if applicable)
  - Decide how to use the identifier given by Goobi to retrieve both ArchiveSpace and Voyager records and update code accordingly