### PR TITLE
Provide batch wide events and display them

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -9,6 +9,8 @@ class BatchProcessesController < ApplicationController
 
   def index
     @batch_process = BatchProcess.new
+    # force user to choose action in form
+    @batch_process.batch_action = nil
 
     respond_to do |format|
       format.html

--- a/app/datatables/batch_process_datatable.rb
+++ b/app/datatables/batch_process_datatable.rb
@@ -16,10 +16,11 @@ class BatchProcessDatatable < AjaxDatatablesRails::ActiveRecord
     @view_columns ||= {
       process_id: { source: "BatchProcess.id", cond: :eq, searchable: true, orderable: true },
       user: { source: "User.uid", cond: :start_with, searchable: true, orderable: true },
-      time: { source: "BatchProcess.created_at", cond: :like, searchable: true, orderable: true },
+      time: { source: "BatchProcess.created_at", cond: :like, orderable: true },
       size: { source: "BatchProcess.oid", searchable: false, orderable: false },
       status: { source: "BatchProcess.batch_status", searchable: false, orderable: false },
-      object_details: { cond: :null_value, searchable: false, orderable: false }
+      batch_ingest_events_count: { source: "BatchProcess.batch_ingest_events_count", searchable: false, orderable: false },
+      batch_action: { source: "BatchProcess.batch_action", searchable: true, orderable: true, options: BatchProcess.batch_actions }
     }
   end
 
@@ -32,7 +33,8 @@ class BatchProcessDatatable < AjaxDatatablesRails::ActiveRecord
         time: batch_process.created_at,
         size: batch_process.oids&.count,
         status: batch_process.batch_status,
-        object_details: link_to("View", batch_process_path(batch_process)),
+        batch_ingest_events_count: link_to(batch_process.batch_ingest_events_count, batch_process_path(batch_process)),
+        batch_action: batch_process.batch_action,
         DT_RowId: batch_process.id
       }
     end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -31,6 +31,11 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     IngestEvent.where(batch_connection: current_batch_connection)
   end
 
+  def batch_ingest_events_count
+    current_batch_connection = batch_connections.find_or_create_by!(connectable: self)
+    IngestEvent.where(batch_connection: current_batch_connection).count
+  end
+
   def validate_import
     return if file.blank?
     if File.extname(file) == '.csv'

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -79,7 +79,7 @@ module Statable
 
   def processing_event(message, status = 'info')
     unless current_batch_connection
-      Rails.logger.error("no batch connection for #{oid} - #{message}")
+      # Rails.logger.error("no batch connection for #{oid} - #{message}")
       return "no batch connection"
     end
     IngestEvent.create!(

--- a/app/views/batch_processes/_form.html.erb
+++ b/app/views/batch_processes/_form.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <div class="form-group" >
       <%= f.label :batch_action %>
-      <%= f.select(:batch_action, BatchProcess.batch_actions, {}, { :class => 'form-control' }) %>
+      <%= f.select(:batch_action, BatchProcess.batch_actions.map {|option| [option.split.map(&:capitalize).join(' '), option]}, {prompt:"Select Batch Action"}, { :class => 'form-control', required: true }) %>
     </div>
     <div class="form-group" >
       <%= f.file_field :file, accept: '.csv, .xml', required: true %>

--- a/app/views/batch_processes/index.html.erb
+++ b/app/views/batch_processes/index.html.erb
@@ -19,7 +19,8 @@
             <th scope='col'> Time </th>
             <th scope='col'> Size </th>
             <th scope='col'> Status </th>
-            <th scope='col'> Object Details </th>
+            <th scope='col'> Messages </th>
+            <th scope='col'> Batch Action </th>
           </tr>
         </thead>
         <tbody>
@@ -31,5 +32,5 @@
 
 
 <div id='batch-processes-data' class='d-none datatable-data'>
-  <%= BatchProcessDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], options: value[:options]} }.to_json %>
+  <%= BatchProcessDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
 </div>

