### PR TITLE
Restrict access to global metadata functions

### DIFF
--- a/app/assets/stylesheets/batch_processes.scss
+++ b/app/assets/stylesheets/batch_processes.scss
@@ -20,3 +20,7 @@
     margin-left: 20px;
   }
 }
+
+.button-list form {
+  display: inline-block;
+}

--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -78,6 +78,7 @@ class BatchProcessesController < ApplicationController
 
   # This is temporary for testing until we enable scheduling
   def trigger_mets_scan
+    authorize!(:trigger_mets_scan, ParentObject)
     MetsDirectoryScanJob.perform_later
     respond_to do |format|
       format.html { redirect_to batch_processes_path, notice: 'Mets scan has been triggered.' }

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -73,6 +73,7 @@ class ParentObjectsController < ApplicationController
   end
 
   def reindex
+    authorize!(:reindex_all, ParentObject)
     ParentObject.solr_index
     respond_to do |format|
       format.html { redirect_to parent_objects_url, notice: 'Parent objects have been reindexed.' }
@@ -81,6 +82,7 @@ class ParentObjectsController < ApplicationController
   end
 
   def all_metadata
+    authorize!(:update_metadata, ParentObject)
     ParentObject.find_each do |po|
       po.metadata_update = true
       po.setup_metadata_job

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,5 +6,8 @@ class Ability
   def initialize(user)
     return unless user
     can :manage, User if user.has_role? :sysadmin
+    can :reindex_all, ParentObject if user.has_role? :sysadmin
+    can :update_metadata, ParentObject if user.has_role? :sysadmin
+    can :trigger_mets_scan, ParentObject if user.has_role? :sysadmin
   end
 end

--- a/app/views/batch_processes/index.html.erb
+++ b/app/views/batch_processes/index.html.erb
@@ -3,8 +3,8 @@
   <div class="row">
     <h1>Batch Processes</h1>
   </div>    
-  <div class="float-right">
-    <%= link_to 'Start Goobi Scan', trigger_mets_scan_batch_processes_path, method: 'post', class: 'btn btn-secondary' %>
+  <div class="float-right button-list">
+    <%= button_to 'Start Goobi Scan', trigger_mets_scan_batch_processes_path, method: 'post', class: 'btn btn-secondary', data:{confirm: "Are you sure you start a Goobi Scan?"}, disabled: !(can? :trigger_mets_scan, ParentObject)  %>
   </div>
   <div class='row'>
     <%= render 'form' %>

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -4,10 +4,10 @@
     <h1>Parent Objects</h1>
   </div>
   <div class='col'>
-    <div class='float-right'>
+    <div class='float-right button-list'>
       <%= link_to 'New Parent Object', new_parent_object_path, class: 'btn btn-primary' %>
-      <%= link_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn btn-secondary', id: 'reindex', data:{confirm: "Are you sure you want to proceed? This action will reindex the entire contents of the system."} %>
-      <%= link_to 'Update Metadata', all_metadata_parent_objects_path, method: 'post', class: 'btn btn-secondary',id: 'update_metadata', data:{confirm: "Are you sure you want to proceed?  This action will update metadata for the entire contents of the system."} %>
+      <%= button_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn btn-secondary', id: 'reindex', data:{confirm: "Are you sure you want to proceed? This action will reindex the entire contents of the system."}, disabled: !(can? :reindex_all, ParentObject) %>
+      <%= button_to 'Update Metadata', all_metadata_parent_objects_path, method: 'post', class: 'btn btn-secondary',id: 'update_metadata', data:{confirm: "Are you sure you want to proceed?  This action will update metadata for the entire contents of the system."}, disabled: !(can? :update_metadata, ParentObject) %>
     </div>
   </div>
 </div>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,5 +10,8 @@ FactoryBot.define do
     first_name { FFaker::Name.first_name }
     last_name { FFaker::Name.last_name }
     provider { "cas" }
+    factory :sysadmin_user do
+      after(:create) { |user| user.add_role(:sysadmin) }
+    end
   end
 end

--- a/spec/requests/batch_processes_request_spec.rb
+++ b/spec/requests/batch_processes_request_spec.rb
@@ -81,4 +81,28 @@ RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
       end
     end
   end
+
+  describe "POST /trigger_mets_scan" do
+    context "logged in with sysadmin" do
+      let(:user) { FactoryBot.create(:sysadmin_user) }
+      before do
+        login_as user
+      end
+
+      it "returns http success" do
+        post trigger_mets_scan_batch_processes_url
+        expect(response).to redirect_to(batch_processes_path)
+      end
+    end
+    context "logged in without sysadmin" do
+      let(:user) { FactoryBot.create(:user) }
+      before do
+        login_as user
+      end
+      it "returns http unauthorized" do
+        post trigger_mets_scan_batch_processes_url
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -14,7 +14,7 @@ require 'rails_helper'
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
 RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:sysadmin_user) }
   # ParentObject. As you add validations to ParentObject, be sure to
   # adjust the attributes here as well.
   before do
@@ -174,6 +174,27 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true do
       post update_metadata_parent_object_url(parent_object)
       expect(response).to redirect_to(parent_objects_url)
       expect(flash[:notice]).to eq('Parent object metadata update was queued.')
+    end
+  end
+
+  context 'without sys admin privileges' do
+    let(:user) { FactoryBot.create(:user) }
+    before do
+      login_as user
+    end
+
+    describe '#reindex' do
+      it 'is not allowed' do
+        post reindex_parent_objects_url
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe "#all_metadata" do
+      it 'is not allowed' do
+        post all_metadata_parent_objects_url
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:sysadmin_user) }
   before do
     stub_ptiffs_and_manifests
     login_as user
@@ -388,6 +388,20 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         click_on("Update Metadata")
         expect(page.driver.browser.switch_to.alert.text).to eq("Are you sure you want to proceed?  This action will update metadata for the entire contents of the system.")
         page.driver.browser.switch_to.alert.accept
+      end
+    end
+
+    context "logged in without sysadmin rights" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        login_as user
+        visit parent_objects_path
+      end
+
+      it "does not update metadata without confirmation" do
+        expect(page).to have_button('Update Metadata', disabled: true)
+        expect(page).to have_button('Reindex', disabled: true)
       end
     end
   end


### PR DESCRIPTION
Restricts Update Metadata, Reindex All, and Goobi Directory Scan functionality to sysadmin users using roles and cancancan.