### PR TITLE
Only pull LB metadata when necessary to get bib or aspace URL

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -114,10 +114,10 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
                     when "ladybird"
                       self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self)
                     when "ils"
-                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self)
+                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) unless bib.present?
                       self.voyager_json = MetadataSource.find_by(metadata_cloud_name: "ils").fetch_record(self)
                     when "aspace"
-                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self)
+                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) unless aspace_uri.present?
                       self.aspace_json = MetadataSource.find_by(metadata_cloud_name: "aspace").fetch_record(self)
                     end
     processing_event("Metadata has been fetched", "metadata-fetched") if fetch_results

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -260,8 +260,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
 
       it "pulls from the MetadataCloud for Voyager" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq voyager
-        expect(parent_object.ladybird_json).not_to be_empty
-        expect(parent_object.ladybird_json).not_to be nil
+        expect(parent_object.ladybird_json).to be nil
         expect(parent_object.voyager_json).not_to be nil
         expect(parent_object.voyager_json).not_to be_empty
         expect(parent_object.aspace_json).to be nil
@@ -281,8 +280,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true do
 
       it "pulls from the MetadataCloud for ArchiveSpace" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq aspace # 3 is ArchiveSpace
-        expect(parent_object.ladybird_json).not_to be_empty
-        expect(parent_object.ladybird_json).not_to be nil
+        expect(parent_object.ladybird_json).to be nil
         expect(parent_object.aspace_json).not_to be nil
         expect(parent_object.aspace_json).not_to be_empty
         expect(parent_object.voyager_json).to be nil


### PR DESCRIPTION
If we already have a bib or aspace URL, don't pull metadata from ladybird.

This will happen for items we ingest through ladybird and then flip to ils/aspace (not necessarily bad to refetch, but not necessary) and for goobi import items that aren't in Ladybird (will cause error since OID doesn't exist in LB).