### PR TITLE
Allow editing of users in management application

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user, only: [:edit]
+  before_action :set_user, only: [:edit, :update, :show]
 
   def index
     respond_to do |format|
@@ -16,13 +16,15 @@ class UsersController < ApplicationController
     respond_to do |format|
       if @user.update(user_params)
         format.html { redirect_to @user, notice: 'User was successfully updated.' }
-        format.json { render :show, status: :ok, location: @user }
+        format.json { render :show, status: :ok }
       else
         format.html { render :edit }
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
   end
+
+  def show; end
 
   private
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,36 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  before_action :set_user, only: [:edit]
+
   def index
     respond_to do |format|
       format.html
       format.json { render json: UserDatatable.new(params, view_context: view_context) }
     end
   end
+
+  def edit; end
+
+  def update
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to @user, notice: 'User was successfully updated.' }
+        format.json { render :show, status: :ok, location: @user }
+      else
+        format.html { render :edit }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:email, :deactivated)
+    end
+
+    def set_user
+      @user = User.find(params[:id])
+    end
 end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -3,7 +3,7 @@
 class UserDatatable < AjaxDatatablesRails::ActiveRecord
   extend Forwardable
 
-  def_delegators :@view, :link_to, :edit_user_path
+  def_delegators :@view, :link_to, :user_path, :edit_user_path
 
   def initialize(params, opts = {})
     @view = opts[:view_context]
@@ -24,7 +24,7 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
   def data
     records.map do |user|
       {
-        netid: user.uid,
+        netid: link_to(user.uid, user_path(user)),
         email: user.email,
         deactivated: user.deactivated ? "Inactive" : "Active",
         actions: actions(user).html_safe # rubocop:disable Rails/OutputSafety

--- a/app/lib/mets_directory_scanner.rb
+++ b/app/lib/mets_directory_scanner.rb
@@ -30,7 +30,7 @@ class MetsDirectoryScanner
   def self.system_user
     system_user = User.find_by_uid('System')
     unless system_user
-      system_user = User.new(uid: 'System')
+      system_user = User.new(uid: 'System', email: 'test@example.com')
       Rails.logger.error("Unable to save system user") unless system_user.save!
     end
     system_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   devise :timeoutable, :omniauthable, omniauth_providers: [:cas]
 
+  validates :email, presence: true
+
   has_many :notifications, as: :recipient
   has_many :batch_processes
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -10,13 +10,14 @@
       </ul>
     </div>
   <% end %>
-  <div class="form-row">
-    <div class="col-med-3">
+  <div>
+    <div>
       <%= form.label :email %>
       <%= form.text_field(:email, required: true) %>
     </div>
+    <br>
 
-    <div class="col-med-3">
+    <div>
       <%= form.label :deactivated %>
       <%= form.check_box(:deactivated) %>
     </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="form-row">
     <div class="col-med-3">
       <%= form.label :email %>
-      <%= form.text_field(:email, disabled: false) %>
+      <%= form.text_field(:email, required: true) %>
     </div>
 
     <div class="col-med-3">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,30 @@
+<%= form_with(model: user, local: true) do |form| %>
+  <% if user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+
+      <ul>
+        <% user.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="form-row">
+    <div class="col-med-3">
+      <%= form.label :email %>
+      <%= form.text_field(:email, disabled: false) %>
+    </div>
+
+    <div class="col-med-3">
+      <%= form.label :deactivated %>
+      <%= form.check_box(:deactivated) %>
+    </div>
+  </div>
+  <br>
+
+  <br>
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Editing User</h1>
+
+<%= render 'form', user: @user %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,6 +9,7 @@
       <th>NetId</th>
       <th>Email</th>
       <th>Inactive</th>
+      <th>Actions</th>
     </tr>
     </thead>
     <tbody>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,4 @@
+<h1>User Details</h1>
 <p id="notice"><%= notice %></p>
 
 <p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>UID:</strong>
+  <%= @user.uid %>
+</p>
+
+<p>
+  <strong>Email:</strong>
+  <%= @user.email %>
+</p>
+
+<p>
+  <strong>Deactivated:</strong>
+  <%= @user.deactivated %>
+</p>
+
+<%= link_to 'Edit', edit_user_path(@user) %>
+<%= link_to 'Back', users_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       get '/parent_objects/:oid/child_objects/:child_oid', to: 'batch_processes#show_child', as: :show_child
     end
   end
-  resources :users, only: [:index]
+  resources :users, only: [:index, :edit, :update]
   resources :child_objects
 
   resources :parent_objects do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       get '/parent_objects/:oid/child_objects/:child_oid', to: 'batch_processes#show_child', as: :show_child
     end
   end
-  resources :users, only: [:index, :edit, :update]
+  resources :users, only: [:index, :edit, :update, :show]
   resources :child_objects
 
   resources :parent_objects do

--- a/db/migrate/20210223164919_add_email_to_user.rb
+++ b/db/migrate/20210223164919_add_email_to_user.rb
@@ -1,0 +1,5 @@
+class AddEmailToUser < ActiveRecord::Migration[6.0]
+  def change
+    execute "update users set email = CONCAT(uid, '@connect.yale.edu') where email = ''";
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_144113) do
+ActiveRecord::Schema.define(version: 2021_02_23_164919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -73,6 +73,7 @@ CSV.parse(user_csv, headers: false) do |row|
     )
   else
     @user.deactivated = false
