### PR TITLE
Goobi import bugfixes

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -79,7 +79,7 @@ class BatchProcessesController < ApplicationController
     def set_child_object
       @child_object = ChildObject.find(params[:child_oid])
       @notes = @child_object.notes_for_batch_process(@batch_process)
-      @failures = @child_object.latest_failure(@batch_process)
+      @failure = @child_object.latest_failure(@batch_process)
     end
 
     def find_notes

--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -79,6 +79,7 @@ class BatchProcessesController < ApplicationController
     def set_child_object
       @child_object = ChildObject.find(params[:child_oid])
       @notes = @child_object.notes_for_batch_process(@batch_process)
+      # TODO: Find failure related only to child object?
       @failure = @child_object.latest_failure(@batch_process)
     end
 

--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -21,6 +21,10 @@ class GenerateManifestJob < ApplicationJob
     if upload
       parent_object.processing_event("IIIF Manifest saved to S3", "manifest-saved", current_batch_process, current_batch_connection)
       parent_object.generate_manifest = false
+      # Once we have successfully created all the ptiffs & created the manifest,
+      # we should no longer need access to the original Goobi package, and should create any further
+      # artifacts from the more persistent data available through the MetadataCloud, database, and access masters
+      parent_object.from_mets = false
       parent_object.save!
     else
       parent_object.processing_event("IIIF Manifest not saved to S3", "failed", current_batch_process, current_batch_connection)

--- a/app/jobs/generate_ptiff_job.rb
+++ b/app/jobs/generate_ptiff_job.rb
@@ -10,7 +10,7 @@ class GeneratePtiffJob < ApplicationJob
   def perform(child_object, current_batch_process, current_batch_connection = child_object.parent_object.current_batch_connection)
     child_object.parent_object.current_batch_process = current_batch_process
     child_object.parent_object.current_batch_connection = current_batch_connection
-    child_object.copy_to_access_master_pairtree if child_object.parent_object.from_mets == true
+    child_object.copy_to_access_master_pairtree if child_object.parent_object.from_mets
     child_object.convert_to_ptiff!
     # Only generate manifest if all children are ready
     GenerateManifestJob.perform_later(child_object.parent_object, current_batch_process, current_batch_connection) if child_object.parent_object.needs_a_manifest?

--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -7,7 +7,7 @@ class SetupMetadataJob < ApplicationJob
     parent_object.current_batch_process = current_batch_process
     parent_object.current_batch_connection = current_batch_connection
     parent_object.generate_manifest = true
-    mets_images_present = check_mets_images(parent_object)
+    mets_images_present = check_mets_images(parent_object, current_batch_process, current_batch_connection)
     return unless mets_images_present
     # Do not continue running the background jobs if the metadata has not been successfully fetched
     return unless parent_object.default_fetch(current_batch_process, current_batch_connection)
@@ -23,9 +23,9 @@ class SetupMetadataJob < ApplicationJob
     raise # this reraises the error after we document it
   end
 
-  def check_mets_images(parent_object)
+  def check_mets_images(parent_object, current_batch_process, _current_batch_connection)
     if parent_object.from_mets
-      parent_object.current_batch_process.mets_doc.all_images_present?
+      current_batch_process.mets_doc.all_images_present?
     else
       true
     end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -90,7 +90,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
     return if fresh
     po.metadata_update = true
-    setup_for_background_jobs(po, metadata_source)
+    setup_for_background_jobs(po, po.metadata_source)
     po.save!
   end
 

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -75,9 +75,9 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def refresh_metadata_cloud_mets
     fresh = false
+    metadata_source = mets_doc.metadata_source
     po = ParentObject.where(oid: oid).first_or_create do |parent_object|
       # Only runs on newly created parent objects
-      metadata_source = mets_doc.metadata_source
       parent_object.bib = mets_doc.bib
       parent_object.visibility = mets_doc.visibility
       parent_object.rights_statement = mets_doc.rights_statement
@@ -90,7 +90,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
     return if fresh
     po.metadata_update = true
-    setup_for_background_jobs(po, po.metadata_source)
+    setup_for_background_jobs(po, metadata_source)
     po.save!
   end
 

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -22,7 +22,7 @@ class MetsDocument
     @mets.xpath("//mods:identifier").inner_text
   end
 
