### PR TITLE
Check for existing ptiff

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -137,7 +137,6 @@ class ChildObject < ApplicationRecord
   end
 
   def convert_to_ptiff!(force = false)
-    # setting the width to nil will force the PTIFF to be generated.
     pyramidal_tiff.force_update = force
     convert_to_ptiff && save!
   end

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -138,7 +138,7 @@ class ChildObject < ApplicationRecord
 
   def convert_to_ptiff!(force = false)
     # setting the width to nil will force the PTIFF to be generated.
-    self.width = nil if force
+    pyramidal_tiff.force_update = force
     convert_to_ptiff && save!
   end
 

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -12,7 +12,8 @@ class ChildObject < ApplicationRecord
   attr_accessor :current_batch_process
   attr_accessor :current_batch_connection
 
-  before_create :check_for_size_and_file
+  # Does not get called because we use upsert to create children
+  # before_create :check_for_size_and_file
 
   # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewinghint
   # These are added to the manifest on the canvas level

--- a/app/models/pyramidal_tiff.rb
+++ b/app/models/pyramidal_tiff.rb
@@ -5,7 +5,7 @@
 class PyramidalTiff
   include ActiveModel::Validations
 
-  attr_accessor :child_object, :conversion_information
+  attr_accessor :child_object, :conversion_information, :force_update
   validate :verify_and_generate
   delegate :access_master_path, :mets_access_master_path, :remote_access_master_path, :remote_ptiff_path, :oid, to: :child_object
 
@@ -27,12 +27,16 @@ class PyramidalTiff
     conversion_information
   end
 
+  def height_and_width?
+    child_object.height && child_object.width
+  end
+
   def verify_and_generate
     ptiff_info = { oid: oid.to_s }
     file_on_s3 = S3Service.s3_exists?(child_object.remote_ptiff_path)
-    child_object.check_for_size_and_file if !child_object.width.present? && file_on_s3
+    child_object.check_for_size_and_file if !height_and_width? && file_on_s3
     # do not do the image conversion if there is already a PTIFF on S3
-    if child_object.height && child_object.width && file_on_s3
+    if height_and_width? && !force_update && file_on_s3
       child_object.processing_event("PTIFF exists on S3, not converting: #{ptiff_info.to_json}", 'ptiff-ready-skipped')
       true
     else

--- a/app/models/pyramidal_tiff.rb
+++ b/app/models/pyramidal_tiff.rb
@@ -8,7 +8,7 @@ class PyramidalTiff
   attr_accessor :child_object, :conversion_information
   validate :verify_and_generate
   delegate :access_master_path, :mets_access_master_path, :remote_access_master_path, :remote_ptiff_path, :oid, to: :child_object
-  
+
   # This method takes the oid of a child_object and creates a new PyramidalTiff
   def initialize(child_object)
     @child_object = child_object
@@ -30,9 +30,7 @@ class PyramidalTiff
   def verify_and_generate
     ptiff_info = { oid: oid.to_s }
     file_on_s3 = S3Service.s3_exists?(child_object.remote_ptiff_path)
-    if !child_object.width.present? && file_on_s3
-      child_object.check_for_size_and_file
-    end    
+    child_object.check_for_size_and_file if !child_object.width.present? && file_on_s3
     # do not do the image conversion if there is already a PTIFF on S3
     if child_object.height && child_object.width && file_on_s3
       child_object.processing_event("PTIFF exists on S3, not converting: #{ptiff_info.to_json}", 'ptiff-ready-skipped')

--- a/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
+++ b/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe RecreateChildOidPtiffsJob, type: :job do
   end
   let(:user) { FactoryBot.create(:user) }
   let(:batch_process) { FactoryBot.create(:batch_process, user: user, batch_action: 'recreate child oid ptiffs') }
+  let(:other_batch_process) { FactoryBot.create(:batch_process, user: user, batch_action: 'other recreate child oid ptiffs') }
   let(:metadata_source) { FactoryBot.create(:metadata_source) }
   let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_004_628, authoritative_metadata_source: metadata_source) }
   let(:child_object) { FactoryBot.create(:child_object, oid: 456_789, parent_object: parent_object) }
   let(:recreate_child_oid_ptiffs_job) { RecreateChildOidPtiffsJob.new }
+  let(:generate_ptiff_job) { GeneratePtiffJob.new }
 
   around do |example|
     original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
@@ -36,10 +38,18 @@ RSpec.describe RecreateChildOidPtiffsJob, type: :job do
     it "has correct queue" do
       expect(recreate_child_oid_ptiffs_job.queue_name).to eq('default')
     end
-    it "can will create appropriate number of ptiff jobs when run" do
+    it "will create appropriate number of ptiff jobs when run" do
       expect do
         recreate_child_oid_ptiffs_job.perform(batch_process)
       end.to change { Delayed::Job.where(queue: 'ptiff').count }.by(1)
+    end
+    it "with recreate batch, will force ptiff creation" do
+      expect(child_object.pyramidal_tiff).to receive(:generate_ptiff).once
+      generate_ptiff_job.perform(child_object, batch_process)
+    end
+    it "another type of batch will not force ptiff creation" do
+      expect(child_object.pyramidal_tiff).not_to receive(:generate_ptiff)
+      generate_ptiff_job.perform(child_object, other_batch_process)
     end
   end
 end

--- a/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
+++ b/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
@@ -44,10 +44,12 @@ RSpec.describe RecreateChildOidPtiffsJob, type: :job do
       end.to change { Delayed::Job.where(queue: 'ptiff').count }.by(1)
     end
     it "with recreate batch, will force ptiff creation" do
-      expect(child_object.pyramidal_tiff).to receive(:generate_ptiff).once
+      expect(child_object.pyramidal_tiff).to receive(:original_file_exists?).and_return(true).once
+      expect(child_object.pyramidal_tiff).to receive(:generate_ptiff).and_return(true).once
       generate_ptiff_job.perform(child_object, batch_process)
     end
     it "another type of batch will not force ptiff creation" do
+      expect(child_object.pyramidal_tiff).not_to receive(:original_file_exists?)
       expect(child_object.pyramidal_tiff).not_to receive(:generate_ptiff)
       generate_ptiff_job.perform(child_object, other_batch_process)
     end


### PR DESCRIPTION
Since we started using upsert to insert new children, the code to check for existing PTIFFs on S3 has not been running.
This PR changes when we check S3 so that the PTIFF will not be regenerated if it exists on S3 and has w/h metadata.