### PR TITLE
Return nil for viewing_hint and viewing_direction when intranda namespace is not included in mets

### DIFF
--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -31,12 +31,12 @@ class MetsDocument
   end
 
   def viewing_direction
-    return nil unless @mets.collect_namespaces.include?("intranda:intranda")
+    return nil unless @mets.collect_namespaces.keys.include?("xmlns:intranda")
     @mets.xpath("//mods:extension/intranda:intranda/intranda:ViewingDirection").inner_text
   end
 
   def viewing_hint
-    return nil unless @mets.collect_namespaces.include?("intranda:intranda")
+    return nil unless @mets.collect_namespaces.include?("xmlns:intranda")
     @mets.xpath("//mods:extension/intranda:intranda/intranda:ViewingHint").inner_text
   end
 

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -31,10 +31,12 @@ class MetsDocument
   end
 
   def viewing_direction
+    return nil unless @mets.collect_namespaces.include?("intranda:intranda")
     @mets.xpath("//mods:extension/intranda:intranda/intranda:ViewingDirection").inner_text
   end
 
   def viewing_hint
+    return nil unless @mets.collect_namespaces.include?("intranda:intranda")
     @mets.xpath("//mods:extension/intranda:intranda/intranda:ViewingHint").inner_text
   end
 

--- a/spec/fixtures/goobi/metadata/30000317_20201203_140947/no_intranda_namespace_mets.xml
+++ b/spec/fixtures/goobi/metadata/30000317_20201203_140947/no_intranda_namespace_mets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:dv="http://dfg-viewer.de/" xmlns:intranda="http://intranda.com/MODS/" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="191" xsi:schemaLocation="http://www.loc.gov/standards/premis/ http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/standards/mix/ http://www.loc.gov/standards/mix/mix.xsd">
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:dv="http://dfg-viewer.de/" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="191" xsi:schemaLocation="http://www.loc.gov/standards/premis/ http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/standards/mix/ http://www.loc.gov/standards/mix/mix.xsd">
   <mets:metsHdr CREATEDATE="2020-12-03T14:09:47Z">
     <mets:agent OTHERTYPE="SOFTWARE" ROLE="CREATOR" TYPE="OTHER">
       <mets:name>Goobi - 3647a - 2020-08-02 19:35:26+0000</mets:name>
@@ -15,7 +15,7 @@
           </mods:titleInfo>
           <mods:identifier type="PPNanalog">/ils/barcode/39002091118928?bib=8394689</mods:identifier>
           <mods:recordInfo>
-            <mods:recordIdentifier source="gbv-ppn">30000317</mods:recordIdentifier>
+            <mods:recordIdentifier source="gbv-ppn">30001317</mods:recordIdentifier>
           </mods:recordInfo>
           <mods:part>Completely digitized</mods:part>
           <mods:classification authority="ivdcc">DefaultCollection</mods:classification>
@@ -36,13 +36,6 @@
             <mods:namePart type="given">Xiutang.</mods:namePart>
             <mods:displayForm>Chen, Xiutang.</mods:displayForm>
           </mods:name>
-          <mods:extension>
-            <intranda:intranda>
-              <intranda:directionRTL>false</intranda:directionRTL>
-              <intranda:ViewingDirection>left-to-right</intranda:ViewingDirection>
-              <intranda:ViewingHint>individuals</intranda:ViewingHint>
-            </intranda:intranda>
-          </mods:extension>
         </mods:mods>
       </mets:xmlData>
     </mets:mdWrap>
@@ -87,7 +80,7 @@
     <mets:div ADMID="AMD" DMDID="DMDLOG_0000" ID="LOG_0000" LABEL="Di qiu quan tu" TYPE="ILSObject" />
   </mets:structMap>
   <mets:structMap TYPE="PHYSICAL">
-    <mets:div CONTENTIDS="30000317" ID="PHYS_0000" TYPE="physSequence">
+    <mets:div CONTENTIDS="30001317" ID="PHYS_0000" TYPE="physSequence">
       <mets:div CONTENTIDS="30000318" ID="PHYS_0001" ORDER="1" ORDERLABEL=" - " TYPE="page">
         <mets:fptr FILEID="444d3360-bf78-4e35-9850-44ef7f832105" />
         <mets:fptr FILEID="63c82a0c-be28-4b42-ae74-c13922db5c15" />

