### PR TITLE
Update RSpec test for metadata_cloud_validation

### DIFF
--- a/spec/requests/metadata_cloud_validation_spec.rb
+++ b/spec/requests/metadata_cloud_validation_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe "MetadataCloud validation", type: :request, prep_metadata_sources
                              "extentOfDigitization", "creationPlace", "date", "extent", "language",
                              "description", "subjectName", "subjectTopic", "genre", "format", "itemType", "partOf",
                              "rights", "orbisBibId", "orbisBarcode", "preferredCitation", "itemPermission",
-                             "dateStructured", "illustrativeMatter", "subjectEra", "contributor",
-                             "repository", "subjectTitle", "subjectTitleDisplay",
+                             "dateStructured", "illustrativeMatter", "intStartYear", "intEndYear", "subjectEra",
+                             "contributor", "repository", "subjectTitle", "subjectTitleDisplay",
                              "contributorDisplay", "dependentUris", "oid", "collectionId", "children", "abstract"]
   end
 


### PR DESCRIPTION
Co-authored-by: Max Kadel max@curationexperts.com


- [ ] Update failing RSpec


------
**Code Modification**

    expect(data.keys).to eq ["jsonModelType", "source", "recordType", "uri", "callNumber", "title",
                             "extentOfDigitization", "creationPlace", "date", "extent", "language",
                             "description", "subjectName", "subjectTopic", "genre", "format", "itemType", "partOf",
                             "rights", "orbisBibId", "orbisBarcode", "preferredCitation", "itemPermission",
                             "dateStructured", "illustrativeMatter",  "subjectEra", "contributor", "repository", 
                             "subjectTitle", "subjectTitleDisplay", "contributorDisplay", "dependentUris", "oid", 
                             "collectionId", "children", "abstract"]


    expect(data.keys).to eq ["jsonModelType", "source", "recordType", "uri", "callNumber", "title",
                             "extentOfDigitization", "creationPlace", "date", "extent", "language",
                             "description", "subjectName", "subjectTopic", "genre", "format", "itemType", "partOf",
                             "rights", "orbisBibId", "orbisBarcode", "preferredCitation", "itemPermission",
                             "dateStructured", "illustrativeMatter",  **"intStartYear",  "intEndYear",** "subjectEra",
                             "contributor", "repository", "subjectTitle", "subjectTitleDisplay",
                             "contributorDisplay", "dependentUris", "oid", "collectionId", "children", "abstract"]