### PR TITLE
Rights statement solr

### DIFF
--- a/app/jobs/add_rights_to_parent_objects_job.rb
+++ b/app/jobs/add_rights_to_parent_objects_job.rb
@@ -3,7 +3,7 @@
 # TODO: this is a onetime thing for a data migration
 # it can be removed after 3/1/2021
 class AddRightsToParentObjectsJob < ApplicationJob
-  queue_as :rights
+  queue_as :default
 
   def perform(*_args)
     ParentObject.where(rights_statement: nil).find_each do |parent|

--- a/app/jobs/add_rights_to_parent_objects_job.rb
+++ b/app/jobs/add_rights_to_parent_objects_job.rb
@@ -5,6 +5,10 @@
 class AddRightsToParentObjectsJob < ApplicationJob
   queue_as :default
 
+  def default_priority
+    -100
+  end
+
   def perform(*_args)
     ParentObject.where(rights_statement: nil).find_each do |parent|
       parent.rights_statement = parent.ladybird_json["rights"]&.first

--- a/app/jobs/add_rights_to_parent_objects_job.rb
+++ b/app/jobs/add_rights_to_parent_objects_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# TODO: this is a onetime thing for a data migration
+# it can be removed after 3/1/2021
+class AddRightsToParentObjectsJob < ApplicationJob
+  queue_as :rights
+
+  def perform(*_args)
+    ParentObject.where(rights_statement: nil).find_each do |parent|
+      parent.rights_statement = parent.ladybird_json["rights"]&.first
+      parent.save!
+    end
+  end
+end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -92,8 +92,8 @@ module SolrIndexable
       repository_ssim: json_to_index["repository"],
       resourceType_ssim: json_to_index["resourceType"],
       resourceType_tesim: json_to_index["resourceType"],
-      rights_ssim: json_to_index["rights"],
-      rights_tesim: json_to_index["rights"],
+      rights_ssim: rights_statement,
+      rights_tesim: rights_statement,
       scale_tesim: json_to_index["scale"],
       source_ssim: json_to_index["source"], # refers to source of metadata, e.g. Ladybird, Voyager, etc.
       sourceCreated_tesim: json_to_index["sourceCreated"],

--- a/db/migrate/20210106144702_add_rights_to_parent_objects.rb
+++ b/db/migrate/20210106144702_add_rights_to_parent_objects.rb
@@ -1,0 +1,5 @@
+class AddRightsToParentObjects < ActiveRecord::Migration[6.0]
+  def change
+    AddRightsToParentObjectsJob.perform_later
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_21_175924) do
+ActiveRecord::Schema.define(version: 2021_01_06_144702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Management is the authoritative source for the rights statement, so should index to Solr from the object, not the json.

Add migration and job to add rights to DB for all existing parent objects