### PR TITLE
Add Set to edit and show page for parent objects

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -127,8 +127,10 @@ class ParentObjectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def parent_object_params
-      params.require(:parent_object).permit(:oid, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
-                                            :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
-                                            :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization)
+      cur_params = params.require(:parent_object).permit(:oid, :admin_set, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
+                                                         :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
+                                                         :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization)
+      cur_params[:admin_set] = AdminSet.where(key: cur_params[:admin_set]).first if cur_params[:admin_set]
+      cur_params
     end
 end

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -17,6 +17,17 @@
     </div>
 
     <div class="col-med-3">
+      <%= form.label "Set" %>
+      <%= form.select(:admin_set,
+                  AdminSet.all.map { |admin_set|
+                    [admin_set.label, admin_set.key]
+                  } << ["None",nil],
+                  selected: parent_object.admin_set&.key || ["None", nil]
+          )
+       %>
+    </div>
+
+    <div class="col-med-3">
       <%= form.label "Metadata Source" %>
       <%= form.select(:authoritative_metadata_source_id, [['Ladybird', 1], ['Voyager', 2], ['ArchiveSpace', 3]]) %>
     </div>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -6,6 +6,11 @@
 </p>
 
 <p>
+  <strong>Set:</strong>
+  <%= @parent_object.admin_set&.label %>
+</p>
+
+<p>
   <strong>MetadataCloud url:</strong><br>
   <small>Note: add "&mediaType=json" or "?mediaType=json" to open in your browser</small><br>
   <%= link_to "#{@parent_object.metadata_cloud_url}", "#{@parent_object.metadata_cloud_url}" %>

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true do
         expect(page.body).to include "Yale Community Only"
       end
 
+      it "can change the Admin Set via the UI", prep_admin_sets: true do
+        visit parent_object_path(2_012_036)
+        click_on("Edit")
+        select 'Sterling', from: "parent_object[admin_set]"
+        click_on("Update Parent object")
+
+        visit parent_object_path(2_012_036)
+        expect(page).to have_content "Sterling"
+      end
+
       it "includes the rights statment" do
         within("div.rights-statement") do
           expect(page).to have_content("The use of this image may be subject to the")


### PR DESCRIPTION
**Acceptance**

- [x] When displaying a ParentObject, list the "Set:" and set's label immediately beneath the OID (where the orange line is)
![Screen Shot 2021-02-28 at 5.17.49 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/af6cfc57-e098-48d4-ad2b-215cf35a7090)

- [x] On the edit page, the user should be able to select a set from  a drop down next to the OID.  For now, we will just display a list of all of the sets.  Again, the label should just be "Set".