### PR TITLE
Make management app users viewable

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,8 @@
 // Place all the styles related to the Users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+#users-datatable {
+  border-bottom: none;
+  border-top: none;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,10 @@
+# frozen_string_literal: true
+
 class UsersController < ApplicationController
   def index
+    respond_to do |format|
+      format.html
+      format.json { render json: UserDatatable.new(params, view_context: view_context) }
+    end
   end
 end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -7,7 +7,7 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
     @view_columns ||= {
       netid: { source: "User.uid", cond: :like, searchable: true, orderable: true },
       email: { source: "User.email", cond: :like, searchable: true, orderable: true },
-      deactivated: { source: "User.deactivated", cond: :like, orderable: true }
+      deactivated: { source: "User.deactivated", cond: :like, searchable: true, orderable: true, options: [true, false] }
     }
   end
 
@@ -22,6 +22,6 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
   end
 
   def get_raw_records # rubocop:disable Naming/AccessorMethodName
-    User.where(deactivated: false)
+    User.all
   end
 end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -5,9 +5,9 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      netid: { source: "User.uid", cond: :like },
-      email: { source: "User.email", cond: :like },
-      deactivated: { source: "User.deactivated", cond: :like }
+      netid: { source: "User.uid", cond: :like, searchable: true, orderable: true },
+      email: { source: "User.email", cond: :like, searchable: true, orderable: true },
+      deactivated: { source: "User.deactivated", cond: :like, orderable: true }
     }
   end
 
@@ -16,12 +16,12 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
       {
         netid: record.uid,
         email: record.email,
-        deactivated: record.deactivated
+        deactivated: record.deactivated ? "Inactive" : "Active"
       }
     end
   end
 
   def get_raw_records # rubocop:disable Naming/AccessorMethodName
-    User.all
+    User.where(deactivated: false)
   end
 end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class UserDatatable < AjaxDatatablesRails::ActiveRecord
+  def view_columns
+    # Declare strings in this format: ModelName.column_name
+    # or in aliased_join_table.column_name format
+    @view_columns ||= {
+      netid: { source: "User.uid", cond: :like },
+      email: { source: "User.email", cond: :like },
+      deactivated: { source: "User.deactivated", cond: :like }
+    }
+  end
+
+  def data
+    records.map do |record|
+      {
+        netid: record.uid,
+        email: record.email,
+        deactivated: record.deactivated
+      }
+    end
+  end
+
+  def get_raw_records # rubocop:disable Naming/AccessorMethodName
+    User.all
+  end
+end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -7,7 +7,7 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
     @view_columns ||= {
       netid: { source: "User.uid", cond: :like, searchable: true, orderable: true },
       email: { source: "User.email", cond: :like, searchable: true, orderable: true },
-      deactivated: { source: "User.deactivated", cond: :like, searchable: true, orderable: true, options: [true, false] }
+      deactivated: { source: "User.deactivated", cond: :like, searchable: true, orderable: true, options: [{ value: true, label: "Inactive" }, { value: false, label: "Active", selected: true }] }
     }
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module UsersHelper
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -36,6 +36,7 @@ $( document ).on('turbolinks:load', function() {
     let columns = JSON.parse($(".datatable-data").text());
     let hasSearch = columns.some(function(col){return col.searchable;});
     dataTable = $('.is-datatable').dataTable({
+      "deferLoading":true,
       "processing": true,
       "serverSide": true,
       "ajax": {
@@ -63,7 +64,13 @@ $( document ).on('turbolinks:load', function() {
               let input = null;
               if (colDef.options) {
                 input = $("<select><option>All</option>" + colDef.options.map(function (option) {
-                  return "<option>" + option + "</option>"
+                  if (typeof option==="string"){
+                    option={value:option, label:option}
+                  }
+                  if (option.selected) {
+                    column.search(option.value)
+                  }
+                  return "<option value='"+ option.value +"' "+ (option.selected ? "selected": '') + ">" + option.label + "</option>"
                 }) + "</select>");
               } else {
                 input = $("<input type='text' size='12' placeholder='" + $(column.header()).text() + "' />");
@@ -85,6 +92,7 @@ $( document ).on('turbolinks:load', function() {
         }
       }
     })
+    dataTable.api().draw()
   }
 });
 

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -2,6 +2,7 @@
   <div class="sidebar-heading">Management</div>
   <div class="list-group list-group-flush">
     <%= link_to 'Dashboard', root_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <%= link_to 'Users', users_index_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Notifications', notifications_path, class: 'list-group-item list-group-item-action bg-light' %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -2,7 +2,7 @@
   <div class="sidebar-heading">Management</div>
   <div class="list-group list-group-flush">
     <%= link_to 'Dashboard', root_path, class: 'list-group-item list-group-item-action bg-light' %>
-    <%= link_to 'Users', users_index_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <%= link_to 'Users', users_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Notifications', notifications_path, class: 'list-group-item list-group-item-action bg-light' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#index</h1>
+<p>Find me in app/views/users/index.html.erb</p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,22 @@
-<h1>Users#index</h1>
-<p>Find me in app/views/users/index.html.erb</p>
+<div class='container'>
+  <% if flash[:notice] %>
+    <div class='notice'><%= flash[:notice] %></div>
+  <% end %>
+  <h1>Users</h1>
+  <table id="users-datatable" class='is-datatable table table-responsive table-bordered table-striped' data-source="<%= users_path(format: :json) %>">
+  <thead class='thead-dark'>
+    <tr>
+      <th>NetId</th>
+      <th>Email</th>
+      <th>Inactive</th>
+    </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+</div>
+
+
+<div id='users-data' class='d-none datatable-data'>
+  <%= UserDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], options: value[:options]} }.to_json %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
     <div class='notice'><%= flash[:notice] %></div>
   <% end %>
   <h1>Users</h1>
