### PR TITLE
Removes checksum check after FileUtils.cp

### DIFF
--- a/app/models/pyramidal_tiff.rb
+++ b/app/models/pyramidal_tiff.rb
@@ -67,10 +67,8 @@ class PyramidalTiff
       end
     else
       FileUtils.cp(access_master_path, tmpdir)
-      if checksums_match?(access_master_path, temp_file_path)
-        child_object.processing_event("Access master retrieved from file system", 'access-master')
-        temp_file_path
-      end
+      child_object.processing_event("Access master retrieved from file system", 'access-master')
+      temp_file_path
     end
   end
 
@@ -92,28 +90,5 @@ class PyramidalTiff
   def save_to_s3(ptiff_output_path, conversion_information)
     metadata = { 'width': conversion_information[:width].to_s, 'height': conversion_information[:height].to_s }
     S3Service.upload_image(ptiff_output_path, remote_ptiff_path, "image/tiff", metadata)
-  end
-
-  DIGEST_CHUNK_SIZE = 1024 * 1024
-
-  ##
-  # perform checksum on file.
-  def digest_file(file_path)
-    digest = Digest::SHA2.new
-    File.open(file_path, "rb") do |f|
-      buffer = String.new
-      digest.update(buffer) while f.read(DIGEST_CHUNK_SIZE, buffer)
-    end
-    digest
-  end
-
-  ##
-  # @return [Boolean] true if checksums match
-  def checksums_match?(access_master_path, temp_file_path)
-    access_master_checksum = digest_file(access_master_path)
-    temp_file_checksum = digest_file(temp_file_path)
-    return true if access_master_checksum == temp_file_checksum
-    checksum_info = { oid: oid.to_s, access_master_path: access_master_path.to_s, temp_file_path: temp_file_path.to_s }
-    errors.add(:base, "File copy unsuccessful, checksums do not match: #{checksum_info.to_json}")
   end
 end

--- a/spec/models/pyramidal_tiff_spec.rb
+++ b/spec/models/pyramidal_tiff_spec.rb
@@ -100,17 +100,6 @@ RSpec.describe PyramidalTiff, prep_metadata_sources: true, type: :has_vcr do
     expect(ptf.errors.full_messages.first).to match(/Conversion script exited with error code .*/)
   end
 
-  it "checks for file checksum and fails if it doesn't match" do
-    ptf.checksums_match?("spec/fixtures/images/access_masters/test_image.tif", "spec/fixtures/images/temp_images/autumn_test.tif")
-    expect(ptf.errors.full_messages.first).to eq("File copy unsuccessful, checksums do not match: {\"oid\":\"1002533\",\"access_master_path\":" \
-                  "\"spec/fixtures/images/access_masters/test_image.tif\",\"temp_file_path\":\"spec/fixtures/images/temp_images/autumn_test.tif\"}")
-  end
-
-  it "checks for file checksum and succeeds if files match" do
-    ptf.checksums_match?("spec/fixtures/images/access_masters/test_image.tif", "spec/fixtures/images/access_masters/test_image.tif")
-    expect(ptf.errors.full_messages).to be_empty
-  end
-
   it "copies the local access master to a swing directory" do
     tmpdir = "spec/fixtures/images/temp_images/"
     expected_file = "#{tmpdir}1002533.tif"


### PR DESCRIPTION
Removes checksum after copying file from access master mount to temp folder.  
Relies on FileUtils.cp throwing errors and reduces network traffic by not reading file from network share twice.