### PR TITLE
Restrict adminset access to users with the sysadmin role

### DIFF
--- a/app/controllers/admin_sets_controller.rb
+++ b/app/controllers/admin_sets_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AdminSetsController < ApplicationController
+  load_and_authorize_resource
   before_action :set_admin_set, only: [:show, :edit, :update, :destroy]
 
   # GET /admin_sets

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
   def initialize(user)
     return unless user
     can :manage, User if user.has_role? :sysadmin
+    can :manage, AdminSet if user.has_role? :sysadmin
     can :reindex_all, ParentObject if user.has_role? :sysadmin
     can :update_metadata, ParentObject if user.has_role? :sysadmin
     can :trigger_mets_scan, ParentObject if user.has_role? :sysadmin

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -8,7 +8,6 @@
     <% if can? :manage,  AdminSet %>
       <%= link_to 'Sets', admin_sets_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% end  %>
-    <%#= link_to 'Sets', admin_sets_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Notifications', notifications_path, class: 'list-group-item list-group-item-action bg-light' %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -5,7 +5,10 @@
     <% if can? :manage, User %>
       <%= link_to 'Users', users_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% end  %>
-    <%= link_to 'Sets', admin_sets_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <% if can? :manage,  AdminSet %>
+      <%= link_to 'Sets', admin_sets_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <% end  %>
+    <%#= link_to 'Sets', admin_sets_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Notifications', notifications_path, class: 'list-group-item list-group-item-action bg-light' %>

--- a/spec/requests/admin_sets_spec.rb
+++ b/spec/requests/admin_sets_spec.rb
@@ -14,10 +14,9 @@ require 'rails_helper'
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
 RSpec.describe "/admin_sets", type: :request do
-  let(:user) { FactoryBot.create(:user) }
-  before do
-    login_as user
-  end
+  let(:sysadmin_user) { FactoryBot.create(:sysadmin_user, uid: 'johnsmith2530') }
+  let(:user) { FactoryBot.create(:user, uid: 'martinsmith2530') }
+
   # AdminSet. As you add validations to AdminSet, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) do
@@ -37,107 +36,133 @@ RSpec.describe "/admin_sets", type: :request do
     }
   end
 
-  describe "GET /index" do
-    it "renders a successful response" do
-      AdminSet.create! valid_attributes
-      get admin_sets_url
-      expect(response).to be_successful
+  context "when user has permission to Sets" do
+    before do
+      login_as sysadmin_user
     end
-  end
-
-  describe "GET /show" do
-    it "renders a successful response" do
-      admin_set = AdminSet.create! valid_attributes
-      get admin_set_url(admin_set)
-      expect(response).to be_successful
+    describe "GET /index" do
+      it "renders a successful response" do
+        AdminSet.create! valid_attributes
+        get admin_sets_url
+        expect(response).to be_successful
+      end
     end
-  end
 
-  describe "GET /new" do
-    it "renders a successful response" do
-      get new_admin_set_url
-      expect(response).to be_successful
+    describe "GET /show" do
+      it "renders a successful response" do
+        admin_set = AdminSet.create! valid_attributes
+        get admin_set_url(admin_set)
+        expect(response).to be_successful
+      end
     end
-  end
 
-  describe "GET /edit" do
-    it "render a successful response" do
-      admin_set = AdminSet.create! valid_attributes
-      get edit_admin_set_url(admin_set)
-      expect(response).to be_successful
+    describe "GET /new" do
+      it "renders a successful response" do
+        get new_admin_set_url
+        expect(response).to be_successful
+      end
     end
-  end
 
-  describe "POST /create" do
-    context "with valid parameters" do
-      it "creates a new AdminSet" do
-        expect do
+    describe "GET /edit" do
+      it "render a successful response" do
+        admin_set = AdminSet.create! valid_attributes
+        get edit_admin_set_url(admin_set)
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST /create" do
+      context "with valid parameters" do
+        it "creates a new AdminSet" do
+          expect do
+            post admin_sets_url, params: { admin_set: valid_attributes }
+          end.to change(AdminSet, :count).by(1)
+        end
+
+        it "redirects to the created admin_set" do
           post admin_sets_url, params: { admin_set: valid_attributes }
-        end.to change(AdminSet, :count).by(1)
+          expect(response).to redirect_to(admin_set_url(AdminSet.last))
+        end
       end
 