-  def full_metadatacloud_url
+  def full_metadata_cloud_url
     "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{metadata_source_path}"
   end
 

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -22,6 +22,10 @@ class MetsDocument
     @mets.xpath("//mods:identifier").inner_text
   end
 
+  def full_metadatacloud_url
+    "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{metadata_source_path}"
+  end
+
   def metadata_source
     metadata_source_path.match(/\/(\w*)\/(\w*)\/(\d*)\W(\w*)\W(\w*)/).captures.first
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -193,7 +193,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def voyager_cloud_url
     # if we're working from a mets document, use the MetadataCloud call from the mets document
-    return current_batch_process.mets_doc.full_metadatacloud_url if from_mets && current_batch_process.mets_doc.full_metadatacloud_url
+    return current_batch_process.mets_doc.full_metadata_cloud_url if from_mets && current_batch_process.mets_doc.full_metadata_cloud_url
     raise StandardError, "Bib id required to build Voyager url" unless bib.present?
     identifier_block = if !barcode.present?
                          "/bib/#{bib}"
@@ -205,7 +205,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def aspace_cloud_url
     # if we're working from a mets document, use the MetadataCloud call from the mets document
-    return current_batch_process.mets_doc.full_metadatacloud_url if from_mets && current_batch_process.mets_doc.full_metadatacloud_url
+    return current_batch_process.mets_doc.full_metadata_cloud_url if from_mets && current_batch_process.mets_doc.full_metadata_cloud_url
     raise StandardError, "ArchiveSpace uri required to build ArchiveSpace url" unless aspace_uri.present?
     "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/aspace#{aspace_uri}"
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -126,6 +126,19 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     json_for(authoritative_metadata_source.metadata_cloud_name)
   end
 
+  def metadata_cloud_url
+    case source_name
+    when "ladybird"
+      ladybird_cloud_url
+    when "ils"
+      voyager_cloud_url
+    when "aspace"
+      aspace_cloud_url
+    else
+      raise StandardError, "Unexpected metadata cloud name: #{authoritative_metadata_source.metadata_cloud_name}"
+    end
+  end
+
   def json_for(source_name)
     case source_name
     when "ladybird"

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -193,7 +193,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def voyager_cloud_url
     # if we're working from a mets document, use the MetadataCloud call from the mets document
-    return "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{current_batch_process.mets_doc.metadata_source_path}" if from_mets && current_batch_process
+    return current_batch_process.mets_doc.full_metadatacloud_url if from_mets && current_batch_process.mets_doc.full_metadatacloud_url
     raise StandardError, "Bib id required to build Voyager url" unless bib.present?
     identifier_block = if !barcode.present?
                          "/bib/#{bib}"
@@ -205,7 +205,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def aspace_cloud_url
     # if we're working from a mets document, use the MetadataCloud call from the mets document
-    return "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{current_batch_process.mets_doc.metadata_source_path}" if from_mets && current_batch_process
+    return current_batch_process.mets_doc.full_metadatacloud_url if from_mets && current_batch_process.mets_doc.full_metadatacloud_url
     raise StandardError, "ArchiveSpace uri required to build ArchiveSpace url" unless aspace_uri.present?
     "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/aspace#{aspace_uri}"
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -193,7 +193,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def voyager_cloud_url
     # if we're working from a mets document, use the MetadataCloud call from the mets document
-    return "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{current_batch_process.mets_doc.metadata_source_path}" if from_mets
+    return "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{current_batch_process.mets_doc.metadata_source_path}" if from_mets && current_batch_process
     raise StandardError, "Bib id required to build Voyager url" unless bib.present?
     identifier_block = if !barcode.present?
                          "/bib/#{bib}"
@@ -205,7 +205,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def aspace_cloud_url
     # if we're working from a mets document, use the MetadataCloud call from the mets document
-    return "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{current_batch_process.mets_doc.metadata_source_path}" if from_mets
+    return "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}#{current_batch_process.mets_doc.metadata_source_path}" if from_mets && current_batch_process
     raise StandardError, "ArchiveSpace uri required to build ArchiveSpace url" unless aspace_uri.present?
     "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/aspace#{aspace_uri}"
   end

