### PR TITLE
Display storage and base urls

### DIFF
--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -35,9 +35,13 @@
       <thead class="thead-dark">
       <tr>
         <th scope="col"> Service </th>
-        <th scope="col"> Name </th>
+        <th scope="col"> Names/URL </th>
       </tr>
       </thead>
+      <tr>
+        <td> Sample Bucket </td>
+        <td id="blacklight_version"> <%= ENV['SAMPLE_BUCKET'].present? ? "#{ENV['SAMPLE_BUCKET']}" : "" %> </td>
+      </tr>
       <tr>
         <td> Manifests </td>
         <td id="blacklight_version"> <%= ENV['IIIF_MANIFESTS_BASE_URL'].present? ? "#{ENV['IIIF_MANIFESTS_BASE_URL']}" : "" %> </td>

--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -39,6 +39,9 @@
       </tr>
       </thead>
       <tr>
+        <td> Sample Resource Bucket </td>
+        <td id="blacklight_version"> <%= ENV['S3_SOURCE_BUCKET_NAME'].present? ? "#{ENV['S3_SOURCE_BUCKET_NAME']}" : "" %> </td>
+      </tr><tr>
         <td> Sample Bucket </td>
         <td id="blacklight_version"> <%= ENV['SAMPLE_BUCKET'].present? ? "#{ENV['SAMPLE_BUCKET']}" : "" %> </td>
       </tr>

--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -29,4 +29,26 @@
         <td id="iiif_image_version"> <%= ENV['IIIF_IMAGE_VERSION'].present? ? "#{ENV['IIIF_IMAGE_VERSION']}" : "" %> </td>
       </tr>
   </table>
+<!--</div>-->
+    <h3> Storage </h3>
+    <table class="table table-bordered table-responsive table-striped">
+      <thead class="thead-dark">
+      <tr>
+        <th scope="col"> Service </th>
+        <th scope="col"> Name </th>
+      </tr>
+      </thead>
+      <tr>
+        <td> Manifests </td>
+        <td id="blacklight_version"> <%= ENV['IIIF_MANIFESTS_BASE_URL'].present? ? "#{ENV['IIIF_MANIFESTS_BASE_URL']}" : "" %> </td>
+      </tr>
+      <tr>
+        <td> PDFs </td>
+        <td id="iiif_image_version"> <%= ENV['PDF_BASE_URL'].present? ? "#{ENV['PDF_BASE_URL']}" : "" %> </td>
+      </tr>
+      <tr>
+        <td> PTIFFs </td>
+        <td id="iiif_image_version"> <%= ENV['IIIF_IMAGE_BASE_URL'].present? ? "#{ENV['IIIF_IMAGE_BASE_URL']}" : "" %> </td>
+      </tr>
+  </table>
 </div>

--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -40,18 +40,22 @@
       </thead>
       <tr>
         <td> Sample Resource Bucket </td>
-        <td id="blacklight_version"> <%= ENV['S3_SOURCE_BUCKET_NAME'].present? ? "#{ENV['S3_SOURCE_BUCKET_NAME']}" : "" %> </td>
+        <td id="sample_resource_bucket"> <%= ENV['S3_SOURCE_BUCKET_NAME'].present? ? "#{ENV['S3_SOURCE_BUCKET_NAME']}" : "" %> </td>
       </tr><tr>
         <td> Sample Bucket </td>
-        <td id="blacklight_version"> <%= ENV['SAMPLE_BUCKET'].present? ? "#{ENV['SAMPLE_BUCKET']}" : "" %> </td>
+        <td id="sample_bucket"> <%= ENV['SAMPLE_BUCKET'].present? ? "#{ENV['SAMPLE_BUCKET']}" : "" %> </td>
+      </tr>
+      <tr>
+        <td> MetaData Cloud </td>
+        <td id="metadata_cloud_host"> <%= ENV['METADATA_CLOUD_HOST'].present? ? "#{ENV['METADATA_CLOUD_HOST']}" : "" %> </td>
       </tr>
       <tr>
         <td> Manifests </td>
-        <td id="blacklight_version"> <%= ENV['IIIF_MANIFESTS_BASE_URL'].present? ? "#{ENV['IIIF_MANIFESTS_BASE_URL']}" : "" %> </td>
+        <td id="manifests_storage"> <%= ENV['IIIF_MANIFESTS_BASE_URL'].present? ? "#{ENV['IIIF_MANIFESTS_BASE_URL']}" : "" %> </td>
       </tr>
       <tr>
         <td> PDFs </td>
-        <td id="iiif_image_version"> <%= ENV['PDF_BASE_URL'].present? ? "#{ENV['PDF_BASE_URL']}" : "" %> </td>
+        <td id="pdf_base_storage"> <%= ENV['PDF_BASE_URL'].present? ? "#{ENV['PDF_BASE_URL']}" : "" %> </td>
       </tr>
       <tr>
         <td> PTIFFs </td>