--- a/spec/fixtures/goobi/metadata/30000317_20201203_140947/no_intranda_namespace_mets.xml
+++ b/spec/fixtures/goobi/metadata/30000317_20201203_140947/no_intranda_namespace_mets.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:dv="http://dfg-viewer.de/" xmlns:intranda="http://intranda.com/MODS/" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="191" xsi:schemaLocation="http://www.loc.gov/standards/premis/ http://www.loc.gov/standards/premis/v2/premis-v2-0.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/standards/mix/ http://www.loc.gov/standards/mix/mix.xsd">
+  <mets:metsHdr CREATEDATE="2020-12-03T14:09:47Z">
+    <mets:agent OTHERTYPE="SOFTWARE" ROLE="CREATOR" TYPE="OTHER">
+      <mets:name>Goobi - 3647a - 2020-08-02 19:35:26+0000</mets:name>
+      <mets:note>Goobi</mets:note>
+    </mets:agent>
+  </mets:metsHdr>
+  <mets:dmdSec ID="DMDLOG_0000">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods:mods>
+          <mods:titleInfo>
+            <mods:title>Di qiu quan tu</mods:title>
+          </mods:titleInfo>
+          <mods:identifier type="PPNanalog">/ils/barcode/39002091118928?bib=8394689</mods:identifier>
+          <mods:recordInfo>
+            <mods:recordIdentifier source="gbv-ppn">30000317</mods:recordIdentifier>
+          </mods:recordInfo>
+          <mods:part>Completely digitized</mods:part>
+          <mods:classification authority="ivdcc">DefaultCollection</mods:classification>
+          <mods:originInfo>
+            <mods:dateIssued keyDate="no">Xianfeng wu nian [1855]</mods:dateIssued>
+            <mods:dateIssued keyDate="yes">1855</mods:dateIssued>
+          </mods:originInfo>
+          <mods:accessCondition displayLabel="Yale Restriction" type="restriction on access">Public</mods:accessCondition>
+          <mods:accessCondition displayLabel="Yale Use" type="use and reproduction">The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement.</mods:accessCondition>
+          <mods:location>
+            <mods:shelfLocator>11 1860A</mods:shelfLocator>
+          </mods:location>
+          <mods:name type="personal">
+            <mods:role>
+              <mods:roleTerm authority="marcrelator" type="code">aut</mods:roleTerm>
+            </mods:role>
+            <mods:namePart type="family">Chen</mods:namePart>
+            <mods:namePart type="given">Xiutang.</mods:namePart>
+            <mods:displayForm>Chen, Xiutang.</mods:displayForm>
+          </mods:name>
+          <mods:extension>
+            <intranda:intranda>
+              <intranda:directionRTL>false</intranda:directionRTL>
+              <intranda:ViewingDirection>left-to-right</intranda:ViewingDirection>
+              <intranda:ViewingHint>individuals</intranda:ViewingHint>
+            </intranda:intranda>
+          </mods:extension>
+        </mods:mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:amdSec ID="AMD">
+    <mets:rightsMD ID="RIGHTS">
+      <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="DVRIGHTS">
+        <mets:xmlData>
+          <dv:rights>
+            <dv:owner>Beinecke Rare Book &amp; Manuscript Library</dv:owner>
+            <dv:ownerLogo />
+            <dv:ownerSiteURL>https://beinecke.library.yale.edu/</dv:ownerSiteURL>
+            <dv:ownerContact />
+          </dv:rights>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:rightsMD>
+    <mets:digiprovMD ID="DIGIPROV">
+      <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="DVLINKS">
+        <mets:xmlData>
+          <dv:links>
+            <dv:reference />
+            <dv:presentation />
+          </dv:links>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:digiprovMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="PRESENTATION" ID="b9afab50-9f22-4505-ada6-807dd7d05733">
+      <mets:file ID="444d3360-bf78-4e35-9850-44ef7f832105" MIMETYPE="image/tiff" CHECKSUMTYPE="SHA-1" CHECKSUM="4e870f62d9b11c7cd93520d1aa5fe3def9ad3565">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///home/app/webapp/spec/fixtures/goobi/metadata/30000317_20201203_140947/111860A_8394689_media/30000318.tif" />
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="PRESERVATION" ID="be69c567-edce-4dd4-b4c7-e68f08242fd0">
+      <mets:file ID="63c82a0c-be28-4b42-ae74-c13922db5c15" MIMETYPE="image/tiff" CHECKSUMTYPE="SHA-1" CHECKSUM="4e870f62d9b11c7cd93520d1aa5fe3def9ad3565">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///brbl-dsu/dcs/30000317_20201203_140947/master/30000318.tif" />
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="LOGICAL">
+    <mets:div ADMID="AMD" DMDID="DMDLOG_0000" ID="LOG_0000" LABEL="Di qiu quan tu" TYPE="ILSObject" />
+  </mets:structMap>
+  <mets:structMap TYPE="PHYSICAL">
+    <mets:div CONTENTIDS="30000317" ID="PHYS_0000" TYPE="physSequence">
+      <mets:div CONTENTIDS="30000318" ID="PHYS_0001" ORDER="1" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="444d3360-bf78-4e35-9850-44ef7f832105" />
+        <mets:fptr FILEID="63c82a0c-be28-4b42-ae74-c13922db5c15" />
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+  <mets:structLink>
+    <mets:smLink xlink:to="PHYS_0001" xlink:from="LOG_0000" />
+  </mets:structLink>
+</mets:mets>