--- a/app/views/batch_processes/show_child.html.erb
+++ b/app/views/batch_processes/show_child.html.erb
@@ -56,7 +56,7 @@
   <% end %>
 </table>
 
-<% if @failures %>
+<% if @failure %>
   <table class="table table-bordered table-striped">
     <thead class="thead-dark">
       <tr>
@@ -64,12 +64,10 @@
         <th scope="col"> Time </th>
       </tr>
     </thead>
-    <% @failures.each do |failure| %>
     <tr>
-      <td class="reason"><%= failure["reason"] %></td>
-      <td class="time"><%= failure["time"] %></td>
+      <td class="reason"><%= @failure["reason"] %></td>
+      <td class="time"><%= @failure["time"] %></td>
     </tr>
-    <% end %>
   </table>
 <% end %>
 

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -6,6 +6,12 @@
 </p>
 
 <p>
+  <strong>MetadataCloud url:</strong><br>
+  <small>Note: the "&mediaType=json" is not used for MetadataCloud calls, just so you can open this directly in your browser</small><br>
+  <%= link_to "#{@parent_object.metadata_cloud_url}&mediaType=json", "#{@parent_object.metadata_cloud_url}&mediaType=json" %>
+</p>
+
+<p>
   <strong>Bib:</strong>
   <%= @parent_object.bib %>
 </p>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -7,8 +7,8 @@
 
 <p>
   <strong>MetadataCloud url:</strong><br>
-  <small>Note: the "&mediaType=json" is not used for MetadataCloud calls, just so you can open this directly in your browser</small><br>
-  <%= link_to "#{@parent_object.metadata_cloud_url}&mediaType=json", "#{@parent_object.metadata_cloud_url}&mediaType=json" %>
+  <small>Note: add "&mediaType=json" or "?mediaType=json" to open in your browser</small><br>
+  <%= link_to "#{@parent_object.metadata_cloud_url}", "#{@parent_object.metadata_cloud_url}" %>
 </p>
 
 <p>

--- a/spec/models/mets_document_spec.rb
+++ b/spec/models/mets_document_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true do
 
   it "can return the system of record API call" do
     mets_doc = described_class.new(valid_goobi_xml)
-    expect(mets_doc.metadata_source_path)
+    expect(mets_doc.metadata_source_path).to eq "/ils/barcode/39002091118928?bib=8394689"
+    expect(mets_doc.full_metadatacloud_url).to eq "https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ils/barcode/39002091118928?bib=8394689"
   end
 
   it "returns nil if there is no oid field in the METs document" do

--- a/spec/models/mets_document_spec.rb
+++ b/spec/models/mets_document_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true do
   it "can return the system of record API call" do
     mets_doc = described_class.new(valid_goobi_xml)
     expect(mets_doc.metadata_source_path).to eq "/ils/barcode/39002091118928?bib=8394689"
-    expect(mets_doc.full_metadatacloud_url).to eq "https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ils/barcode/39002091118928?bib=8394689"
+    expect(mets_doc.full_metadata_cloud_url).to eq "https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ils/barcode/39002091118928?bib=8394689"
   end
 
   it "returns nil if there is no oid field in the METs document" do

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         expect(page.body).to include "Ladybird"
         expect(page.body).to include "Authoritative JSON"
         expect(page.body).to include "Public"
+        expect(page.body).to include "MetadataCloud url"
       end
 
       it "can change the visibility via the UI" do


### PR DESCRIPTION
- Were getting a type mismatch on the "@failures" on the batch process child object page, so have it reflect that the method's been changed to return only the last failure 
- don't need the `== true` in if statements
- Pass current batch process to the "check_mets_images" to ensure that it can find the correct mets & mets_doc
- In the "refresh_metadata_cloud_mets" method the inner loop only happens on newly created parent objects, so set the metadata_source for both new and old parent objects
- Add shortcut to just the parent_object's metadata_cloud url
- Ensure that either the full url from the mets document is returned, or we build up the Metadata cloud url as normal