### PR TITLE
Export all child oids connected to a given list of parent objects

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BatchProcessesController < ApplicationController
-  before_action :set_batch_process, only: [:show, :edit, :update, :destroy, :download, :download_csv, :download_xml, :show_parent, :show_child]
+  before_action :set_batch_process, only: [:show, :edit, :update, :destroy, :download, :download_csv, :download_xml, :download_created, :show_parent, :show_child]
   before_action :set_parent_object, only: [:show_parent, :show_child]
   before_action :find_notes, only: [:show_parent]
   before_action :latest_failure, only: [:show_parent]
@@ -43,6 +43,12 @@ class BatchProcessesController < ApplicationController
 
   def download
     @batch_process.csv.nil? ? download_xml : download_csv
+  end
+
+  def download_created
+    send_data @batch_process.output_csv,
+              type: 'text/csv; charset=utf-8; header=present',
+              disposition: "attachment; filename=#{@batch_process.created_file_name}"
   end
 
   def download_csv

--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -33,7 +33,7 @@ class BatchProcessesController < ApplicationController
       if @batch_process.save
         format.html do
           redirect_to batch_processes_path,
-                      notice: "Your records have been retrieved from the MetadataCloud. PTIFF generation, manifest generation and indexing happen in the background."
+                      notice: "Your job is queued for processing in the background"
         end
       else
         format.html { render :new }
@@ -92,6 +92,6 @@ class BatchProcessesController < ApplicationController
     end
 
     def batch_process_params
-      params.require(:batch_process).permit(:file)
+      params.require(:batch_process).permit(:file, :batch_action)
     end
 end

--- a/app/jobs/create_child_oid_csv_job.rb
+++ b/app/jobs/create_child_oid_csv_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# TODO: this is a onetime thing for a data migration
+# it can be removed after 3/1/2021
+class CreateChildOidCsvJob < ApplicationJob
+  queue_as :default
+
+  def default_priority
+    -100
+  end
+
+  def perform(batch_process)
+    batch_process.output_csv
+  end
+end

--- a/app/jobs/create_child_oid_csv_job.rb
+++ b/app/jobs/create_child_oid_csv_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: this is a onetime thing for a data migration
-# it can be removed after 3/1/2021
 class CreateChildOidCsvJob < ApplicationJob
   queue_as :default
 

--- a/app/jobs/generate_output_csv_job.rb
+++ b/app/jobs/generate_output_csv_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class GenerateOutputCsvJob < ApplicationJob
+  queue_as :default
+
+  def perform(batch_process)
+    batch_process.output_csv
+  rescue => e
+    parent_object.processing_event("Setup job failed to save: #{e.message}", "failed", current_batch_process, current_batch_connection)
+    raise # this reraises the error after we document it
+  end
+end

--- a/app/jobs/generate_output_csv_job.rb
+++ b/app/jobs/generate_output_csv_job.rb
@@ -3,6 +3,10 @@
 class GenerateOutputCsvJob < ApplicationJob
   queue_as :default
 
+  def default_priority
+    -100
+  end
+
   def perform(batch_process)
     batch_process.output_csv
   rescue => e

--- a/app/jobs/refresh_metadata_cloud_csv_job.rb
+++ b/app/jobs/refresh_metadata_cloud_csv_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# TODO: this is a onetime thing for a data migration
+# it can be removed after 3/1/2021
+class RefreshMetadataCloudCsvJob < ApplicationJob
+  queue_as :default
+
+  def default_priority
+    -50
+  end
+
+  def perform(batch_process)
+    batch_process.refresh_metadata_cloud_csv
+  end
+end

--- a/app/jobs/refresh_metadata_cloud_csv_job.rb
+++ b/app/jobs/refresh_metadata_cloud_csv_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: this is a onetime thing for a data migration
-# it can be removed after 3/1/2021
 class RefreshMetadataCloudCsvJob < ApplicationJob
   queue_as :default
 

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -9,6 +9,10 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :batch_connections
   has_many :parent_objects, through: :batch_connections, source_type: "ParentObject", source: :connectable
 
+  def self.batch_actions
+    ['create parent objects', 'export child oids']
+  end
+
   def validate_import
     return if file.blank?
     if File.extname(file) == '.csv'

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -51,6 +51,22 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     @oids ||= [oid]
   end
 