-      it "redirects to the created admin_set" do
-        post admin_sets_url, params: { admin_set: valid_attributes }
-        expect(response).to redirect_to(admin_set_url(AdminSet.last))
-      end
-    end
+      context "with invalid parameters" do
+        it "does not create a new AdminSet" do
+          expect do
+            post admin_sets_url, params: { admin_set: invalid_attributes }
+          end.to change(AdminSet, :count).by(0)
+        end
 
-    context "with invalid parameters" do
-      it "does not create a new AdminSet" do
-        expect do
+        it "renders a successful response (i.e. to display the 'new' template)" do
           post admin_sets_url, params: { admin_set: invalid_attributes }
-        end.to change(AdminSet, :count).by(0)
-      end
-
-      it "renders a successful response (i.e. to display the 'new' template)" do
-        post admin_sets_url, params: { admin_set: invalid_attributes }
-        expect(response).to be_successful
-      end
-    end
-  end
-
-  describe "PATCH /update" do
-    context "with valid parameters" do
-      let(:new_attributes) do
-        skip("Add a hash of attributes valid for your model")
-      end
-
-      it "updates the requested admin_set" do
-        admin_set = AdminSet.create! valid_attributes
-        patch admin_set_url(admin_set), params: { admin_set: new_attributes }
-        admin_set.reload
-        skip("Add assertions for updated state")
-      end
-
-      it "redirects to the admin_set" do
-        admin_set = AdminSet.create! valid_attributes
-        patch admin_set_url(admin_set), params: { admin_set: new_attributes }
-        admin_set.reload
-        expect(response).to redirect_to(admin_set_url(admin_set))
+          expect(response).to be_successful
+        end
       end
     end
 
-    context "with invalid parameters" do
-      it "renders a successful response (i.e. to display the 'edit' template)" do
-        admin_set = AdminSet.create! valid_attributes
-        patch admin_set_url(admin_set), params: { admin_set: invalid_attributes }
-        expect(response).to be_successful
+    describe "PATCH /update" do
+      context "with valid parameters" do
+        let(:new_attributes) do
+          skip("Add a hash of attributes valid for your model")
+        end
+
+        it "updates the requested admin_set" do
+          admin_set = AdminSet.create! valid_attributes
+          patch admin_set_url(admin_set), params: { admin_set: new_attributes }
+          admin_set.reload
+          skip("Add assertions for updated state")
+        end
+
+        it "redirects to the admin_set" do
+          admin_set = AdminSet.create! valid_attributes
+          patch admin_set_url(admin_set), params: { admin_set: new_attributes }
+          admin_set.reload
+          expect(response).to redirect_to(admin_set_url(admin_set))
+        end
+      end
+
+      context "with invalid parameters" do
+        it "renders a successful response (i.e. to display the 'edit' template)" do
+          admin_set = AdminSet.create! valid_attributes
+          patch admin_set_url(admin_set), params: { admin_set: invalid_attributes }
+          expect(response).to be_successful
+        end
       end
     end
-  end
 
-  describe "DELETE /destroy" do
-    it "destroys the requested admin_set" do
-      admin_set = AdminSet.create! valid_attributes
-      expect do
+    describe "DELETE /destroy" do
+      it "destroys the requested admin_set" do
+        admin_set = AdminSet.create! valid_attributes
+        expect do
+          delete admin_set_url(admin_set)
+        end.to change(AdminSet, :count).by(-1)
+      end
+
+      it "redirects to the admin_sets list" do
+        admin_set = AdminSet.create! valid_attributes
         delete admin_set_url(admin_set)
-      end.to change(AdminSet, :count).by(-1)
+        expect(response).to redirect_to(admin_sets_url)
+      end
+    end
+  end
+
+  context "when user does not permission to Sets" do
+    before do
+      login_as user
+    end
+    describe "GET /index" do
+      it "renders an unauthorized message" do
+        AdminSet.create! valid_attributes
+        get admin_sets_url
+        expect(response).to be_unauthorized
+      end
     end
 
-    it "redirects to the admin_sets list" do
-      admin_set = AdminSet.create! valid_attributes
-      delete admin_set_url(admin_set)
-      expect(response).to redirect_to(admin_sets_url)
+    describe "GET /show" do
+      it "renders an unauthorized message" do
+        admin_set = AdminSet.create! valid_attributes
+        get admin_set_url(admin_set)
+        expect(response).to be_unauthorized
+      end
     end
   end
 end

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -3,93 +3,116 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Sets', type: :system, js: true do
   let(:admin_set) { FactoryBot.create(:admin_set, key: "admin-set-key", label: "admin-set-label", homepage: "http://admin-set-homepage.com") }
