### PR TITLE
1137 respect permissions when creating batch jobs

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -104,7 +104,6 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         fresh = true
       end
       next if fresh
-      next unless user_update_parent_permission(index, po)
 
       po.metadata_update = true
       po.admin_set = admin_set
@@ -161,19 +160,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def user_create_permission(index, admin_set, oid)
     user = self.user
     unless user.has_role?(:editor, admin_set)
-      batch_processing_event("Skipping row [#{index}] because #{user.uid} does not have permission to create parent: #{oid}", 'Permission Denied')
-      return false
-    end
-
-    true
-  end
-
-  def user_update_parent_permission(index, parent_object)
-    user = self.user
-    unless current_ability.can? :update, parent_object
-      attach_item(parent_object)
-      batch_processing_event("Skipping row [#{index}] because #{user.uid} does not have permission to update parent: #{parent_object.oid}", 'Skipped Row')
-      parent_object.processing_event("#{user.uid} does not have permission to update parent: #{parent_object.oid}", 'Permission Denied')
+      batch_processing_event("Skipping row [#{index}] because #{user.uid} does not have permission to create or update parent: #{oid}", 'Permission Denied')
       return false
     end
 

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -144,7 +144,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
       configure_parent_object(child_object, parents)
       attach_item(child_object)
-      next unless user_update_permission(child_object, child_object.parent_object)
+      next unless user_update_child_permission(child_object, child_object.parent_object)
 
       GeneratePtiffJob.perform_later(child_object, self)
       attach_item(child_object)
@@ -163,12 +163,12 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     parents
   end
 
-  def user_update_permission(child_object, parent_object)
+  def user_update_child_permission(child_object, parent_object)
     user = self.user
     unless current_ability.can? :update, child_object
       batch_processing_event("#{user.uid} does not have permission to update Child: #{child_object.oid} on Parent: #{child_object.parent_object.oid}", 'Permission Denied')
-      child_object.processing_event("#{user.uid} does not have permission to update Child: #{child_object.oid}", 'failed')
-      parent_object.processing_event("#{user.uid} does not have permission to update Child: #{child_object.oid}", 'failed')
+      child_object.processing_event("#{user.uid} does not have permission to update Child: #{child_object.oid}", 'Permission Denied')
+      parent_object.processing_event("#{user.uid} does not have permission to update Child: #{child_object.oid}", 'Permission Denied')
       return false
     end
 

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -19,7 +19,7 @@ module Reassociatable
 
       attach_item(po)
       attach_item(co)
-      next unless user_update_permission(co, po)
+      next unless user_update_child_permission(co, po)
 
       parents_needing_update << co.parent_object.oid
       parents_needing_update << row["parent_oid"].to_i

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -136,20 +136,20 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
         expect(parent_object.batch_processes).to include(batch_process)
       end
 
-      it 'calls the user_update_permission method and returns false if the user does not have editor permissions on the admin set' do
+      it 'calls the user_update_child_permission method and returns false if the user does not have editor permissions on the admin set' do
         parents = Set[]
         batch_process.configure_parent_object(child_object, parents)
         batch_process.attach_item(child_object)
         expect do
-          batch_process.user_update_permission(child_object, child_object.parent_object)
+          batch_process.user_update_child_permission(child_object, child_object.parent_object)
         end.to change { IngestEvent.count }.by(3)
 
-        expect(batch_process.user_update_permission(child_object, parent_object)).to eq(false)
+        expect(batch_process.user_update_child_permission(child_object, parent_object)).to eq(false)
       end
 
-      it 'calls the user_update_permission method and returns true if the user does have editor permission on the admin set' do
+      it 'calls the user_update_child_permission method and returns true if the user does have editor permission on the admin set' do
         user.add_role(:editor, admin_set)
-        expect(batch_process.user_update_permission(child_object, parent_object)).to eq(true)
+        expect(batch_process.user_update_child_permission(child_object, parent_object)).to eq(true)
       end
     end
 


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>
Co-author: Martin Lovell <martin.lovell@yale.edu>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1137

# Expected behavior
- users with an editor role on an admin set can create or update parent objects for that set using the "create parent objects" action
- users without an editor role on an admin set cannot create or update parent objects for that set using the "create parent objects" action
- if a csv has oids with various admin sets, only the sets where the user is an editor will be created/updated
- for failed uploads, there will be an ingest error noted on the batch process detail page

# Demo
https://user-images.githubusercontent.com/29032869/111508394-e6681100-8708-11eb-938a-840234ed52bc.mp4