--- a/app/views/batch_processes/show.html.erb
+++ b/app/views/batch_processes/show.html.erb
@@ -29,8 +29,24 @@
   <%= @batch_process.file_name && @batch_process.batch_action == "export child oids" ? link_to(@batch_process.created_file_name, download_created_batch_process_path) : "n/a" %>
 </p>
 
+<% if @batch_process.batch_ingest_events.present? %>
+  <h3>Batch Messages:</h3>
+  <table class="table table-bordered table-responsive table-striped"><thead class='thead-dark'>
+  <tr>
+    <th scope='col'> Time </th>
+    <th scope='col'> Status </th>
+    <th scope='col'> Problem </th>
+  </tr>
+  </thead>
+    <% @batch_process.batch_ingest_events.each do |event| %>
+      <tr><td><%= event.updated_at %></td><td><%= event.status %></td><td><%= event.reason %></td></tr>
+    <% end %>
+  </table>
+<% end %>
+
 <div class='row'>
   <div class='col overflow-auto'>
+    <h3>Batch Parent Objects:</h3>
     <table id='batch-process-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= batch_process_path(format: :json) %>'>
       <thead class='thead-dark'>
         <tr>

--- a/spec/factories/ingest_events.rb
+++ b/spec/factories/ingest_events.rb
@@ -4,8 +4,6 @@ FactoryBot.define do
   factory :ingest_event do
     reason { "MyString" }
     status { "MyString" }
-    batch_process { nil }
     batch_connection { nil }
-    user { nil }
   end
 end

--- a/spec/system/batch_process_detail_spec.rb
+++ b/spec/system/batch_process_detail_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
         created_at: "2020-10-08 14:17:01"
       )
     end
+
     it "can see the details of the import" do
       expect(page).to have_content(batch_process.id.to_s)
       expect(page).to have_content("johnsmith2530")
@@ -36,6 +37,27 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
       expect(page).to have_link('16057779', href: "/batch_processes/#{batch_process.id}/parent_objects/16057779")
       expect(page).to have_content("4")
       expect(page).to have_content("2020-10-08 14:17:01")
+    end
+
+    context "when batch wide ingest event is available" do
+      let(:ingest_event) do
+        IngestEvent.create(
+          reason: "This is the batch event",
+          status: "Batch event statue"
+        )
+      end
+
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(BatchProcess).to receive(:batch_ingest_events).and_return([ingest_event])
+        # rubocop:enable RSpec/AnyInstance
+        visit batch_process_path(batch_process)
+      end
+
+      it "can see the ingest events of the import" do
+        expect(page).to have_content(batch_process.id.to_s)
+        expect(page).to have_content(ingest_event.reason)
+      end
     end
 
     it "can see the status of the parent object imports" do

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
     stub_metadata_cloud("16854285")
     login_as user
     visit batch_processes_path
+    select("Create Parent Objects")
   end
 
   context "having created a parent_object via the UI" do
@@ -36,8 +37,8 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
     end
     it "can still successfully see the batch_process page" do
       visit batch_processes_path
-      click_on("View")
-      expect(page.body).to have_link('View', href: "/batch_processes/#{BatchProcess.last.id}")
+      click_on(BatchProcess.last.id.to_s)
+      expect(page.body).to have_link(BatchProcess.last.id.to_s, href: "/batch_processes/#{BatchProcess.last.id}")
     end
     context "deleting a parent object" do
       it "can still load the batch_process page" do
@@ -45,8 +46,8 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
         po.delete
         expect(po.destroyed?).to be true
         visit batch_processes_path
-        click_on("View")
-        expect(page.body).to have_link('View', href: "/batch_processes/#{BatchProcess.last.id}")
+        click_on(BatchProcess.last.id.to_s)
+        expect(page.body).to have_link(BatchProcess.last.id.to_s, href: "/batch_processes/#{BatchProcess.last.id}")
       end
     end
   end
@@ -85,7 +86,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
       it "uploads a CSV of child oids in order to re-associate them with new parent oids" do
         expect(BatchProcess.count).to eq 0
         page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_small.csv")