-  let(:user) { FactoryBot.create(:user, uid: 'johnsmith2530') }
+  let(:sysadmin_user) { FactoryBot.create(:sysadmin_user, uid: 'johnsmith2530') }
+  let(:user) { FactoryBot.create(:user, uid: 'martinsmith2530') }
 
   before do
     admin_set
-    login_as user
   end
 
-  it "display admin sets" do
-    visit admin_sets_path
-    expect(page).to have_content("admin-set-key")
-  end
-
-  it 'displays the user roles tables' do
-    visit admin_sets_path
-    click_link('Show')
-    expect(page).to have_css('table', text: 'Viewers')
-    expect(page).to have_css('table', text: 'Editors')
-  end
-
-  it "display admin edit form" do
-    visit admin_sets_path
-    within "tr#admin_set_#{admin_set.id}" do
-      click_link("Edit")
+  context "when user has permission to Sets" do
+    before do
+      login_as sysadmin_user
     end
-    expect(find_field('Key').value).to eq('admin-set-key')
-    expect(find_field('Label').value).to eq('admin-set-label')
-    expect(find_field('Homepage').value).to eq('http://admin-set-homepage.com')
-  end
+    it "display admin sets" do
+      visit admin_sets_path
+      expect(page).to have_content("admin-set-key")
+    end
 
-  it "allow editing using form" do
-    visit edit_admin_set_path(admin_set)
-    expect(find_field('Key').value).to eq('admin-set-key')
-    expect(find_field('Label').value).to eq('admin-set-label')
-    expect(find_field('Homepage').value).to eq('http://admin-set-homepage.com')
-    fill_in('Label', with: 'admin-set2-label')
-    click_on("Update Admin Set")
-    expect(page).to have_content("admin-set2-label")
-    expect(page).to have_content("Admin set was successfully updated.")
-  end
+    it 'displays the user roles tables' do
+      visit admin_sets_path
+      click_link('Show')
+      expect(page).to have_css('table', text: 'Viewers')
+      expect(page).to have_css('table', text: 'Editors')
+    end
 
-  it "allow new using form" do
-    visit admin_sets_path
-    click_on("New Admin Set")
-    fill_in('Key', with: 'admin-set3-key')
-    fill_in('Label', with: 'admin-set3-label')
-    fill_in('Homepage', with: 'http://admin-set3-homepage.com')
-    click_on("Create Admin Set")
-    expect(page).to have_content("Admin set was successfully created.")
-    expect(page).to have_content("admin-set3-key")
-    expect(page).to have_content("admin-set3-label")
-    expect(page).to have_content("http://admin-set3-homepage.com")
-  end
+    it "display admin edit form" do
+      visit admin_sets_path
+      within "tr#admin_set_#{admin_set.id}" do
+        click_link("Edit")
+      end
+      expect(find_field('Key').value).to eq('admin-set-key')
+      expect(find_field('Label').value).to eq('admin-set-label')
+      expect(find_field('Homepage').value).to eq('http://admin-set-homepage.com')
+    end
 
-  it "create fails with invalid url" do
-    visit admin_sets_path
-    click_on("New Admin Set")
-    fill_in('Key', with: 'admin-set3-key')
-    fill_in('Label', with: 'admin-set3-label')
-    fill_in('Homepage', with: 'h99ttp://admin-set3-homepage.com')
-    click_on("Create Admin Set")
-    expect(page).to have_content("error prohibited this admin_set from being saved:\nHomepage is invalid")
-    expect(find_field('Key').value).to eq('admin-set3-key')
-    expect(find_field('Label').value).to eq('admin-set3-label')
-  end
+    it "allow editing using form" do
+      visit edit_admin_set_path(admin_set)
+      expect(find_field('Key').value).to eq('admin-set-key')
+      expect(find_field('Label').value).to eq('admin-set-label')
+      expect(find_field('Homepage').value).to eq('http://admin-set-homepage.com')
+      fill_in('Label', with: 'admin-set2-label')
+      click_on("Update Admin Set")
+      expect(page).to have_content("admin-set2-label")
+      expect(page).to have_content("Admin set was successfully updated.")
+    end
 
