### PR TITLE
Update code for editing rights statements on parent objects

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -121,6 +121,7 @@ class ParentObjectsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def parent_object_params
       params.require(:parent_object).permit(:oid, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
-                                            :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction, :display_layout, :representative_child_oid)
+                                            :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
+                                            :display_layout, :representative_child_oid, :rights_statement)
     end
 end

--- a/app/jobs/add_rights_to_parent_objects_job.rb
+++ b/app/jobs/add_rights_to_parent_objects_job.rb
@@ -11,7 +11,7 @@ class AddRightsToParentObjectsJob < ApplicationJob
 
   def perform(*_args)
     ParentObject.where(rights_statement: nil).find_each do |parent|
-      parent.rights_statement = parent.ladybird_json["rights"]&.first if parent.ladybird_json
+      parent.rights_statement = parent.ladybird_json&.[]("rights")&.first
       parent.save!
     end
   end

--- a/app/jobs/add_rights_to_parent_objects_job.rb
+++ b/app/jobs/add_rights_to_parent_objects_job.rb
@@ -11,7 +11,7 @@ class AddRightsToParentObjectsJob < ApplicationJob
 
   def perform(*_args)
     ParentObject.where(rights_statement: nil).find_each do |parent|
-      parent.rights_statement = parent.ladybird_json["rights"]&.first
+      parent.rights_statement = parent.ladybird_json["rights"]&.first if parent.ladybird_json
       parent.save!
     end
   end

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         click_on("Create Parent object")
         click_on("Edit")
         expect(page).to have_field("Rights statement")
+        fill_in("Rights statement", with: "This is a rights statement")
+        click_on("Update Parent object")
+        expect(page).to have_content("This is a rights statement")
       end
 
       it "can show the representative thumbnail via the UI" do


### PR DESCRIPTION
- Don't have the background job error out if no ladybird_json
- Pass the rights statement through the controller. D'oh. Going on break problems.