### PR TITLE
Updated manifest metadata fields

### DIFF
--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -19,7 +19,7 @@ METADATA_FIELDS = [
     ]
   },
   {
-    label: 'Date',
+    label: 'Published/Created Date',
     field: 'date',
     solr_fields: [
       'date_ssim'

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -128,35 +128,35 @@ METADATA_FIELDS = [
     ]
   },
   {
-    label: 'Source Title',
+    label: 'Collection Title',
     field: 'sourceTitle',
     solr_fields: [
       'sourceTitle_tesim'
     ]
   },
   {
-    label: 'Source Created',
+    label: 'Collection Created',
     field: 'sourceCreated',
     solr_fields: [
       'sourceCreated_tesim'
     ]
   },
   {
-    label: 'Source Date',
+    label: 'Collection Date',
     field: 'sourceDate',
     solr_fields: [
       'sourceDate_tesim'
     ]
   },
   {
-    label: 'Source Note',
+    label: 'Collection Note',
     field: 'sourceNote',
     solr_fields: [
       'sourceNote_tesim'
     ]
   },
   {
-    label: 'Source Edition',
+    label: 'Collection Edition',
     field: 'sourceEdition',
     solr_fields: [
       'sourceEdition_tesim'
@@ -166,8 +166,7 @@ METADATA_FIELDS = [
     label: 'Container / Volume Information',
     field: 'extract_container_information',
     solr_fields: [
-      'containerGrouping_ssim',
-      'containerGrouping_tesim'
+      'containerGrouping_ssim'
     ],
     digital_only: true
   },
@@ -249,14 +248,14 @@ METADATA_FIELDS = [
     ]
   },
   {
-    label: 'References',
+    label: 'Citation',
     field: 'preferredCitation',
     solr_fields: [
       'preferredCitation_tesim'
     ]
   },
   {
-    label: 'Orbis Bib ID',
+    label: 'Orbis ID',
     field: 'bib',
     solr_fields: [
       'orbisBibId_ssi'

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["metadata"].first["value"].first).to include "Morris & Co. (London, England)"
       expect(iiif_presentation.manifest["metadata"].last.class).to eq Hash
       expect(iiif_presentation.manifest["metadata"].last["label"]).to eq "OID"
-      expect(iiif_presentation.manifest["metadata"].select { |k| true if k["label"] == "Orbis Bib ID" }).not_to be_empty
+      expect(iiif_presentation.manifest["metadata"].select { |k| true if k["label"] == "Orbis ID" }).not_to be_empty
       expect(iiif_presentation.manifest["metadata"].select { |k| true if k["label"] == "Container / Volume Information" }.first["value"].first).to eq 'Box 12, Folder 117'
     end
 


### PR DESCRIPTION
- [ ]  Make label changes to : 
        Published/Created Date name currently appears as Date 
        Collection Title, name currently appears as Source Title 
        Collection Created, name currently appears as Source Created
        Collection Date, name currently appears as Source Date
        Collection Note, name currently appears as Source Note 
        Collection Edition, name currently appears as Source **edition** [I changed this to a capital letter to match the rest of the         names]
        Citation,  name currently appears as References

------

**The work is missing some of the correct labels.** 

Alternative Title
Creator
Published/Created Date (currently just Date) **- does need to change, this does not match the blacklight application  already**
Copyright Date
Publication Place
Publisher
Abstract
Description
Extent
Extent of Digitization
Projection
Scale
Coordinates
Digital
Edition
Langauge
Call Number
Collection Title (currently Source Title) **- does need to change, this does not match the blacklight application  already**
Collection Creator (doesn't exist, coming in 1048, not sure if you wanted a heads up now) **- separate into another card, work is not ready for this sprint**
Collection Created (Currently Source Created)**- does need to change, this does not match the blacklight application  already**
Collection Date (currently Source Date)**- does need to change, this does not match the blacklight application  already**
Collection Note (currently Source Note)**- does need to change, this does not match the blacklight application  already**
Collection Edition (currently Source edition)**- does need to change, this does not match the blacklight application  already**
Container / Volume Information
Finding Aid
Format
Genre
Material
Resource Type
Subject (Geographic)
Subject (Name)
Subject (Topic)
Access
Rights
Citation (currently References) **- does need to change, this does not match the blacklight application  already**
Orbis ID (currently Orbis Bib ID)
OID
More Information