-  it "create does not submit with missing label" do
-    visit admin_sets_path
-    click_on("New Admin Set")
-    fill_in('Key', with: 'admin-set3-key')
-    fill_in('Homepage', with: 'http://admin-set3-homepage.com')
-    click_on("Create Admin Set")
-    expect(page).to have_content("New Admin Set")
-    page.evaluate_script("document.activeElement.id") == "admin_set_key"
-  end
+    it "allow new using form" do
+      visit admin_sets_path
+      click_on("New Admin Set")
+      fill_in('Key', with: 'admin-set3-key')
+      fill_in('Label', with: 'admin-set3-label')
+      fill_in('Homepage', with: 'http://admin-set3-homepage.com')
+      click_on("Create Admin Set")
+      expect(page).to have_content("Admin set was successfully created.")
+      expect(page).to have_content("admin-set3-key")
+      expect(page).to have_content("admin-set3-label")
+      expect(page).to have_content("http://admin-set3-homepage.com")
+    end
 
-  it "edit fails with invalid url" do
-    visit edit_admin_set_path(admin_set)
-    fill_in('Homepage', with: 'h99ttp://admin-set3-homepage.com')
-    click_on("Update Admin Set")
-    expect(page).to have_content("error prohibited this admin_set from being saved:\nHomepage is invalid")
-  end
+    it "create fails with invalid url" do
+      visit admin_sets_path
+      click_on("New Admin Set")
+      fill_in('Key', with: 'admin-set3-key')
+      fill_in('Label', with: 'admin-set3-label')
+      fill_in('Homepage', with: 'h99ttp://admin-set3-homepage.com')
+      click_on("Create Admin Set")
+      expect(page).to have_content("error prohibited this admin_set from being saved:\nHomepage is invalid")
+      expect(find_field('Key').value).to eq('admin-set3-key')
+      expect(find_field('Label').value).to eq('admin-set3-label')
+    end
 
-  it "edit does not submit with missing label" do
-    visit edit_admin_set_path(admin_set)
-    fill_in('Key', with: '')
-    click_on("Update Admin Set")
-    expect(page).to have_content("Editing Admin Set")
-    page.evaluate_script("document.activeElement.id") == "admin_set_key"
+    it "create does not submit with missing label" do
+      visit admin_sets_path
+      click_on("New Admin Set")
+      fill_in('Key', with: 'admin-set3-key')
+      fill_in('Homepage', with: 'http://admin-set3-homepage.com')
+      click_on("Create Admin Set")
+      expect(page).to have_content("New Admin Set")
+      page.evaluate_script("document.activeElement.id") == "admin_set_key"
+    end
+
+    it "edit fails with invalid url" do
+      visit edit_admin_set_path(admin_set)
+      fill_in('Homepage', with: 'h99ttp://admin-set3-homepage.com')
+      click_on("Update Admin Set")
+      expect(page).to have_content("error prohibited this admin_set from being saved:\nHomepage is invalid")
+    end
+
+    it "edit does not submit with missing label" do
+      visit edit_admin_set_path(admin_set)
+      fill_in('Key', with: '')
+      click_on("Update Admin Set")
+      expect(page).to have_content("Editing Admin Set")
+      page.evaluate_script("document.activeElement.id") == "admin_set_key"
+    end
+
+    it "the label appears on the slide bar" do
+      visit root_path
+      expect(page).to have_link('Sets')
+    end
+  end
+  context "when user does not have permission to Sets" do
+    before do
+      login_as user
+    end
+    it "the label does not appear on the slide bar" do
+      visit root_path
+      expect(page).to have_no_link('Sets')
+    end
+    it "display not not have admin sets" do
+      visit admin_sets_path
+      expect(page).to have_content("Access denied")
+    end
   end
 end


### PR DESCRIPTION
co-authored-by: Martin Lovell <martin.lovell@yale.edu>

**Story**

For now, we want to restrict the management of AdminSets to sysadmins.   Sysadmins will have the ability to create new sets and grant users roles on those sets.

**Acceptance**
- [x] Only users with the sysadmin role can access/update AdminSets
- [x] The "Sets" left menu option is displayed only if the logged-in user has the sysadmin role

**Notes**
See #1090 for an example of this with Users.

**Before Code Modification**
![Screen Shot 2021-03-05 at 10 33 18 AM](https://user-images.githubusercontent.com/41123693/110136906-3f958380-7d9e-11eb-83d5-6863c42e0945.png)

**After Code Modification**
![image](https://user-images.githubusercontent.com/41123693/110137314-b468bd80-7d9e-11eb-9b9b-d497540b3a27.png)