+  def output_csv
+    return nil unless batch_action == "export child oids"
+    headers = ["child_oid", "current_parent_oid", "order", "parent_title", "label (order_label in goobi)", "caption", "viewing_hint"]
+    csv_string = CSV.generate do |csv|
+      csv << headers
+      oids.each do |oid|
+        po = ParentObject.find(oid.to_i)
+        po.child_objects.each do |co|
+          row = [co.oid, po.oid, co.order, po.authoritative_json["title"]&.first, co.label, co.caption, co.viewing_hint]
+          csv << row
+        end
+      end
+      csv_string
+    end
+  end
+
   def create_parent_objects_from_oids(oids, metadata_sources)
     oids.zip(metadata_sources).each do |oid, metadata_source|
       fresh = false

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -53,7 +53,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def output_csv
     return nil unless batch_action == "export child oids"
-    headers = ["child_oid", "current_parent_oid", "order", "parent_title", "label (order_label in goobi)", "caption", "viewing_hint"]
+    headers = ["child_oid", "parent_oid", "order", "parent_title", "label", "caption", "viewing_hint"]
     csv_string = CSV.generate do |csv|
       csv << headers
       oids.each do |oid|
@@ -121,7 +121,9 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def determine_background_jobs
     if csv.present? && (batch_action.eql? 'create parent objects')
-      refresh_metadata_cloud_csv
+      RefreshMetadataCloudCsvJob.perform_later(self)
+    elsif csv.present? && (batch_action.eql? 'export child oids')
+      CreateChildOidCsvJob.perform_later(self)
     elsif mets_xml.present?
       refresh_metadata_cloud_mets
     end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -64,12 +64,17 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
             csv << row
           end
         rescue ActiveRecord::RecordNotFound
-          row = ["Parent Not Found in database", oid, "", "", "", ""]
+          row = ["----", oid, "", "Parent Not Found in database", "", ""]
           csv << row
         end
       end
       csv_string
     end
+  end
+
+  def created_file_name
+    return nil unless file_name
+    "#{file_name.delete_suffix('.csv')}_bp_#{id}.csv"
   end
 
   def create_parent_objects_from_oids(oids, metadata_sources)

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CsvExportable
+  extend ActiveSupport::Concern
+
+  def output_csv
+    return nil unless batch_action == "export child oids"
+    headers = ["child_oid", "parent_oid", "order", "parent_title", "label", "caption", "viewing_hint"]
+    csv_string = CSV.generate do |csv|
+      csv << headers
+      oids.each do |oid|
+        begin
+          po = ParentObject.find(oid.to_i)
+          po.child_objects.each do |co|
+            row = [co.oid, po.oid, co.order, po.authoritative_json["title"]&.first, co.label, co.caption, co.viewing_hint]
+            csv << row
+          end
+        rescue ActiveRecord::RecordNotFound
+          row = ["----", oid, "", "Parent Not Found in database", "", ""]
+          csv << row
+        end
+      end
+      csv_string
+    end
+  end
+end

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -30,10 +30,10 @@ module Statable
     notes = notes_for_batch_process(batch_process)
     if notes.empty?
       "Pending"
-    elsif finished_note(notes)
-      "Complete"
     elsif deleted_note(notes)
       "Parent object deleted"
+    elsif finished_note(notes)
+      "Complete"
     elsif latest_failure(batch_process).nil?
       "In progress - no failures"
     elsif latest_failure(batch_process)

--- a/app/views/batch_processes/_form.html.erb
+++ b/app/views/batch_processes/_form.html.erb
@@ -1,6 +1,5 @@
 <div class='batch-import'>
-  <h3>Batch Import</h3>
-  <%= form_for(@batch_process, multipart: true, html: { class: 'btn form form-inline' }) do |f| %>
+  <%= form_for(@batch_process, multipart: true, html: { class: 'form' }) do |f| %>
     <% if @batch_process.errors.any? %>
       <div id="error_explanation">
         <h2><%= pluralize(@batch_process.errors.count, "error") %> prohibited this event from being saved:</h2>
