### PR TITLE
Confirmation to Reindex & Update Metadata buttons

### DIFF
--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -6,8 +6,8 @@
   <div class='col'>
     <div class='float-right'>
       <%= link_to 'New Parent Object', new_parent_object_path, class: 'btn btn-primary' %>
-      <%= link_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn btn-secondary' %>
-      <%= link_to 'Update Metadata', all_metadata_parent_objects_path, method: 'post', class: 'btn btn-secondary' %>
+      <%= link_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn btn-secondary', id: 'reindex', data:{confirm: "Are you sure you want to proceed? This action will reindex the entire contents of the system."} %>
+      <%= link_to 'Update Metadata', all_metadata_parent_objects_path, method: 'post', class: 'btn btn-secondary',id: 'update_metadata', data:{confirm: "Are you sure you want to proceed?  This action will update metadata for the entire contents of the system."} %>
     </div>
   </div>
 </div>

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -352,7 +352,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
     end
   end
 
-  context "pages has a ReIndex button with an action event" do
+  # TODO: test confirmation box
+  context "pages has a Reindex button with an action event" do
     before do
       visit parent_objects_path
     end
@@ -362,6 +363,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
     end
   end
 
+  # TODO: test confirmation box
   context "pages has a Update Metadata button with an action event" do
     before do
       visit parent_objects_path

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -341,4 +341,37 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
       expect(page).to have_field("Oid", disabled: true)
     end
   end
+
+  context "pages has a New Parent Object button with an action event" do
+    before do
+      visit parent_objects_path
+    end
+
+    it "has a New Parent Object button" do
+      click_on("New Parent Object")
+    end
+
+  end
+
+  context "pages has a ReIndex button with an action event" do
+    before do
+      visit parent_objects_path
+    end
+
+    it "has a Reindex button" do
+      click_on("Reindex")
+    end
+
+  end
+
+  context "pages has a Update Metadata button with an action event" do
+    before do
+      visit parent_objects_path
+    end
+
+    it "has a Update Metadata button" do
+      click_on("Update Metadata")
+    end
+
+  end
 end

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -350,7 +350,6 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
     it "has a New Parent Object button" do
       click_on("New Parent Object")
     end
-
   end
 
   context "pages has a ReIndex button with an action event" do
@@ -361,7 +360,6 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
     it "has a Reindex button" do
       click_on("Reindex")
     end
-
   end
 
   context "pages has a Update Metadata button with an action event" do
@@ -372,6 +370,5 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
     it "has a Update Metadata button" do
       click_on("Update Metadata")
     end
-
   end
 end


### PR DESCRIPTION
**Story**

![Screen Shot 2021-02-18 at 1.07.51 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/4ad0d099-a551-4b60-93b7-f32da71817d4)

Reindexing is very expensive and we should confirm the user's intent when they click on this option.
(In the future we will likely limit this permission to superusers).

**Acceptance**

- [x] Add a confirmation dialog or intermediate screen for each of the two functions with the text:  "This action will (reindex|update metadata for) the entire contents of the system.  Are you sure you want to proceed?" 

--- 

**Demo of Feature in Dev Environment**

![Add confirmation for global Reindex and Update Metadata buttons#1079](https://user-images.githubusercontent.com/41123693/109356520-d7e7b180-784e-11eb-853a-e8f445a478f5.gif)
