### PR TITLE
Update datatables with turbolinks for back button

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -53,7 +53,7 @@ $( document ).on('turbolinks:load', function() {
       initComplete: function () {
         // create the inputs for each header
         if (hasSearch) {
-          let searchRow = $("<tr role='row'></tr>");
+          let searchRow = $("<tr role='row' id='search-row'></tr>");
           let index = 0;
           this.api().columns().every(function () {
             let column = this;
@@ -84,6 +84,10 @@ $( document ).on('turbolinks:load', function() {
           $(this.api().table().header()).append(searchRow);
         }
       }
+    })
+    $(document).on('turbolinks:before-cache', function(){
+      dataTable.api().destroy();
+      $('#search-row').remove();
     })
   }
 });


### PR DESCRIPTION
Datatable searching and sorting was not working if you navigate away and hit the back button.
This fixes that issue.