### PR TITLE
Ingest error handling

### DIFF
--- a/app/models/batch_connection.rb
+++ b/app/models/batch_connection.rb
@@ -14,7 +14,7 @@ class BatchConnection < ApplicationRecord
     update_status && save!
   end
 
-  def batch_connections_for(batch_process)
+  def batch_connections_for(_batch_process)
     [self]
   end
 end

--- a/app/models/batch_connection.rb
+++ b/app/models/batch_connection.rb
@@ -13,4 +13,8 @@ class BatchConnection < ApplicationRecord
   def update_status!
     update_status && save!
   end
+
+  def batch_connections_for(batch_process)
+    [self]
+  end
 end

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -138,6 +138,6 @@ class ChildObject < ApplicationRecord
   end
 
   def batch_connections_for(batch_process)
-    self.parent_object.batch_connections.where(batch_process: batch_process)
+    parent_object.batch_connections.where(batch_process: batch_process)
   end
 end

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -136,4 +136,8 @@ class ChildObject < ApplicationRecord
   def convert_to_ptiff!
     convert_to_ptiff && save!
   end
+
+  def batch_connections_for(batch_process)
+    self.parent_object.batch_connections.where(batch_process: batch_process)
+  end
 end

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -22,7 +22,7 @@ module Statable
     notes["parent-deleted"]
   end
 
-  def batch_connections_for(batch_process)
+  def batch_connections_for(_batch_process)
     raise 'Must be implemented'
   end
 

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -7,7 +7,7 @@ module Statable
   end
 
   def events_for_batch_process(batch_process)
-    IngestEvent.where(batch_connection: batch_process.batch_connections)
+    IngestEvent.where(batch_connection: batch_connections_for(batch_process))
   end
 
   def start_note(notes)
@@ -20,6 +20,10 @@ module Statable
 
   def deleted_note(notes)
     notes["parent-deleted"]
+  end
+
+  def batch_connections_for(batch_process)
+    raise 'Must be implemented'
   end
 
   def status_for_batch_process(batch_process)

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -276,4 +276,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     base = ENV['BLACKLIGHT_BASE_URL'] || 'localhost:3000'
     "#{base}/catalog/#{oid}"
   end
+
+  def batch_connections_for(batch_process)
+    batch_connections.where(batch_process: batch_process)
+  end
 end

--- a/spec/models/batch_connection_spec.rb
+++ b/spec/models/batch_connection_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe BatchConnection, type: :model, prep_metadata_sources: true do
     expect(po.batch_connections.first.connectable.child_object_count).to eq po.child_object_count
   end
 
+  it "batch_connections_for returns itself" do
+    batch_process.file = csv_upload
+    batch_process.save!
+    batch_process.run_callbacks :create
+    po = ParentObject.find(2_034_600)
+    batch_connection = po.batch_connections.first
+    expect(batch_connection.batch_connections_for(batch_process)).to eq([batch_connection])
+  end
+
   describe "running the background job" do
     around do |example|
       perform_enqueued_jobs do

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -163,6 +163,22 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       expect(child_object.remote_ptiff_path).to eq "ptiffs/89/45/67/89/456789.tif"
     end
 
+    it "finds batch connections on the parent object" do
+      user = FactoryBot.create(:user)
+      batch_process = FactoryBot.create(:batch_process, user: user)
+      csv_upload = Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'short_fixture_ids.csv'))
+
+      batch_process.file = csv_upload
+      batch_process.save!
+      batch_process.run_callbacks :create
+
+      po = ParentObject.find(2_034_600)
+      po.child_objects = [child_object]
+      batch_connection = po.batch_connections.first
+
+      expect(child_object.batch_connections_for(batch_process)).to eq([batch_connection])
+    end
+
     describe "with a cached width and height on s3" do
       before do
         stub_request(:head, "https://yale-test-image-samples.s3.amazonaws.com/ptiffs/89/45/67/89/456789.tif")

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -165,18 +165,12 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
 
     it "finds batch connections on the parent object" do
       user = FactoryBot.create(:user)
-      batch_process = FactoryBot.create(:batch_process, user: user)
-      csv_upload = Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'short_fixture_ids.csv'))
-
-      batch_process.file = csv_upload
+      batch_process = BatchProcess.new(oid: parent_object.oid, user: user)
+      batch_process.batch_connections.build(connectable: parent_object)
       batch_process.save!
-      batch_process.run_callbacks :create
+      batch_connection = parent_object.batch_connections
 
-      po = ParentObject.find(2_034_600)
-      po.child_objects = [child_object]
-      batch_connection = po.batch_connections.first
-
-      expect(child_object.batch_connections_for(batch_process)).to eq([batch_connection])
+      expect(child_object.batch_connections_for(batch_process)).to eq(batch_connection)
     end
 
     describe "with a cached width and height on s3" do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -455,4 +455,17 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
       expect(po.rights_statement).to be nil
     end
   end
+
+  context 'a Parent Object' do
+    it 'finds batch connections' do
+      user = FactoryBot.create(:user)
+      parent_object = FactoryBot.create(:parent_object, oid: 2_003_431)
+      batch_process = BatchProcess.new(oid: parent_object.oid, user: user)
+      batch_process.batch_connections.build(connectable: parent_object)
+      batch_process.save!
+      batch_connection = parent_object.batch_connections
+
+      expect(parent_object.batch_connections_for(batch_process)).to eq(batch_connection)
+    end
+  end
 end


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Rob Kaufman <rob@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1007

# Summary
- we were displaying all events for a batch…for each parent
- if any parent in the batch had successfully generated a manifest, then a given parent in that batch would show that it had generated a manifest…even if it hadn't
- we're now making sure that the status that returns for a child object or parent object, is specific to that object
- updated the tests

# Expected Behavior
- when a batch process is created, the proper status will be shown on the batch processES,  batch process, parent batch process and single child batch process pages

# Demo
- We pushed this branch to https://collections-test.library.yale.edu/management, uploaded the file of 65 oids and verified the proper statuses were showing
- The [list of 65 items](https://docs.google.com/spreadsheets/d/1HvbMAxP1T1AjIMWLcqRxDqoX7HNQIixkTxdcIXyWNVQ/edit#gid=0) that we went through shows that only 10 out of 65 oids were actually successful
- The batch process page does show 10 "complete" oids, whose oids match the successful oids on the list of 65.

https://collections-test.library.yale.edu/management/batch_processes
![65](https://user-images.githubusercontent.com/29032869/105930041-b69c6700-5ffd-11eb-87ee-f205d1d3f246.jpg)

https://collections-test.library.yale.edu/management/batch_processes/89
![image](https://user-images.githubusercontent.com/29032869/105930063-c451ec80-5ffd-11eb-89b2-c14e51ce3a22.png)

https://collections-test.library.yale.edu/management/batch_processes/89/parent_objects/16590537
![image](https://user-images.githubusercontent.com/29032869/105930093-d5026280-5ffd-11eb-886f-aa8ebdd534fd.png)