### PR TITLE
1121 show user roles for adminset

### DIFF
--- a/app/assets/stylesheets/admin_sets.scss
+++ b/app/assets/stylesheets/admin_sets.scss
@@ -5,4 +5,9 @@
 .table {
   display: inline-block;
   width: auto;
+  vertical-align: top;
+
+  th {
+    width: 300px;
+  }
 }

--- a/app/assets/stylesheets/admin_sets.scss
+++ b/app/assets/stylesheets/admin_sets.scss
@@ -1,3 +1,8 @@
 // Place all the styles related to the AdminSets controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.table {
+  display: inline-block;
+  width: auto;
+}

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -5,4 +5,24 @@ class AdminSet < ApplicationRecord
   validates :label, presence: true
   validates :homepage, presence: true
   validates :homepage, format: URI.regexp(%w[http https])
+  attr_accessor :uid
+  attr_accessor :role
+
+  def add_viewer(user)
+    remove_editor(user) if user.editor(self)
+    user.add_role(:viewer, self)
+  end
+
+  def remove_viewer(user)
+    user.remove_role(:viewer)
+  end
+
+  def add_editor(user)
+    remove_viewer(user) if user.viewer(self)
+    user.add_role(:editor, self)
+  end
+
+  def remove_editor(user)
+    user.remove_role(:editor)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,28 +31,12 @@ class User < ApplicationRecord
     has_role?(:sysadmin)
   end
 
-  def editor=(value)
-    if value.present? && value && value != '0'
-      add_role :editor
-    else
-      remove_role :editor
-    end
+  def editor(admin_set)
+    has_role?(:editor, admin_set)
   end
 
-  def editor
-    has_role?(:editor)
-  end
-
-  def viewer=(value)
-    if value.present? && value && value != '0'
-      add_role :viewer
-    else
-      remove_role :viewer
-    end
-  end
-
-  def viewer
-    has_role?(:viewer)
+  def viewer(admin_set)
+    has_role?(:viewer, admin_set)
   end
 
   def deactivate!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,30 @@ class User < ApplicationRecord
     has_role?(:sysadmin)
   end
 
+  def editor=(value)
+    if value.present? && value && value != '0'
+      add_role :editor
+    else
+      remove_role :editor
+    end
+  end
+
+  def editor
+    has_role?(:editor)
+  end
+
+  def viewer=(value)
+    if value.present? && value && value != '0'
+      add_role :viewer
+    else
+      remove_role :viewer
+    end
+  end
+
+  def viewer
+    has_role?(:viewer)
+  end
+
   def deactivate!
     deactivate
     save!

--- a/app/views/admin_sets/_roles_tables.html.erb
+++ b/app/views/admin_sets/_roles_tables.html.erb
@@ -1,0 +1,33 @@
+<table class='table table-striped'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'> Viewers </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% User.all.each do |user| %>
+      <% if user.has_role?(:viewer, @admin_set) %>
+        <tr>
+          <td><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %> </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+
+<table class='table table-striped'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'> Editors </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% User.all.each do |user| %>
+      <% if user.has_role?(:editor, @admin_set) %>
+        <tr>
+          <td><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %> </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin_sets/_roles_tables.html.erb
+++ b/app/views/admin_sets/_roles_tables.html.erb
@@ -5,12 +5,10 @@
     </tr>
   </thead>
   <tbody>
-    <% User.all.each do |user| %>
-      <% if user.has_role?(:viewer, @admin_set) %>
-        <tr>
-          <td><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %> </td>
-        </tr>
-      <% end %>
+    <% User.with_role(:viewer, @admin_set).order('last_name ASC').each do |viewer| %>
+      <tr>
+        <td><%= "#{viewer.last_name}, #{viewer.first_name} (#{viewer.uid})" %> </td>
+      </tr>
     <% end %>
   </tbody>
 </table>
@@ -22,12 +20,10 @@
     </tr>
   </thead>
   <tbody>
-    <% User.all.each do |user| %>
-      <% if user.has_role?(:editor, @admin_set) %>
+    <% User.with_role(:editor, @admin_set).order('last_name ASC').each do |user| %>
         <tr>
           <td><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %> </td>
         </tr>
-      <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/admin_sets/show.html.erb
+++ b/app/views/admin_sets/show.html.erb
@@ -20,5 +20,9 @@
   <%= @admin_set.summary %>
 </p>
 
-<%= link_to 'Edit', edit_admin_set_path(@admin_set) %> |
-<%= link_to 'Back', admin_sets_path %>
+<%= render partial: "roles_tables" %>
+
+<p>
+  <%= link_to 'Edit', edit_admin_set_path(@admin_set) %> |
+  <%= link_to 'Back', admin_sets_path %>
+</p>

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe AdminSet, type: :model do
   let(:admin_set) { FactoryBot.create(:admin_set, key: "key", label: "label", homepage: "http://test.com") }