@@ -11,9 +10,13 @@
         </ul>
       </div>
     <% end %>
-    <div class="field" >
+    <div class="form-group" >
+      <%= f.label :batch_action %>
+      <%= f.select(:batch_action, BatchProcess.batch_actions, {}, { :class => 'form-control' }) %>
+    </div>
+    <div class="form-group" >
       <%= f.file_field :file, accept: '.csv, .xml', required: true %>
-      <%= f.submit "Import", class: "btn btn-primary" %>
+      <%= f.submit "Submit", class: "btn btn-primary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/batch_processes/index.html.erb
+++ b/app/views/batch_processes/index.html.erb
@@ -3,8 +3,9 @@
     <div class='notice'><%= flash[:notice] %></div>
   <% end %>
   <h1>Batch Processes</h1>
-  <%= render 'form' %>
-
+  <div class='row'>
+    <%= render 'form' %>
+  </div>
   <div class='row'>
     <div class='col overflow-auto'>
       <table id='batch-processes-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= batch_processes_path(format: :json) %>'>

--- a/app/views/batch_processes/show.html.erb
+++ b/app/views/batch_processes/show.html.erb
@@ -21,7 +21,12 @@
 
 <p>
   <strong>Manifest:</strong>
-  <%= link_to @batch_process.file_name, download_batch_process_path %>
+  <%= @batch_process.file_name ? link_to(@batch_process.file_name, download_batch_process_path) : "n/a" %>
+</p>
+
+<p>
+  <strong>Created file:</strong>
+  <%= @batch_process.file_name && @batch_process.batch_action == "export child oids" ? link_to(@batch_process.created_file_name, download_created_batch_process_path) : "n/a" %>
 </p>
 
 <div class='row'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     collection { post :import }
     member do
       get :download
+      get :download_created
       get '/parent_objects/:oid', to: 'batch_processes#show_parent', as: :show_parent
       get '/parent_objects/:oid/child_objects/:child_oid', to: 'batch_processes#show_child', as: :show_child
     end

--- a/db/migrate/20210129175706_add_action_to_batch_process.rb
+++ b/db/migrate/20210129175706_add_action_to_batch_process.rb
@@ -1,0 +1,6 @@
+class AddActionToBatchProcess < ActiveRecord::Migration[6.0]
+  def change
+    add_column :batch_processes, :batch_action, :string
+    add_column :batch_processes, :output_csv, :string
+  end
+end

--- a/db/migrate/20210129175706_add_action_to_batch_process.rb
+++ b/db/migrate/20210129175706_add_action_to_batch_process.rb
@@ -1,6 +1,6 @@
 class AddActionToBatchProcess < ActiveRecord::Migration[6.0]
   def change
-    add_column :batch_processes, :batch_action, :string
+    add_column :batch_processes, :batch_action, :string, default: "create parent objects"
     add_column :batch_processes, :output_csv, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2021_01_29_175706) do
     t.bigint "user_id", null: false
     t.string "file_name"
     t.string "batch_status"
-    t.string "batch_action"
+    t.string "batch_action", default: "create parent objects"
     t.string "output_csv"
     t.index ["oid"], name: "index_batch_processes_on_oid"
     t.index ["user_id"], name: "index_batch_processes_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_23_185904) do
+ActiveRecord::Schema.define(version: 2021_01_29_175706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,8 @@ ActiveRecord::Schema.define(version: 2021_01_23_185904) do
     t.bigint "user_id", null: false
     t.string "file_name"
     t.string "batch_status"
+    t.string "batch_action"
+    t.string "output_csv"
     t.index ["oid"], name: "index_batch_processes_on_oid"
     t.index ["user_id"], name: "index_batch_processes_on_user_id"
   end

--- a/spec/fixtures/ladybird/30000016189097.json
+++ b/spec/fixtures/ladybird/30000016189097.json
@@ -61,5 +61,6 @@
   ],
   "oid": "30000016189097",
   "collectionId": 1,
-  "children": []
+  "children": [],
+  "itemPermission": "Private"
 }

--- a/spec/fixtures/short_fixture_ids_with_source.csv
+++ b/spec/fixtures/short_fixture_ids_with_source.csv
@@ -1,7 +1,7 @@
 oid,Source
 2034600,ladybird
