### PR TITLE
Make subject geo clickable links 

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -102,6 +102,7 @@ module SolrIndexable
       sourceNote_tesim: json_to_index["sourceNote"],
       sourceTitle_tesim: json_to_index["sourceTitle"],
       subjectEra_ssim: json_to_index["subjectEra"],
+      subjectGeographic_ssim: json_to_index["subjectGeographic"],
       subjectGeographic_tesim: json_to_index["subjectGeographic"],
       subjectTitle_tsim: json_to_index["subjectTitle"],
       subjectTitleDisplay_tsim: json_to_index["subjectTitleDisplay"],


### PR DESCRIPTION
The example for subject (geographic).

**Before**
![Screen Shot 2021-01-12 at 4.33.40 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/fcf9422d-374f-4559-ae54-f6a20fcf0365)

-------

**After**
![Screen Shot 2021-01-12 at 4.28.30 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/c8578eb0-72ca-46b1-a08e-77245b7296e9)  

![Screen Shot 2021-01-12 at 4.28.51 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/ece49096-781a-48ac-b94e-08fa9c1a005c)