### PR TITLE
Reindex all in batches

### DIFF
--- a/app/jobs/solr_reindex_all_job.rb
+++ b/app/jobs/solr_reindex_all_job.rb
@@ -3,21 +3,21 @@
 class SolrReindexAllJob < ApplicationJob
   queue_as :solr_index
 
-  def job_limit
+  def self.job_limit
     5000
   end
 
-  def solr_batch_limit
+  def self.solr_batch_limit
     500
   end
 
   def perform(start_position = 0)
     solr = SolrService.connection
     # Groups of limit
-    parent_objects = ParentObject.order(:oid).offset(start_position).limit(job_limit)
-    last_job = parent_objects.count < job_limit
+    parent_objects = ParentObject.order(:oid).offset(start_position).limit(SolrReindexAllJob.job_limit)
+    last_job = parent_objects.count < SolrReindexAllJob.job_limit
     if parent_objects.count.positive?
-      parent_objects.each_slice(solr_batch_limit) do |parent_objects_group|
+      parent_objects.each_slice(SolrReindexAllJob.solr_batch_limit) do |parent_objects_group|
         solr.add(parent_objects_group.map(&:to_solr).compact)
         solr.commit
       end

--- a/spec/jobs/solr_reindex_all_job_spec.rb
+++ b/spec/jobs/solr_reindex_all_job_spec.rb
@@ -3,17 +3,56 @@
 require 'rails_helper'
 
 RSpec.describe SolrReindexAllJob, type: :job, prep_metadata_sources: true, solr: true do
-  def queue_adapter_for_test
-    ActiveJob::QueueAdapters::DelayedJobAdapter.new
-  end
-
   let(:parent_object) { FactoryBot.build(:parent_object, oid: '16797069') }
 
-  it 'increments the job queue by one' do
-    parent_object
-    ActiveJob::Base.queue_adapter = :delayed_job
-    expect do
+  context 'with tests active job queue' do
+    def queue_adapter_for_test
+      ActiveJob::QueueAdapters::DelayedJobAdapter.new
+    end
+
+    it 'increments the job queue by one' do
+      parent_object
+      ActiveJob::Base.queue_adapter = :delayed_job
+      expect do
+        SolrReindexAllJob.perform_later
+      end.to change { Delayed::Job.count }.by(1)
+    end
+  end
+
+  context 'with more than limit parent objects' do
+    before do
+      limit = SolrReindexAllJob.job_limit
+      solr_limit = SolrReindexAllJob.solr_batch_limit
+      total_records = 8000 #  some number > SolrReindexAllJob.job_limit < SolrReindexAllJob.job_limit * 2
+
+      # create mocks for everything the job uses
+      solr_service = double
+      expect(SolrService).to receive(:connection).and_return(solr_service).twice
+      expect(SolrService).to receive(:clean_index_orphans).once
+      expect(solr_service).to receive(:add).exactly(total_records / solr_limit).times
+      expect(solr_service).to receive(:commit).exactly(total_records / solr_limit).times
+
+      doc = double
+      expect(doc).to receive(:to_solr).exactly(total_records).times
+
+      parent_object_order = double
+      parent_object_order_offset1 = double
+      parent_object_order_offset2 = double
+      expect(ParentObject).to receive(:order).and_return(parent_object_order).exactly((total_records.to_f / limit).ceil).times
+      expect(parent_object_order).to receive(:offset).with(0).and_return parent_object_order_offset1
+      expect(parent_object_order).to receive(:offset).with(limit).and_return parent_object_order_offset2
+      expect(parent_object_order_offset1).to receive(:limit).with(limit).and_return [*1..limit].map { |_ix| doc }
+      expect(parent_object_order_offset2).to receive(:limit).with(limit).and_return [*1..(total_records - limit)].map { |_ix| doc }
+    end
+
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
+
+    it 'goes through all parents in batches' do
       SolrReindexAllJob.perform_later
-    end.to change { Delayed::Job.count }.by(1)
+    end
   end
 end


### PR DESCRIPTION
Ordering by OID when taking chunks since it's indexed.
It's possible a parent with an out-of-sequence OID could be ingested after the first job starts and get skipped, but that one is already re-indexed since it was just ingested, so it should be ok.