-2046567,ils
-14716192,aspace
+2030006,ils
+2012036,aspace
 16414889,ils
 16854285,ladybird
 30000016189097,

--- a/spec/models/batch_connection_spec.rb
+++ b/spec/models/batch_connection_spec.rb
@@ -6,20 +6,35 @@ RSpec.describe BatchConnection, type: :model, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:user) }
   let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "short_fixture_ids.csv")) }
+  around do |example|
+    perform_enqueued_jobs do
+      example.run
+    end
+  end
+
+  before do
+    stub_ptiffs_and_manifests
+    stub_metadata_cloud("2004628")
+    stub_metadata_cloud("16414889")
+    stub_metadata_cloud("14716192")
+    stub_metadata_cloud("16854285")
+    stub_metadata_cloud("16057779")
+  end
 
   it { is_expected.to have_db_column(:connectable_id).of_type(:integer) }
   it { is_expected.to have_db_column(:connectable_type).of_type(:string) }
   it { is_expected.to belong_to(:connectable) }
 
   it "can see a batch process and parent objects" do
-    expect do
-      batch_process.file = csv_upload
-      batch_process.save!
-      batch_process.run_callbacks :create
-    end.to change { batch_process.batch_connections.size }.from(0).to(5)
+    expect(batch_process.batch_connections.size).to eq 0
+    batch_process.file = csv_upload
+    batch_process.save!
+    batch_process.run_callbacks :create
+    expect(batch_process.batch_connections.count).to eq 5
     po = ParentObject.find(2_034_600)
+    bp = BatchProcess.find(batch_process.id)
     expect(po.batch_connections).not_to eq nil
-    expect(po.batch_connections.first).to eq batch_process.batch_connections.first
+    expect(po.batch_connections.first).to eq bp.batch_connections.first
     expect(po.batch_connections.first.connectable.child_object_count).to eq po.child_object_count
   end
 
@@ -32,30 +47,14 @@ RSpec.describe BatchConnection, type: :model, prep_metadata_sources: true do
     expect(batch_connection.batch_connections_for(batch_process)).to eq([batch_connection])
   end
 
-  describe "running the background job" do
-    around do |example|
-      perform_enqueued_jobs do
-        example.run
-      end
-    end
-
-    before do
-      stub_ptiffs_and_manifests
-      stub_metadata_cloud("2004628")
-      stub_metadata_cloud("16414889")
-      stub_metadata_cloud("14716192")
-      stub_metadata_cloud("16854285")
-      stub_metadata_cloud("16057779")
-    end
-    # this is failing in CI, but not locally. May simply be too slow, trying to do all the jobs for all the
-    # parent objects. Marking pending for now, believe this code is sufficiently tested elsewhere.
-    xit "gets a complete status when a complete notification is emitted" do
-      batch_process.file = csv_upload
-      batch_process.run_callbacks :create
-      po = ParentObject.find(2_034_600)
-      expect(po.status_for_batch_process(batch_process)).to eq "Complete"
-      batch_connection = batch_process.batch_connections.detect { |b| b.connectable == po }
-      expect(batch_connection.status).to eq "Complete"
-    end
+  # this is failing in CI, but not locally. May simply be too slow, trying to do all the jobs for all the
+  # parent objects. Marking pending for now, believe this code is sufficiently tested elsewhere.
+  xit "gets a complete status when a complete notification is emitted" do
+    batch_process.file = csv_upload
+    batch_process.run_callbacks :create
+    po = ParentObject.find(2_034_600)
+    expect(po.status_for_batch_process(batch_process)).to eq "Complete"
+    batch_connection = batch_process.batch_connections.detect { |b| b.connectable == po }
+    expect(batch_connection.status).to eq "Complete"
   end
 end

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -34,7 +34,12 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       FactoryBot.create(:batch_connection,
                         connectable: parent_object, batch_process: batch_process_with_failure)
     end
-
+    # rubocop:disable RSpec/AnyInstance
+    before do
+      allow_any_instance_of(ChildObject).to receive(:remote_ptiff_exists?).and_return(false)
+      allow_any_instance_of(PyramidalTiff).to receive(:valid?).and_return(false)
+    end
+    # rubocop:enable RSpec/AnyInstance
     it "can reflect a failure" do
       parent_object
       batch_process_with_failure.file = csv_upload
