### PR TITLE
Update datatables to pass orderable to JS so indicators are correct, update some columns for batches

### DIFF
--- a/app/datatables/batch_process_datatable.rb
+++ b/app/datatables/batch_process_datatable.rb
@@ -14,11 +14,11 @@ class BatchProcessDatatable < AjaxDatatablesRails::ActiveRecord
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      process_id: { source: "BatchProcess.id", cond: :like, searchable: true },
-      user: { source: "BatchProcess.user_id", cond: :like, searchable: true },
-      time: { source: "BatchProcess.created_at", cond: :like, searchable: true },
-      size: { source: "BatchProcess.oid", cond: :like, searchable: true },
-      status: { source: "BatchProcess.batch_status", cond: :null_value, searchable: false, orderable: false },
+      process_id: { source: "BatchProcess.id", cond: :eq, searchable: true, orderable: true },
+      user: { source: "User.uid", cond: :start_with, searchable: true, orderable: true },
+      time: { source: "BatchProcess.created_at", cond: :like, searchable: true, orderable: true },
+      size: { source: "BatchProcess.oid", searchable: false, orderable: false },
+      status: { source: "BatchProcess.batch_status", searchable: false, orderable: false },
       object_details: { cond: :null_value, searchable: false, orderable: false }
     }
   end

--- a/app/datatables/batch_process_detail_datatable.rb
+++ b/app/datatables/batch_process_detail_datatable.rb
@@ -14,10 +14,10 @@ class BatchProcessDetailDatatable < AjaxDatatablesRails::ActiveRecord
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      parent_oid: { source: 'BatchConnection.connectable_id', cond: :like, searchable: true },
-      time: { source: 'BatchConnection.created_at', cond: :like, searchable: true },
-      children: { source: 'ParentObject.child_object_count', cond: :like, searchable: true },
-      status: { source: 'BatchConnection.status', cond: :like, searchable: true }
+      parent_oid: { source: 'BatchConnection.connectable_id', cond: :like, searchable: true, orderable: true },
+      time: { source: 'BatchConnection.created_at', cond: :like, searchable: true, orderable: true },
+      children: { source: 'ParentObject.child_object_count', cond: :like, searchable: true, orderable: true },
+      status: { source: 'BatchConnection.status', cond: :like, searchable: true, orderable: true }
     }
   end
 

--- a/app/datatables/batch_process_parent_datatable.rb
+++ b/app/datatables/batch_process_parent_datatable.rb
@@ -13,8 +13,8 @@ class BatchProcessParentDatatable < AjaxDatatablesRails::ActiveRecord
 
   def view_columns
     @view_columns ||= {
-      child_oid: { source: 'ChildObject.oid' },
-      time: { source: 'ChildObject.created_at' },
+      child_oid: { source: 'ChildObject.oid', orderable: true },
+      time: { source: 'ChildObject.created_at', orderable: true },
       status: { source: '', cond: :null_value, searchable: false, orderable: false }
     }
   end