--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -29,37 +29,46 @@
         <td id="iiif_image_version"> <%= ENV['IIIF_IMAGE_VERSION'].present? ? "#{ENV['IIIF_IMAGE_VERSION']}" : "" %> </td>
       </tr>
   </table>
-<!--</div>-->
-    <h3> Storage </h3>
+  <h3> Base URLs</h3>
     <table class="table table-bordered table-responsive table-striped">
       <thead class="thead-dark">
       <tr>
         <th scope="col"> Service </th>
-        <th scope="col"> Names/URL </th>
+        <th scope="col"> URL </th>
       </tr>
       </thead>
       <tr>
-        <td> Sample Resource Bucket </td>
-        <td id="sample_resource_bucket"> <%= ENV['S3_SOURCE_BUCKET_NAME'].present? ? "#{ENV['S3_SOURCE_BUCKET_NAME']}" : "" %> </td>
-      </tr><tr>
-        <td> Sample Bucket </td>
-        <td id="sample_bucket"> <%= ENV['SAMPLE_BUCKET'].present? ? "#{ENV['SAMPLE_BUCKET']}" : "" %> </td>
+        <td> IIIF Images </td>
+        <td id="iiif_image_version"> <%= ENV['IIIF_IMAGE_BASE_URL'].present? ? "#{ENV['IIIF_IMAGE_BASE_URL']}" : "" %> </td>
+      </tr>
+      <tr>
+        <td> IIIF Manifests </td>
+        <td id="iiif_manifests"> <%= ENV['IIIF_MANIFESTS_BASE_URL'].present? ? "#{ENV['IIIF_MANIFESTS_BASE_URL']}" : "" %> </td>
       </tr>
       <tr>
         <td> MetaData Cloud </td>
         <td id="metadata_cloud_host"> <%= ENV['METADATA_CLOUD_HOST'].present? ? "#{ENV['METADATA_CLOUD_HOST']}" : "" %> </td>
       </tr>
       <tr>
-        <td> Manifests </td>
-        <td id="manifests_storage"> <%= ENV['IIIF_MANIFESTS_BASE_URL'].present? ? "#{ENV['IIIF_MANIFESTS_BASE_URL']}" : "" %> </td>
-      </tr>
-      <tr>
         <td> PDFs </td>
         <td id="pdf_base_storage"> <%= ENV['PDF_BASE_URL'].present? ? "#{ENV['PDF_BASE_URL']}" : "" %> </td>
       </tr>
-      <tr>
-        <td> PTIFFs </td>
-        <td id="iiif_image_version"> <%= ENV['IIIF_IMAGE_BASE_URL'].present? ? "#{ENV['IIIF_IMAGE_BASE_URL']}" : "" %> </td>
-      </tr>
   </table>
+    <h3> Storage </h3>
+    <table class="table table-bordered table-responsive table-striped">
+      <thead class="thead-dark">
+      <tr>
+        <th scope="col"> Service </th>
+        <th scope="col"> Name </th>
+      </tr>
+      </thead>
+      <tr>
+        <td> S3 Source </td>
+        <td id="s3_source_bucket"> <%= ENV['S3_SOURCE_BUCKET_NAME'].present? ? "#{ENV['S3_SOURCE_BUCKET_NAME']}" : "" %> </td>
+      </tr>
+      <tr>
+      <td> S3 Samples </td>
+      <td id="s3_samples"> <%= ENV['SAMPLE_BUCKET'].present? ? "#{ENV['SAMPLE_BUCKET']}" : "" %> </td>
+      </tr>
+    </table>
 </div>


### PR DESCRIPTION
**STORY** 
As a support engineer, I would like be able to view S3 bucket configurations directly in the management application, in order to simplify diagnostics for issues with PTIFFs, PDFs, and other content stored on S3.

**ACCEPTANCE**
- [x] The management application has a "Storage" section on the Management Dashboard page
 
- [x] The management application has a "Base URLs" section on the Management Dashboard page that lists:
  - [x] "IIIF images"  -  IIIF_IMAGE_BASE_URL
  - [x] "IIIF manifests" - IIIF_MANIFESTS_BASE_URL
  - [x] "MetaData Cloud" - METADATA_CLOUD_HOST
  - [x] "PDFs" - PDF_BASE_URL


- [x] The "Storage" status page displays *read-only* values for each of the buckets used on S3:
  - [x] "S3 Source" - S3_SOURCE_BUCKET_NAME
  - [x] "S3 Samples" - SAMPLE_BUCKET

-----

**Code Modification Visual**

![Screen Shot 2021-02-11 at 3.52.25 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/2c3e1031-a790-4f08-ac06-afcc445063d8)