### PR TITLE
Don't index empty strings to solr

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -150,7 +150,7 @@ module SolrIndexable
       sourceTitle_ssim: json_to_index["sourceTitle"], # repleaced by sourceTitle_tesim
       subject_topic_tsim: json_to_index["subjectTopic"], # replaced by subjectTopic_tesim and subjectTopic_ssim
       title_tsim: json_to_index["title"] # replaced by title_tesim
-    }.delete_if { |_k, v| v.nil? }
+    }.delete_if { |_k, v| !v.present? } # Delete nil and empty values
   end
 
   def expand_date_structured(date_structured)

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       expect(solr_document.values).not_to include(nil)
     end
 
+    it "does not have empty strings in to_solr hash" do
+      parent_object.bib = ""
+      parent_object.save!
+      solr_document = parent_object.reload.to_solr
+      expect(solr_document.values).not_to include("")
+    end
+
     it "will index the count of child objects" do
       solr_document = parent_object.reload.to_solr
       expect(solr_document[:imageCount_isi]).to eq 1


### PR DESCRIPTION
Connected to https://github.com/yalelibrary/YUL-DC/issues/1083
Editing objects through the UI results in some text fields being set to empty strings, which then get indexed to solr. Indexing empty strings to solr makes it so that labels show up in Blacklight when there are apparently no values connected. 