+  let(:user) { FactoryBot.create(:user) }
+
   it "returns proper values" do
     expect(admin_set.key).to eq "key"
     expect(admin_set.label).to eq "label"
@@ -13,5 +15,51 @@ RSpec.describe AdminSet, type: :model do
     expect(admin_set.valid?).to be_truthy
     admin_set.key = nil
     expect(admin_set.valid?).to be_falsey
+  end
+
+  describe "user roles" do
+    it "adds a viewer" do
+      expect(user.roles).to be_empty
+      admin_set.add_viewer(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("viewer")
+    end
+
+    it "removes a viewer" do
+      admin_set.add_viewer(user)
+      expect(user.roles.count).to eq(1)
+      admin_set.remove_viewer(user)
+      expect(user.roles.count).to eq(0)
+    end
+
+    it "adds an editor" do
+      expect(user.roles).to be_empty
+      admin_set.add_editor(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("editor")
+    end
+
+    it "removes an editor" do
+      admin_set.add_editor(user)
+      expect(user.roles.count).to eq(1)
+      admin_set.remove_editor(user)
+      expect(user.roles.count).to eq(0)
+    end
+
+    it "removes an editor when a viewer is added" do
+      admin_set.add_editor(user)
+      expect(user.roles.count).to eq(1)
+      admin_set.add_viewer(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("viewer")
+    end
+
+    it "removes a viewer when an editor is added" do
+      admin_set.add_viewer(user)
+      expect(user.roles.count).to eq(1)
+      admin_set.add_editor(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("editor")
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,6 +47,42 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'viewer property' do
+    it 'adds the viewer role when set to true' do
+      user.remove_role :viewer
+      user.viewer = true
+      expect(user.has_role?(:viewer)).to eq(true)
+    end
+    it 'removes the viewer role when set to false' do
+      user.add_role :viewer
+      user.viewer = false
+      expect(user.has_role?(:viewer)).to eq(false)
+    end
+    it 'removes the viewer role when set to 0' do
+      user.add_role :viewer
+      user.viewer = '0'
+      expect(user.has_role?(:viewer)).to eq(false)
+    end
+  end
+
+  describe 'editor property' do
+    it 'adds the editor role when set to true' do
+      user.remove_role :editor
+      user.editor = true
+      expect(user.has_role?(:editor)).to eq(true)
+    end
+    it 'removes the editor role when set to false' do
+      user.add_role :editor
+      user.editor = false
+      expect(user.has_role?(:editor)).to eq(false)
+    end
+    it 'removes the editor role when set to 0' do
+      user.add_role :editor
+      user.editor = '0'
+      expect(user.has_role?(:editor)).to eq(false)
+    end
+  end
+
   describe 'with validations' do
     it 'verifies that a new user has an email' do
       user2 = described_class.new(email: nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,42 +47,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'viewer property' do
-    it 'adds the viewer role when set to true' do
-      user.remove_role :viewer
-      user.viewer = true
-      expect(user.has_role?(:viewer)).to eq(true)
-    end
-    it 'removes the viewer role when set to false' do
-      user.add_role :viewer
-      user.viewer = false
-      expect(user.has_role?(:viewer)).to eq(false)
-    end
-    it 'removes the viewer role when set to 0' do
-      user.add_role :viewer
-      user.viewer = '0'
-      expect(user.has_role?(:viewer)).to eq(false)
-    end
-  end
-
-  describe 'editor property' do
-    it 'adds the editor role when set to true' do
-      user.remove_role :editor
-      user.editor = true
-      expect(user.has_role?(:editor)).to eq(true)
-    end
-    it 'removes the editor role when set to false' do
-      user.add_role :editor
-      user.editor = false
-      expect(user.has_role?(:editor)).to eq(false)
-    end
-    it 'removes the editor role when set to 0' do
-      user.add_role :editor
-      user.editor = '0'
-      expect(user.has_role?(:editor)).to eq(false)
-    end
-  end
-
   describe 'with validations' do
     it 'verifies that a new user has an email' do
       user2 = described_class.new(email: nil)

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
     expect(page).to have_content("admin-set-key")
   end
 
+  it 'displays the user roles tables' do
+    visit admin_sets_path
+    click_link('Show')
+    expect(page).to have_css('table', text: 'Viewers')
+    expect(page).to have_css('table', text: 'Editors')
+  end
+
   it "display admin edit form" do
     visit admin_sets_path
     click_link("Edit")


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1121

# Summary
- the admin set "show" page has a table to display all users with the role of "viewer"
- the admin set "show" page has a table to display all users with the role of "editor"

# Demo
| table with users | table without users |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/109727364-150eb500-7b69-11eb-8297-39e399b5840b.png) |  <img width="455" alt="image" src="https://user-images.githubusercontent.com/29032869/109727412-2b1c7580-7b69-11eb-86e4-59fb72decbde.png"> |

