### PR TITLE
Use ActiveRecord for generate_manifest update

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -220,7 +220,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def needs_a_manifest?
     if ready_for_manifest? && generate_manifest
-      updated_rows = ActiveRecord::Base.connection.update("update parent_objects set generate_manifest = false where oid=#{oid}")
+      updated_rows = ParentObject.where(oid: oid, generate_manifest: true).update_all(generate_manifest: false) # rubocop:disable Rails/SkipsModelValidations
       self.generate_manifest = false
       return updated_rows == 1
     end


### PR DESCRIPTION
Updates to a prior change when setting generate_manifest to false for a parent object:
- Uses ActiveRecord so direct SQL is not needed.
- Fixes selection criterial to get desired "affected_rows"


Co-authored-by: Michael Appleby <michael.appleby@yale.edu>