@@ -157,6 +162,9 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   describe "with the metadata cloud mocked" do
     before do
       stub_metadata_cloud("2034600")
+      stub_metadata_cloud("V-2030006", "ils")
+      stub_metadata_cloud("V-16414889", "ils")
+      stub_metadata_cloud("AS-2012036", "aspace")
       stub_metadata_cloud("2005512")
       stub_metadata_cloud("2046567")
       stub_metadata_cloud("16414889")
@@ -216,11 +224,11 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       it "can identify the metadata source" do
         batch_process.file = csv_upload_with_source
         batch_process.save
-        expect(ParentObject.first.authoritative_metadata_source_id).to eq 1
-        expect(ParentObject.second.authoritative_metadata_source_id).to eq 2
-        expect(ParentObject.third.authoritative_metadata_source_id).to eq 3
-        expect(ParentObject.fourth.authoritative_metadata_source_id).to eq 2
-        expect(ParentObject.fifth.authoritative_metadata_source_id).to eq 1
+        expect(ParentObject.find(2034600).authoritative_metadata_source_id).to eq 1
+        expect(ParentObject.find(2030006).authoritative_metadata_source_id).to eq 2
+        expect(ParentObject.find(2012036).authoritative_metadata_source_id).to eq 3
+        expect(ParentObject.find(16414889).authoritative_metadata_source_id).to eq 2
+        expect(ParentObject.find(16854285).authoritative_metadata_source_id).to eq 1
       end
 
       it 'defaults to ladybird if no metadata source is provided' do

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       allow_any_instance_of(ChildObject).to receive(:remote_ptiff_exists?).and_return(false)
       allow_any_instance_of(PyramidalTiff).to receive(:valid?).and_return(false)
     end
-    # rubocop:enable RSpec/AnyInstance
+
     it "can reflect a failure" do
       parent_object
       batch_process_with_failure.file = csv_upload
       batch_process_with_failure.save
       batch_process_with_failure.run_callbacks :create