-  <table id="users-datatable" class='is-datatable table table-responsive table-bordered table-striped' data-source="<%= users_path(format: :json) %>">
+  <table style="width:100%" id="users-datatable" class='is-datatable table table-responsive table-bordered table-striped' data-source="<%= users_path(format: :json) %>">
   <thead class='thead-dark'>
     <tr>
       <th>NetId</th>
@@ -18,5 +18,5 @@
 
 
 <div id='users-data' class='d-none datatable-data'>
-  <%= UserDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], options: value[:options]} }.to_json %>
+  <%= UserDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'users/index'
   resources :batch_processes do
     collection { post :import }
     member do
@@ -11,6 +10,7 @@ Rails.application.routes.draw do
       get '/parent_objects/:oid/child_objects/:child_oid', to: 'batch_processes#show_child', as: :show_child
     end
   end
+  resources :users, only: [:index]
   resources :child_objects
 
   resources :parent_objects do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get 'users/index'
   resources :batch_processes do
     collection { post :import }
     member do

--- a/spec/datatables/users_datatable_spec.rb
+++ b/spec/datatables/users_datatable_spec.rb
@@ -30,13 +30,5 @@ RSpec.describe UserDatatable, type: :datatable do
         deactivated: "Active"
       )
     end
-
-    it "does not show deactivated users" do
-      login_as user
-      user2.deactivated = true
-      user2.save
-      output = UserDatatable.new(datatable_sample_params(columns)).data
-      expect(output.size).to eq(1)
-    end
   end
 end

--- a/spec/datatables/users_datatable_spec.rb
+++ b/spec/datatables/users_datatable_spec.rb
@@ -30,5 +30,13 @@ RSpec.describe UserDatatable, type: :datatable do
         deactivated: "Active"
       )
     end
+
+    it "shows both active and deactivated users" do
+      login_as user
+      user2.deactivated = true
+      user2.save
+      output = UserDatatable.new(datatable_sample_params(columns)).data
+      expect(output.size).to eq(2)
+    end
   end
 end

