### PR TITLE
Modified to show correct event timestamp for children

### DIFF
--- a/app/datatables/batch_process_parent_datatable.rb
+++ b/app/datatables/batch_process_parent_datatable.rb
@@ -25,7 +25,7 @@ class BatchProcessParentDatatable < AjaxDatatablesRails::ActiveRecord
       {
         child_oid: link_to(child_object&.oid, show_child_batch_process_path(oid: child_object&.parent_object_oid, child_oid: child_object&.oid)),
         # time: child_object&.created_at,
-        time: child_object.events_for_batch_process(batch_process).maximum(:created_at),
+        time: child_object.events_for_batch_process(@batch_process).maximum(:created_at),
         status: child_object&.status_for_batch_process(@batch_process).to_s,
         DT_RowId: child_object&.oid
       }

--- a/app/datatables/batch_process_parent_datatable.rb
+++ b/app/datatables/batch_process_parent_datatable.rb
@@ -24,7 +24,8 @@ class BatchProcessParentDatatable < AjaxDatatablesRails::ActiveRecord
     records.map do |child_object|
       {
         child_oid: link_to(child_object&.oid, show_child_batch_process_path(oid: child_object&.parent_object_oid, child_oid: child_object&.oid)),
-        time: child_object&.created_at,
+        # time: child_object&.created_at,
+        time: child_object.events_for_batch_process(batch_process).maximum(:created_at),
         status: child_object&.status_for_batch_process(@batch_process).to_s,
         DT_RowId: child_object&.oid
       }

--- a/spec/datatables/batch_process_parent_datatable_spec.rb
+++ b/spec/datatables/batch_process_parent_datatable_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe BatchProcessParentDatatable, type: :datatable, prep_metadata_sour
         DT_RowId: child_object.oid,
         child_oid: "<a href='/batch_processes/#{batch_process.id}/parent_objects/#{parent_object.oid}/child_objects/#{child_object.oid}'>#{child_object.oid}</a>",
         status: 'Pending',
-        time: child_object.created_at
+        # time: child_object.created_at
+        time: child_object.events_for_batch_process(batch_process).maximum(:created_at)
+
       )
     end
   end


### PR DESCRIPTION
Co-authored-by: Martin Lovell <martin.lovell@yale.edu>

**Story**

In the Batch Process Detail view the child object's timestamp is not that of the event, but of the record creation.   The table should display the timestamp of the event.

![Screen Shot 2021-02-22 at 11.09.32 AM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/8544431e-e92a-4388-b845-345e2c80eac8)

**Acceptance**

- [ ] The table shows the timestamp of the correlated status/event.