+    @user.email = "#{@user.uid}@example.com"
     @user.save!
   end
   authorized_uids.push uid

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -73,7 +73,7 @@ CSV.parse(user_csv, headers: false) do |row|
     )
   else
     @user.deactivated = false
-    @user.email = "#{@user.uid}@example.com"
+    @user.email = "#{@user.uid}@connect.yale.edu"
     @user.save!
   end
   authorized_uids.push uid

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe OmniauthCallbacksController do
   context "when origin is present" do
     before do
       User.create(provider: 'cas',
-                  uid: 'handsome_dan')
+                  uid: 'handsome_dan',
+                  email: "handsome_dan@email.com")
       request.env["omniauth.origin"] = '/yale-only-map-of-china'
     end
 
@@ -33,7 +34,8 @@ RSpec.describe OmniauthCallbacksController do
   context "when origin is missing" do
     before do
       User.create(provider: 'cas',
-                  uid: 'handsome_dan')
+                  uid: 'handsome_dan',
+                  email: "handsome_dan@email.com")
     end
     it "redirects to dashboard" do
       post :cas
@@ -55,6 +57,7 @@ RSpec.describe OmniauthCallbacksController do
     before do
       User.create(provider: 'cas',
                   uid: 'handsome_dan',
+                  email: "handsome_dan@email.com",
                   deactivated: true)
     end
     it "redirect to origin" do

--- a/spec/datatables/users_datatable_spec.rb
+++ b/spec/datatables/users_datatable_spec.rb
@@ -16,18 +16,13 @@ RSpec.describe UserDatatable, type: :datatable do
 
     it 'renders a complete data table' do
       login_as user
-      user2.reload
-      output = UserDatatable.new(datatable_sample_params(columns)).data
-      expect(output.size).to eq(2)
+      output = UserDatatable.new(datatable_sample_params(columns), view_context: user_datatable_view_mock(user.id, user.uid)).data
+      expect(output.size).to eq(1)
       expect(output[0]).to include(
-        netid: 'js2530',
+        netid: "<a href='/management/users/#{user.id}'>#{user.uid}</a>",
         email: 'juliasmith@email.com',
-        deactivated: "Active"
-      )
-      expect(output[1]).to include(
-        netid: 'pt4645',
-        email: 'pamthomas@email.com',
-        deactivated: "Active"
+        deactivated: "Active",
+        actions: "<a href='/management/users/#{user.id}/edit'>Edit</a>"
       )
     end
 
@@ -35,7 +30,7 @@ RSpec.describe UserDatatable, type: :datatable do
       login_as user
       user2.deactivated = true
       user2.save
-      output = UserDatatable.new(datatable_sample_params(columns)).data
+      output = UserDatatable.new(datatable_sample_params(columns), view_context: user_datatable_view_mock(user.id, user.uid)).data
       expect(output.size).to eq(2)
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
   # provider "cas"
   factory :user do
     uid { FFaker::Internet.user_name }
+    email { FFaker::Internet.email }
     provider { "cas" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,4 +23,12 @@ RSpec.describe User, type: :model do
       expect(user.deactivated).to eq(true)
     end
   end
+
+  describe 'with email validations' do
+    it 'verifies that a new user has an email' do
+      user2 = described_class.new(email: nil)
+      expect(user2).to_not be_valid
+      expect(user2.errors.messages[:email]).to eq ["can't be blank"]
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe User, type: :model do
   describe 'with email validations' do
     it 'verifies that a new user has an email' do
       user2 = described_class.new(email: nil)
-      expect(user2).to_not be_valid
+      expect(user2).not_to be_valid
       expect(user2.errors.messages[:email]).to eq ["can't be blank"]
     end
   end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -9,10 +9,72 @@ RSpec.describe "Users", type: :request do
     login_as user
   end
 
+  let(:valid_attributes) do
+    {
+      uid: 'fg1248',
+      email: 'fg1248@example.com',
+      deactivated: false
+    }
+  end
+
+  let(:invalid_attributes) do
+    {
+      email: ''
+    }
+  end
+
   describe "GET /index" do
     it "returns http success" do
       get users_path
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "renders a successful response" do
+      user = User.create! valid_attributes
+      get user_url(user)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /edit" do
+    it "render a successful response" do
+      user = User.create! valid_attributes
+      get edit_user_url(user)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:new_attributes) do
+        {
+          email: 'br1589@example.com'
+        }
+      end
+
+      it "updates the requested user" do
+        user = User.create! valid_attributes
+        patch user_url(user), params: { user: new_attributes }
+        user.reload
+        expect(user.email).to eq('br1589@example.com')
+      end
+
+      it "redirects to the user" do
+        user = User.create! valid_attributes
+        patch user_url(user), params: { user: new_attributes }
+        user.reload
+        expect(response).to redirect_to(user_url(user))
+      end
+    end
+
+    context "with invalid parameters" do
+      it "renders a successful response (i.e. to display the 'edit' template)" do
+        user = User.create! valid_attributes
+        patch user_url(user), params: { user: invalid_attributes }
+        expect(response).to be_successful
+      end
     end
   end
 end

