### PR TITLE
Remove manifest app from management dashboard

### DIFF
--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -28,11 +28,5 @@
         <td> <a href="https://github.com/yalelibrary/yul-dc-iiif-imageserver">yalelibrary/yul-dc-iiif-imageserver</a></td>
         <td id="iiif_image_version"> <%= ENV['IIIF_IMAGE_VERSION'].present? ? "#{ENV['IIIF_IMAGE_VERSION']}" : "" %> </td>
       </tr>
-      <tr>
-        <td> IIIF Manifest Server </td>
-        <td> <a href="https://hub.docker.com/repository/docker/yalelibraryit/dc-iiif-manifest">yalelibraryit/dc-iiif-manifest</a> </td>
-        <td> <a href="https://github.com/yalelibrary/yul-dc-iiif-manifest">yalelibrary/yul-dc-iiif-manifest</a> </td>
-        <td id="iiif_manifest_version"> <%= ENV['IIIF_MANIFEST_VERSION'].present? ? "#{ENV['IIIF_MANIFEST_VERSION']}" : "" %> </td>
-      </tr>
   </table>
 </div>

--- a/spec/views/management_spec.rb
+++ b/spec/views/management_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "Management", type: :feature do
       expect(page).to have_selector("#iiif_image_version", text: "v4.delta.chi"),
                       "has a css id for the iiif image version"
       expect(page).to have_content("yalelibraryit/dc-iiif-cantaloupe")
-      expect(page).to have_selector("#iiif_manifest_version", text: "v5.lambda.phi")
-      expect(page).to have_content("yalelibraryit/dc-iiif-manifest")
+      expect(page).not_to have_selector("#iiif_manifest_version", text: "v5.lambda.phi")
+      expect(page).not_to have_content("yalelibraryit/dc-iiif-manifest")
     end
   end
 end


### PR DESCRIPTION
Co-authored-by: Rachel Kadel <rkadel@curationexperts.com>

 - [x] Remove manifest app from management dashboard

**Before Code Modification**
![Screen Shot 2021-01-14 at 1 49 44 PM](https://user-images.githubusercontent.com/41123693/104635134-82c15900-566f-11eb-977e-d89e0fa1f10a.png)


---- 

**After Code Modification**
![Screen Shot 2021-01-14 at 1 48 41 PM](https://user-images.githubusercontent.com/41123693/104634935-41c94480-566f-11eb-8f1f-5b48044aca3a.png)