-      allow(parent_object).to receive(:processing_event).and_return(
+      allow_any_instance_of(ParentObject).to receive(:processing_event).and_return(
         IngestEvent.create(
           status: "failed",
           reason: "Fake failure 1",
@@ -69,6 +69,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       expect(parent_object.latest_failure(batch_process_with_failure)[:time]).to be
       expect(batch_process_with_failure.batch_status).to eq "Batch failed"
     end
+    # rubocop:enable RSpec/AnyInstance
   end
 
   describe 'xml file import' do

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -224,11 +224,11 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       it "can identify the metadata source" do
         batch_process.file = csv_upload_with_source
         batch_process.save
-        expect(ParentObject.find(2034600).authoritative_metadata_source_id).to eq 1
-        expect(ParentObject.find(2030006).authoritative_metadata_source_id).to eq 2
-        expect(ParentObject.find(2012036).authoritative_metadata_source_id).to eq 3
-        expect(ParentObject.find(16414889).authoritative_metadata_source_id).to eq 2
-        expect(ParentObject.find(16854285).authoritative_metadata_source_id).to eq 1
+        expect(ParentObject.find(2_034_600).authoritative_metadata_source_id).to eq 1
+        expect(ParentObject.find(2_030_006).authoritative_metadata_source_id).to eq 2
+        expect(ParentObject.find(2_012_036).authoritative_metadata_source_id).to eq 3
+        expect(ParentObject.find(16_414_889).authoritative_metadata_source_id).to eq 2
+        expect(ParentObject.find(16_854_285).authoritative_metadata_source_id).to eq 1
       end
 
       it 'defaults to ladybird if no metadata source is provided' do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -104,8 +104,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
     it 'returns a processing_event message' do
       expect do
         batch_process.file = csv_upload
+        batch_process.save
         batch_process.run_callbacks :create
-      end.to change { batch_process.batch_connections.size }.from(0).to(5)
+      end.to change { batch_process.batch_connections.count }.from(0).to(5)
         .and change { IngestEvent.count }.from(0).to(456)
       statuses = IngestEvent.all.map(&:status)
       expect(statuses).to include "processing-queued"

--- a/spec/system/batch_process_child_detail_spec.rb
+++ b/spec/system/batch_process_child_detail_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
     around do |example|
       access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
       ENV["ACCESS_MASTER_MOUNT"] = "/data"
-      example.run
+      perform_enqueued_jobs do
+        example.run
+      end
       ENV["ACCESS_MASTER_MOUNT"] = access_master_mount
     end
     before do
@@ -43,7 +45,7 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
       end
 
       it 'shows the status of the child object' do
-        expect(page).to have_content('In progress - no failures')
+        expect(page).to have_content('Complete')
       end
 
       it 'shows the duration of the batch process' do

--- a/spec/system/batch_process_detail_spec.rb
+++ b/spec/system/batch_process_detail_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources: true, js: true do
   let(:user) { FactoryBot.create(:user, uid: "johnsmith2530") }
   before do
+    stub_ptiffs_and_manifests
     stub_metadata_cloud("2004628")
     stub_metadata_cloud("2030006")
     stub_metadata_cloud("2034600")
@@ -14,6 +15,11 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
   end
 
   context "when uploading a csv" do
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
     let(:batch_process) do
       FactoryBot.create(
         :batch_process,
@@ -33,12 +39,12 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
     end
 
     it "can see the status of the parent object imports" do
-      expect(page).to have_content("In progress - no failures")
+      expect(page).to have_content("Batch complete")
     end
 
     it "can see the overall status of the batch process" do
-      expect(batch_process.batch_status).to eq "Batch in progress - no failures"
-      expect(page).to have_content("Batch in progress - no failures")
+      expect(batch_process.batch_status).to eq "Batch complete"
+      expect(page).to have_content("Batch complete")
     end
 
     context "deleting a parent object" do

--- a/spec/system/batch_process_parent_detail_spec.rb
+++ b/spec/system/batch_process_parent_detail_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Batch Process Parent detail page", type: :system, prep_metadata_
   around do |example|
     original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
     ENV["S3_SOURCE_BUCKET_NAME"] = "yale-test-image-samples"
-    example.run
+    perform_enqueued_jobs do
+      example.run
+    end
     ENV["S3_SOURCE_BUCKET_NAME"] = original_image_bucket
   end
 
@@ -66,7 +68,7 @@ RSpec.describe "Batch Process Parent detail page", type: :system, prep_metadata_
       end
 
       it "shows the status of the parent object" do
-        expect(page).to have_content("In progress - no failures")
+        expect(page).to have_content("Complete")
       end
 
       it "shows when the parent object was submitted" do

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -55,18 +55,31 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
       expect(page).to have_content("Your job is queued for processing in the background")
       expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
       expect(BatchProcess.last.batch_action).to eq "create parent objects"
+      expect(BatchProcess.last.output_csv).to be nil
     end
 
-    it "uploads a CSV of parent oids in order to create export of child objects oids and orders" do
-      expect(BatchProcess.count).to eq 0
-      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
-      select("export child oids")
-      click_button("Submit")
-      expect(BatchProcess.count).to eq 1
-      expect(page).to have_content("Your job is queued for processing in the background")
-      expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
-      expect(BatchProcess.last.batch_action).to eq "export child oids"
-      expect(BatchProcess.last.output_csv).to be
+    context "outputting csv" do
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_034_600) }
+      before do
+        stub_ptiffs_and_manifests
+        parent_object
+      end
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
+      end
+      it "uploads a CSV of parent oids in order to create export of child objects oids and orders" do
+        expect(BatchProcess.count).to eq 0
+        page.attach_file("batch_process_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
+        select("export child oids")
+        click_button("Submit")
+        expect(BatchProcess.count).to eq 1
+        expect(page).to have_content("Your job is queued for processing in the background")
+        expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
+        expect(BatchProcess.last.batch_action).to eq "export child oids"
+        expect(BatchProcess.last.output_csv).to include "1126257"
+      end
     end
 
     context "deleting a parent object" do

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -50,15 +50,29 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
     it "uploads and increases csv count and gives a success message" do
       expect(BatchProcess.count).to eq 0
       page.attach_file("batch_process_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
-      click_button("Import")
+      click_button("Submit")
       expect(BatchProcess.count).to eq 1
-      expect(page).to have_content("Your records have been retrieved from the MetadataCloud. PTIFF generation, manifest generation and indexing happen in the background.")
+      expect(page).to have_content("Your job is queued for processing in the background")
       expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
+      expect(BatchProcess.last.batch_action).to eq "create parent objects"
     end
+
+    it "uploads a CSV of parent oids in order to create export of child objects oids and orders" do
+      expect(BatchProcess.count).to eq 0
+      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
+      select("export child oids")
+      click_button("Submit")
+      expect(BatchProcess.count).to eq 1
+      expect(page).to have_content("Your job is queued for processing in the background")
+      expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
+      expect(BatchProcess.last.batch_action).to eq "export child oids"
+      expect(BatchProcess.last.output_csv).to be
+    end
+
     context "deleting a parent object" do
       before do
         page.attach_file("batch_process_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
-        click_button("Import")
+        click_button("Submit")
         po = ParentObject.find(16_854_285)
         po.delete
         page.refresh
@@ -75,16 +89,16 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
     it "uploads and increases xml count and gives a success message" do
       expect(BatchProcess.count).to eq 0
       page.attach_file("batch_process_file", fixture_path + '/goobi/metadata/30000317_20201203_140947/111860A_8394689_mets.xml')
-      click_button("Import")
+      click_button("Submit")
       expect(BatchProcess.count).to eq 1
-      expect(page).to have_content("Your records have been retrieved from the MetadataCloud. PTIFF generation, manifest generation and indexing happen in the background.")
+      expect(page).to have_content("Your job is queued for processing in the background")
       expect(BatchProcess.last.file_name).to eq "111860A_8394689_mets.xml"
     end
 
     context "deleting a parent object" do
       before do
         page.attach_file("batch_process_file", fixture_path + '/goobi/metadata/30000317_20201203_140947/111860A_8394689_mets.xml')
-        click_button("Import")
+        click_button("Submit")
       end
       it "can still load the batch_process page" do
         po = ParentObject.find(30_000_317)

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
   end
 
   before do
+    stub_ptiffs_and_manifests
     stub_metadata_cloud("2034600")
     stub_metadata_cloud("2005512")
     stub_metadata_cloud("16414889")
@@ -61,7 +62,6 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
     context "outputting csv" do
       let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_034_600) }
       before do
-        stub_ptiffs_and_manifests
         parent_object
       end
       around do |example|
@@ -83,11 +83,16 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
     end
 
     context "deleting a parent object" do
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
+      end
       before do
         page.attach_file("batch_process_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
         click_button("Submit")
         po = ParentObject.find(16_854_285)
-        po.delete
+        po.destroy
         page.refresh
       end
 

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
         expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
         expect(BatchProcess.last.batch_action).to eq "export child oids"
         expect(BatchProcess.last.output_csv).to include "1126257"
+        click_on("View")
+        expect(page).to have_link("short_fixture_ids.csv", href: "/batch_processes/#{BatchProcess.last.id}/download")
+        expect(page).to have_link("short_fixture_ids_bp_#{BatchProcess.last.id}.csv", href: "/batch_processes/#{BatchProcess.last.id}/download_created")
+        click_on("short_fixture_ids_bp_#{BatchProcess.last.id}.csv")
       end
     end
 


### PR DESCRIPTION
Add new functionality to Batch Processes
  * Select "export child oids" from dropdown (see first screenshot)
  * User uploads a CSV of Parent Object oids, with the same formatting as the Parent Object creation csv
  * In a background job, the output / created CSV is generated and saved to the database 
  * The user can then go to the batch process show page and download the created file (see second screenshot)
  * This PR also refactors the creation of parent objects from a CSV upload to a background job, to make CSV upload faster and more immediately clear whether it's been successful or not. This necessitated a number of test expectation changes.
![image](https://user-images.githubusercontent.com/45948126/106616802-f43c4b00-653b-11eb-863c-864db339bf99.png)
![image](https://user-images.githubusercontent.com/45948126/106616980-28177080-653c-11eb-9299-57153b1fb2e2.png)