--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -14,19 +14,19 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      oid: { source: "ParentObject.oid", cond: :start_with, searchable: true },
-      authoritative_source: { source: "MetadataSource.metadata_cloud_name", cond: :string_eq, searchable: true, options: ["ladybird", "aspace", "ils"] },
-      child_object_count: { source: "ParentObject.child_object_count" },
-      bib: { source: "ParentObject.bib", cond: :string_eq, searchable: true },
-      holding: { source: "ParentObject.holding", cond: :string_eq, searchable: true },
-      item: { source: "ParentObject.item", cond: :string_eq, searchable: true },
-      barcode: { source: "ParentObject.barcode", cond: :string_eq, searchable: true },
-      aspace_uri: { source: "ParentObject.aspace_uri", cond: :like, searchable: true },
-      last_ladybird_update: { source: "ParentObject.last_ladybird_update" },
-      last_voyager_update: { source: "ParentObject.last_voyager_update" },
-      last_aspace_update: { source: "ParentObject.last_aspace_update" },
-      last_id_update: { source: "ParentObject.last_id_update" },
-      visibility: { source: "ParentObject.visibility", cond: :string_eq, searchable: true, options: ["Public", "Yale Community Only", "Private"] },
+      oid: { source: "ParentObject.oid", cond: :start_with, searchable: true, orderable: true },
+      authoritative_source: { source: "MetadataSource.metadata_cloud_name", cond: :string_eq, searchable: true, options: ["ladybird", "aspace", "ils"], orderable: true },
+      child_object_count: { source: "ParentObject.child_object_count", orderable: true },
+      bib: { source: "ParentObject.bib", cond: :string_eq, searchable: true, orderable: true },
+      holding: { source: "ParentObject.holding", cond: :string_eq, searchable: true, orderable: true },
+      item: { source: "ParentObject.item", cond: :string_eq, searchable: true, orderable: true },
+      barcode: { source: "ParentObject.barcode", cond: :string_eq, searchable: true, orderable: true },
+      aspace_uri: { source: "ParentObject.aspace_uri", cond: :like, searchable: true, orderable: true },
+      last_ladybird_update: { source: "ParentObject.last_ladybird_update", orderable: true },
+      last_voyager_update: { source: "ParentObject.last_voyager_update", orderable: true },
+      last_aspace_update: { source: "ParentObject.last_aspace_update", orderable: true },
+      last_id_update: { source: "ParentObject.last_id_update", orderable: true },
+      visibility: { source: "ParentObject.visibility", cond: :string_eq, searchable: true, options: ["Public", "Yale Community Only", "Private"], orderable: true },
       actions: { source: "ParentObject.oid", cond: :null_value, searchable: false, orderable: false }
     }
   end

--- a/app/views/batch_processes/index.html.erb
+++ b/app/views/batch_processes/index.html.erb
@@ -28,5 +28,5 @@
 
 
 <div id='batch-processes-data' class='d-none datatable-data'>
-  <%= BatchProcessDatatable.new(nil).view_columns.keys.map {|key| {data: key} }.to_json %>
+  <%= BatchProcessDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], options: value[:options]} }.to_json %>
 </div>

--- a/app/views/batch_processes/show.html.erb
+++ b/app/views/batch_processes/show.html.erb
@@ -47,7 +47,7 @@
 </div>
 
 <div id='batch-process-data' class='d-none datatable-data'>
-  <%= BatchProcessDetailDatatable.new(nil).view_columns.keys.map {|key| {data: key} }.to_json %>
+  <%= BatchProcessDetailDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], options: value[:options]} }.to_json %>
 </div>
 
 <%= link_to 'Back', batch_processes_path %>

--- a/app/views/batch_processes/show_parent.html.erb
+++ b/app/views/batch_processes/show_parent.html.erb
@@ -91,7 +91,7 @@
 </div>
 
 <div id='parent-batch-process-data' class='d-none datatable-data'>
-  <%= BatchProcessParentDatatable.new(nil).view_columns.keys.map {|key| {data: key} }.to_json %>
+  <%= BatchProcessParentDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], options: value[:options]} }.to_json %>
 </div>
 
 

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -39,5 +39,5 @@
 </div>
 
 <div id="parent-objects-data" class='d-none datatable-data'>
-  <%= ParentObjectDatatable.new(nil).view_columns.map {|key, value| {data: key, searchable: value[:searchable], options: value[:options]} }.to_json %>
+  <%= ParentObjectDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
 </div>


### PR DESCRIPTION
Some data tables for batches had issues with search and order.
Orderable indicator was not getting to JS so all columns had order indicators (for batches and parent objects).
User id column for batch view_columns had incorrect source specified.

Before (has sort indicators on all columns, even ones that cannot sort):
![image](https://user-images.githubusercontent.com/32851993/106814295-2c2cb680-6640-11eb-9576-13bd12929c50.png)

After (only has sort indicators on columns that can be sorted):
![image](https://user-images.githubusercontent.com/32851993/106814326-377fe200-6640-11eb-83fd-ecd196c43387.png)


Before (unable to filter by user id):
![image](https://user-images.githubusercontent.com/32851993/106814448-65652680-6640-11eb-8c14-ceea2332c86b.png)


After (filters by user id):
![image](https://user-images.githubusercontent.com/32851993/106814404-52eaed00-6640-11eb-815a-c7e67a538dc5.png)