--- a/spec/system/batch_process_detail_spec.rb
+++ b/spec/system/batch_process_detail_spec.rb
@@ -84,4 +84,25 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
       expect(page).to have_content("2020-10-08 16:17:01")
     end
   end
+
+  context "when uploading an xml doc without intranda information" do
+    let(:batch_process) do
+      FactoryBot.create(
+        :batch_process,
+        user: user,
+        mets_xml: File.open(fixture_path + '/goobi/metadata/30000317_20201203_140947/no_intranda_namespace_mets.xml').read,
+        file_name: "111860A_8394689_no_intranda_mets.xml",
+        created_at: "2020-10-08 16:17:01"
+      )
+    end
+    it "can see the details of the import" do
+      expect(page).to have_content(batch_process.id.to_s)
+      expect(page).to have_content("johnsmith2530")
+      expect(page).to have_link("111860A_8394689_no_intranda_mets.xml", href: "/batch_processes/#{batch_process.id}/download")
+      expect(page).to have_link('30000317', href: "/batch_processes/#{batch_process.id}/parent_objects/30000317")
+      expect(page).to have_content("2020-10-08 16:17:01")
+      expect(ParentObject.find_by_oid(30_000_317).viewing_direction).to be_nil
+      expect(ParentObject.find_by_oid(30_000_317).display_layout).to be_nil
+    end
+  end
 end

--- a/spec/system/batch_process_detail_spec.rb
+++ b/spec/system/batch_process_detail_spec.rb
@@ -99,10 +99,10 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
       expect(page).to have_content(batch_process.id.to_s)
       expect(page).to have_content("johnsmith2530")
       expect(page).to have_link("111860A_8394689_no_intranda_mets.xml", href: "/batch_processes/#{batch_process.id}/download")
-      expect(page).to have_link('30000317', href: "/batch_processes/#{batch_process.id}/parent_objects/30000317")
+      expect(page).to have_link('30001317', href: "/batch_processes/#{batch_process.id}/parent_objects/30001317")
       expect(page).to have_content("2020-10-08 16:17:01")
-      expect(ParentObject.find_by_oid(30_000_317).viewing_direction).to be_nil
-      expect(ParentObject.find_by_oid(30_000_317).display_layout).to be_nil
+      expect(ParentObject.find_by_oid(30_001_317).viewing_direction).to be_nil
+      expect(ParentObject.find_by_oid(30_001_317).display_layout).to be_nil
     end
   end
 end


### PR DESCRIPTION
Check for intranda namespace.  Return nil for viewing_hint and viewing_direction if namespace is not included in document.


Co-authored-by: Lakeisha Robinson <lakeisha.robinson@yale.edu>
Co-authored-by: Maggie Zhao <maggie.zhao@yale.edu>
Co-authored-by: Maura Carbone <maura.carbone@yale.edu>
Co-authored-by: Max Kadel <max@curation_experts.com>