### PR TITLE
Temporarily don't copy goobi

### DIFF
--- a/app/jobs/generate_ptiff_job.rb
+++ b/app/jobs/generate_ptiff_job.rb
@@ -10,6 +10,9 @@ class GeneratePtiffJob < ApplicationJob
   def perform(child_object, current_batch_process, current_batch_connection = child_object.parent_object.current_batch_connection)
     child_object.parent_object.current_batch_process = current_batch_process
     child_object.parent_object.current_batch_connection = current_batch_connection
+    # TODO: Uncomment the line below to re-implement Goobi ingest and copy to the access master pair-tree.
+    # There is a test in  spec/models/batch_process_spec.rb that should fail, take out the "pending" and logger
+    # mocks there to see if it passes
     # child_object.copy_to_access_master_pairtree if child_object.parent_object.from_mets == true
     child_object.convert_to_ptiff!
     # Only generate manifest if all children are ready

--- a/app/jobs/generate_ptiff_job.rb
+++ b/app/jobs/generate_ptiff_job.rb
@@ -10,7 +10,7 @@ class GeneratePtiffJob < ApplicationJob
   def perform(child_object, current_batch_process, current_batch_connection = child_object.parent_object.current_batch_connection)
     child_object.parent_object.current_batch_process = current_batch_process
     child_object.parent_object.current_batch_connection = current_batch_connection
-    child_object.copy_to_access_master_pairtree if child_object.parent_object.from_mets == true
+    # child_object.copy_to_access_master_pairtree if child_object.parent_object.from_mets == true
     child_object.convert_to_ptiff!
     # Only generate manifest if all children are ready
     GenerateManifestJob.perform_later(child_object.parent_object, current_batch_process, current_batch_connection) if child_object.parent_object.needs_a_manifest?

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -107,8 +107,12 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
         end
       end
 
+      let(:logger_mock) { instance_double("Rails.logger").as_null_object }
       # Doing one large test here, because with copying images, etc., it is an expensive one
       it "creates a parent object with the expected values and child objects with expected values" do
+        # TODO: TURN THIS BACK ON FOR GOOBI!!! - Remove the following two lines - pending and rails logger mock
+        pending("Copying the goobi files to the access master pair-tree in the GeneratePtiffJob")
+        allow(Rails.logger).to receive(:all) { :logger_mock }
         expect(File.exist?("spec/fixtures/images/access_masters/00/02/30/00/04/02/30000402.tif")).to be false
         expect(File.exist?("spec/fixtures/images/access_masters/00/03/30/00/04/03/30000403.tif")).to be false
         expect(File.exist?("spec/fixtures/images/access_masters/00/04/30/00/04/04/30000404.tif")).to be false

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       it "creates a parent object with the expected values and child objects with expected values" do
         # TODO: TURN THIS BACK ON FOR GOOBI!!! - Remove the following two lines - pending and rails logger mock
         pending("Copying the goobi files to the access master pair-tree in the GeneratePtiffJob")
-        allow(Rails.logger).to receive(:all) { :logger_mock }
+        allow(Rails.logger).to receive(:debug) { :logger_mock }
         expect(File.exist?("spec/fixtures/images/access_masters/00/02/30/00/04/02/30000402.tif")).to be false
         expect(File.exist?("spec/fixtures/images/access_masters/00/03/30/00/04/03/30000403.tif")).to be false
         expect(File.exist?("spec/fixtures/images/access_masters/00/04/30/00/04/04/30000404.tif")).to be false


### PR DESCRIPTION
* Mike Appleby has asked that we make sure that we don't accidentally write to the access master pair-tree while we determine a multi-pair-tree implementation.
* The "pending" test should make it so that we won't accidentally start doing this - it should fail if the test passes, meaning we're copying the images again.