-        select("reassociate child oids")
+        select("Reassociate Child Oids")
         click_button("Submit")
         expect(BatchProcess.count).to eq 1
         expect(page).to have_content("Your job is queued for processing in the background")
@@ -105,14 +106,14 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
       it "uploads a CSV of parent oids in order to create export of child objects oids and orders" do
         expect(BatchProcess.count).to eq 0
         page.attach_file("batch_process_file", Rails.root + "spec/fixtures/short_fixture_ids.csv")
-        select("export child oids")
+        select("Export Child Oids")
         click_button("Submit")
         expect(BatchProcess.count).to eq 1
         expect(page).to have_content("Your job is queued for processing in the background")
         expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
         expect(BatchProcess.last.batch_action).to eq "export child oids"
         expect(BatchProcess.last.output_csv).to include "1126257"
-        click_on("View")
+        click_on(BatchProcess.last.id.to_s)
         expect(page).to have_link("short_fixture_ids.csv", href: "/batch_processes/#{BatchProcess.last.id}/download")
         expect(page).to have_link("short_fixture_ids_bp_#{BatchProcess.last.id}.csv", href: "/batch_processes/#{BatchProcess.last.id}/download_created")
         bp = BatchProcess.last
@@ -123,7 +124,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
       context "round-tripping csv" do
         it "can create the output csv from a csv that has been generated from the application" do
           page.attach_file("batch_process_file", Rails.root + "spec/fixtures/parents_for_reassociation_as_output.csv")
-          select("export child oids")
+          select("Export Child Oids")
           click_button("Submit")
           expect(BatchProcess.count).to eq 1
           expect(page).to have_content("Your job is queued for processing in the background")
@@ -133,7 +134,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
 
         it "can create the output csv from a handmade csv" do
           page.attach_file("batch_process_file", Rails.root + "spec/fixtures/parents_for_reassociation.csv")
-          select("export child oids")
+          select("Export Child Oids")
           click_button("Submit")
           expect(BatchProcess.count).to eq 1
           expect(page).to have_content("Your job is queued for processing in the background")
@@ -160,7 +161,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
       it "can still see the details of the import" do
         expect(page).to have_link(BatchProcess.last.id.to_s, href: "/batch_processes/#{BatchProcess.last.id}")
         expect(page).to have_content('5')
-        expect(page).to have_link('View', href: "/batch_processes/#{BatchProcess.last.id}")
+        expect(page).to have_link(BatchProcess.last.id.to_s, href: "/batch_processes/#{BatchProcess.last.id}")
       end
     end
   end
@@ -184,8 +185,8 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, js: tru
         po.delete
         expect(po.destroyed?).to be true
         visit batch_processes_path
-        click_on("View")
-        expect(page.body).to have_link('View', href: "/batch_processes/#{BatchProcess.last.id}")
+        click_on(BatchProcess.last.id.to_s)
+        expect(page.body).to have_link(BatchProcess.last.id.to_s, href: "/batch_processes/#{BatchProcess.last.id}")
       end
     end
   end


### PR DESCRIPTION
- Adds method BatchProcess.batch_processing_event to store batch wide IngestEvents that aren't associated with an existing ParentObject or ChildObject
- Display those events on the batch show page.
- Generate batch wide IngestEvents for Reassociate Child batches when parent or child don't exist or order is not valid.  Batch continues to process other rows.
- Generate batch wide IngestEvent for Recreate PTIFF batches when a child oid does not exist.  Batch continues to process other rows.
- Updates batch table to show number of batch wide messages, updates batch show to list the messages
- Update batch form to force user to choose an option (instead of defaulting to Create Parent Objects to prevent errors)

After (batch index/new batch page):
![image](https://user-images.githubusercontent.com/32851993/109160102-5f47fe80-7743-11eb-85ad-89f521c02c53.png)

After (batch show page):
![image](https://user-images.githubusercontent.com/32851993/109160242-89012580-7743-11eb-94d2-1b4328615037.png)
