### PR TITLE
Set current_batch_connection on ParentObject

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -113,7 +113,7 @@ class ParentObjectsController < ApplicationController
 
     def batch_process_of_one
       @batch_process = BatchProcess.new(user: current_user, oid: @parent_object.oid)
-      @batch_process.batch_connections.build(connectable: @parent_object)
+      @parent_object.current_batch_connection = @batch_process.batch_connections.build(connectable: @parent_object)
       @batch_process.save!
       @parent_object.current_batch_process = @batch_process
     end


### PR DESCRIPTION
Sets the current_batch_process on the parent_object in batch_process_for_one before saving the batch_process.
Saving the batch_process triggers the parent_object to save, which triggers the SetupMetadataJob.  

So, current_batch_process needs to be set on the parent before saving the batch_process.