--- a/spec/datatables/users_datatable_spec.rb
+++ b/spec/datatables/users_datatable_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserDatatable, type: :datatable do
+  let(:user) { FactoryBot.create(:user, uid: 'js2530', email: 'juliasmith@email.com') }
+  columns = ['netid', 'email', 'deactivated']
+
+  describe 'user data tables' do
+    it 'can handle an empty model set' do
+      output = UserDatatable.new(datatable_sample_params(columns)).data
+
+      expect(output).to eq([])
+    end
+
+    it 'renders a complete data table' do
+      login_as user
+      output = UserDatatable.new(datatable_sample_params(columns)).data
+      expect(output.size).to eq(1)
+      expect(output).to include(
+        netid: 'js2530',
+        email: 'juliasmith@email.com',
+        deactivated: false
+      )
+    end
+  end
+end

--- a/spec/datatables/users_datatable_spec.rb
+++ b/spec/datatables/users_datatable_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe UserDatatable, type: :datatable do
   let(:user) { FactoryBot.create(:user, uid: 'js2530', email: 'juliasmith@email.com') }
+  let(:user2) { FactoryBot.create(:user, uid: 'pt4645', email: 'pamthomas@email.com') }
   columns = ['netid', 'email', 'deactivated']
 
   describe 'user data tables' do
@@ -15,13 +16,27 @@ RSpec.describe UserDatatable, type: :datatable do
 
     it 'renders a complete data table' do
       login_as user
+      user2.reload
       output = UserDatatable.new(datatable_sample_params(columns)).data
-      expect(output.size).to eq(1)
-      expect(output).to include(
+      expect(output.size).to eq(2)
+      expect(output[0]).to include(
         netid: 'js2530',
         email: 'juliasmith@email.com',
-        deactivated: false
+        deactivated: "Active"
       )
+      expect(output[1]).to include(
+        netid: 'pt4645',
+        email: 'pamthomas@email.com',
+        deactivated: "Active"
+      )
+    end
+
+    it "does not show deactivated users" do
+      login_as user
+      user2.deactivated = true
+      user2.save
+      output = UserDatatable.new(datatable_sample_params(columns)).data
+      expect(output.size).to eq(1)
     end
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+
   it "has the expected fields" do
     u = described_class.new
     u.email = "river@yale.edu"
@@ -12,5 +14,13 @@ RSpec.describe User, type: :model do
     expect(u.errors).to be_empty
     expect(u.provider).to eq "cas"
     expect(u.uid).to eq "River"
+  end
+
+  describe 'deactivate!' do
+    it 'deactivates a user' do
+      expect(user.deactivated).to eq(false)
+      user.deactivate!
+      expect(user.deactivated).to eq(true)
+    end
   end
 end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    login_as user
+  end
+
+  describe "GET /index" do
+    it "returns http success" do
+      get "/users/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe "Users", type: :request do
@@ -13,5 +15,4 @@ RSpec.describe "Users", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Users", type: :request do
 
   describe "GET /index" do
     it "returns http success" do
-      get "/users/index"
+      get users_path
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "ChildObjects", type: :system, js: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user, deactivated: true) }
+  before do
+    login_as user
+    visit users_path
+  end
+
+  describe "users datatable" do
+    it "defaults to only display Active users" do
+      user2.reload
+      expect(page).to have_content(user.uid)
+      expect(page).to have_no_content(user2.uid)
+    end
+  end
+end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "users/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe "users/index.html.erb", type: :view do


### PR DESCRIPTION
Acceptance
- [x] A new item Users is added to the left menu in the management app
- [x] Clicking that item leads to a page that presents a paginated and sortable list of users, with column headers/values:
    - [x] "NetId" as label for uid
    - [x] "Email" as label for email
    - [x] "Inactive" as label for deactivated

Stretch Goals:
- [x] Default to "Active" users only
- [x] Dropdowns on columns like with the parent object table for "Active," etc (like ILS Ladybird)