### PR TITLE
#1003 Fix race condition queueing GenerateManifestJob: Only return true from needs_a_manifest once

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -212,7 +212,12 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def needs_a_manifest?
-    ready_for_manifest? && generate_manifest
+    if ready_for_manifest? && generate_manifest
+      updated_rows = ActiveRecord::Base.connection.update("update parent_objects set generate_manifest = false where oid=#{oid}")
+      self.generate_manifest = false
+      return updated_rows == 1
+    end
+    false
   end
 
   def ready_for_manifest?

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -221,6 +221,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
       it "pdf path on S3" do
         expect(parent_object.remote_pdf_path).not_to be_nil
       end
+
+      it "returns true from needs_a_manifest? only one time" do
+        parent_object.generate_manifest = true
+        parent_object.save!
+        expect(parent_object.needs_a_manifest?).to be_truthy
+        expect(parent_object.needs_a_manifest?).to be_falsey
+      end
     end
 
     context "a newly created ParentObject with Voyager as authoritative_metadata_source" do


### PR DESCRIPTION
Ensures that needs_a_manifest? returns true only one time after generate_manifest is true and all PTiffs are ready.  After the first call to needs_a_manifest, the ParentObject's generate_manifest flag is set to false.

The number of affected rows in the database is used to handle multithreading.


Co-authored-by: Lakeisha Robinson <lakeisha.robinson@yale.edu>