### PR TITLE
Added new batch type to force recreate Ptiff for a list of child oids

### DIFF
--- a/app/jobs/generate_ptiff_job.rb
+++ b/app/jobs/generate_ptiff_job.rb
@@ -14,7 +14,7 @@ class GeneratePtiffJob < ApplicationJob
     # There is a test in  spec/models/batch_process_spec.rb that should fail, take out the "pending" and logger
     # mocks there to see if it passes
     # child_object.copy_to_access_master_pairtree if child_object.parent_object.from_mets
-    child_object.convert_to_ptiff!
+    child_object.convert_to_ptiff!(current_batch_process&.batch_action == 'recreate child oid ptiffs')
     # Only generate manifest if all children are ready
     GenerateManifestJob.perform_later(child_object.parent_object, current_batch_process, current_batch_connection) if child_object.parent_object.needs_a_manifest?
   end

--- a/app/jobs/recreate_child_oid_ptiffs_job.rb
+++ b/app/jobs/recreate_child_oid_ptiffs_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RecreateChildOidPtiffsJob < ApplicationJob
+  queue_as :default
+
+  def default_priority
+    9
+  end
+
+  def perform(batch_process)
+    batch_process.recreate_child_oid_ptiffs
+  end
+end

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -133,7 +133,9 @@ class ChildObject < ApplicationRecord
     end
   end
 
-  def convert_to_ptiff!
+  def convert_to_ptiff!(force = false)
+    # setting the width to nil will force the PTIFF to be generated.
+    self.width = nil if force
     convert_to_ptiff && save!
   end
 

--- a/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
+++ b/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RecreateChildOidPtiffsJob, type: :job do
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::DelayedJobAdapter.new
+  end
+  let(:user) { FactoryBot.create(:user) }
+  let(:batch_process) { FactoryBot.create(:batch_process, user: user, batch_action: 'recreate child oid ptiffs') }
+  let(:metadata_source) { FactoryBot.create(:metadata_source) }
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_004_628, authoritative_metadata_source: metadata_source) }
+  let(:child_object) { FactoryBot.create(:child_object, oid: 456_789, parent_object: parent_object) }
+  let(:recreate_child_oid_ptiffs_job) { RecreateChildOidPtiffsJob.new }
+
+  around do |example|
+    original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
+    ENV["S3_SOURCE_BUCKET_NAME"] = "not-a-real-bucket"
+    example.run
+    ENV["S3_SOURCE_BUCKET_NAME"] = original_image_bucket
+  end
+
+  before do
+    stub_request(:head, "https://not-a-real-bucket.s3.amazonaws.com/originals/89/45/67/89/456789.tif")
+        .to_return(status: 200, body: "", headers: {})
+    stub_request(:head, "https://not-a-real-bucket.s3.amazonaws.com/ptiffs/89/45/67/89/456789.tif")
+        .to_return(status: 200, body: "", headers: {})
+    allow(batch_process).to receive(:oids).and_return(['456789'])
+    child_object
+  end
+
+  describe 'recreate ptiff job' do
+    it "has correct priority" do
+      expect(recreate_child_oid_ptiffs_job.default_priority).to eq(9)
+    end
+    it "has correct queue" do
+      expect(recreate_child_oid_ptiffs_job.queue_name).to eq('default')
+    end
+    it "can will create appropriate number of ptiff jobs when run" do
+      expect do
+        recreate_child_oid_ptiffs_job.perform(batch_process)
+      end.to change { Delayed::Job.where(queue: 'ptiff').count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
Batch is setup using existing PTIFF jobs, but forcing it to recreate the PTIFF.

![image](https://user-images.githubusercontent.com/32851993/107284268-873d1f80-6a2b-11eb-81f4-51daeea5359f.png)