--- a/spec/support/datatables_helper.rb
+++ b/spec/support/datatables_helper.rb
@@ -106,3 +106,12 @@ def batch_process_parent_datatable_view_mock(id, parent_oid, child_oid) # ruboco
                                                   .and_return("<a href='/batch_processes/#{id}/parent_objects/#{parent_oid}/child_objects/#{child_oid}'>#{child_oid}</a>")
   @datatable_view_mock
 end
+
+def user_datatable_view_mock(id, uid) # rubocop:disable Metrics/AbcSize
+  @datatable_view_mock ||= double
+  allow(@datatable_view_mock).to receive(:user_path).and_return("/management/users/#{id}")
+  allow(@datatable_view_mock).to receive(:edit_user_path).and_return("/management/users/#{id}/edit")
+  allow(@datatable_view_mock).to receive(:link_to).with(anything, "/management/users/#{id}").and_return("<a href='/management/users/#{id}'>#{uid}</a>")
+  allow(@datatable_view_mock).to receive(:link_to).with("Edit", "/management/users/#{id}/edit").and_return("<a href='/management/users/#{id}/edit'>Edit</a>")
+  @datatable_view_mock
+end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -3,22 +3,24 @@ require 'rails_helper'
 
 RSpec.describe 'Users', type: :system, js: true do
   let(:user) { FactoryBot.create(:user) }
-  let(:user2) { FactoryBot.create(:user, deactivated: true) }
+  let(:user2) { FactoryBot.create(:user) }
+
   before do
     login_as user
-    visit users_path
   end
 
   describe 'datatable' do
     it 'defaults to only display Active users' do
       user2.reload
+      visit users_path
       expect(page).to have_content(user.uid)
-      expect(page).to have_no_content(user2.uid)
+      expect(page).to have_content(user2.uid)
     end
   end
 
   describe 'are editable' do
     it 'and require an email to be present' do
+      visit users_path
       click_on('Edit')
       fill_in('Email', with: '')
       click_on('Update User')
@@ -27,6 +29,16 @@ RSpec.describe 'Users', type: :system, js: true do
 
       expect(message).to eq 'Please fill out this field.'
       expect(current_path).to eq edit_user_path(user.id)
+    end
+
+    it 'and can be deactivated' do
+      visit edit_user_path(user2.id)
+      page.check('Deactivated')
+      click_on('Update User')
+      visit users_path
+
+      expect(page).to have_content(user.uid)
+      expect(page).to have_no_content(user2.uid)
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "ChildObjects", type: :system, js: true do
+RSpec.describe 'Users', type: :system, js: true do
   let(:user) { FactoryBot.create(:user) }
   let(:user2) { FactoryBot.create(:user, deactivated: true) }
   before do
@@ -9,11 +9,24 @@ RSpec.describe "ChildObjects", type: :system, js: true do
     visit users_path
   end
 
-  describe "users datatable" do
-    it "defaults to only display Active users" do
+  describe 'datatable' do
+    it 'defaults to only display Active users' do
       user2.reload
       expect(page).to have_content(user.uid)
       expect(page).to have_no_content(user2.uid)
+    end
+  end
+
+  describe 'are editable' do
+    it 'and require an email to be present' do
+      click_on('Edit')
+      fill_in('Email', with: '')
+      click_on('Update User')
+
+      message = page.find('#user_email').native.attribute('validationMessage')
+
+      expect(message).to eq 'Please fill out this field.'
+      expect(current_path).to eq edit_user_path(user.id)
     end
   end
 end


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>
Co-author: Martin Lovell <martin.lovell@yale.edu>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1087

# Expected behavior
- users are editable from `/management/users`
- users can be deactivated
- new users require an email address
- if an existing user is edited, an email address must be added
- there is a user show page
- existing users will have an email address with the domain @connect.yale.edu

# Demo
|users page | edit page | show page |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/108768121-2540e780-750c-11eb-896b-abb18be1ecf7.png) | ![image](https://user-images.githubusercontent.com/29032869/108768213-3d186b80-750c-11eb-9eb9-8244c9955a12.png) | ![image](https://user-images.githubusercontent.com/29032869/108768172-31c54000-750c-11eb-9681-f61e4207672a.png) |

# Resources
- https://til.hashrocket.com/posts/af87b1eaa8-test-validation-errors-with-rspec
- https://medium.com/@tmikeschu/testing-html5-messages-with-rspec-selenium-5f5834c5af10

# Testing
- press "edit" by a user that isn't yourself
- check the check box underneath "deactivated"
- press "update user"
- you'll get an error to add an email
- add the email
- press "update user"
- in the users datatable click the "active" dropdown and select "inactive"
- you should see the user you just deactivated
- press "edit" next to their name
- uncheck the check box underneath "deactivated"
- press "update user"
- the user should again be listed as active