### PR TITLE
Expect before filling in with system test

### DIFF
--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Users', type: :system, js: true do
     it 'and require an email to be present' do
       visit users_path
       click_on('Edit')
+      expect(page).to have_content('Email')
       fill_in('Email', with: '')
       click_on('Update User')
 
@@ -35,6 +36,7 @@ RSpec.describe 'Users', type: :system, js: true do
     it 'and require their full name to be present' do
       visit users_path
       click_on('Edit')
+      expect(page).to have_content('First name')
       fill_in('First name', with: '')
       click_on('Update User')
 


### PR DESCRIPTION
Adjusts test to use expect() before fill_in() when clicking to another page.
This may cause the test browser to properly wait for the page to load before trying to fill_in the field, which fixes some failures.