### PR TITLE
1166 default users to ascending order

### DIFF
--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -14,7 +14,7 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      netid: { source: "User.uid", cond: :like, searchable: true, orderable: true },
+      netid: { source: "User.uid", cond: :like, searchable: true, orderable: true, options: [{ order: 'asc' }] },
       email: { source: "User.email", cond: :like, searchable: true, orderable: true },
       first_name: { source: "User.first_name", cond: :like, searchable: true, orderable: true },
       last_name: { source: "User.last_name", cond: :like, searchable: true, orderable: true },

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -44,7 +44,6 @@ $( document ).on('turbolinks:load', function() {
       },
       "pagingType": "full_numbers",
       "columns": columns,
-      // This will order all datatables by the first column descending
       "order": columnOrder(columns),
       "lengthMenu": [[50, 100, 500, -1], [50, 100, 500, "All"]],
       "sDom":hasSearch?'lrtip':'<"row"<"col-sm-12 col-md-6"l><"col-sm-12 col-md-6"f>>rtip',
@@ -110,22 +109,13 @@ let scheduleDraw = function() {
 let triggerDraw = function() {
   clearInterval(drawTimer);
   drawTimer = 0;
-  dataTable.api().draw();  
+  dataTable.api().draw();
 }
 
-let columnOrder = function(columns) {
-  let index = 0
-  let colDef = columns[index++]
-  console.log(colDef)
-  if(colDef.options==null){
-    return [[0, "desc"]]
-  } else {
-    colDef.options.map(function (option) {
-      if(option.order==="asc"){
-        [[0, "asc"]]
-      } else {
-        [[0, "desc"]]
-      } 
-    })
-  }
+// This will order all datatables by the first column descending
+// unless the first column has a value of "options: [{ order: 'asc' }]"
+const columnOrder = (columns) => {
+  return columns[0].options === null
+    ? [[0, 'desc']]
+    : [[0, 'asc']]
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -45,7 +45,7 @@ $( document ).on('turbolinks:load', function() {
       "pagingType": "full_numbers",
       "columns": columns,
       // This will order all datatables by the first column descending
-      "order": [[0, "desc"]],
+      "order": columnOrder(columns),
       "lengthMenu": [[50, 100, 500, -1], [50, 100, 500, "All"]],
       "sDom":hasSearch?'lrtip':'<"row"<"col-sm-12 col-md-6"l><"col-sm-12 col-md-6"f>>rtip',
       // pagingType is optional, if you want full pagination controls.
@@ -111,4 +111,21 @@ let triggerDraw = function() {
   clearInterval(drawTimer);
   drawTimer = 0;
   dataTable.api().draw();  
+}
+
+let columnOrder = function(columns) {
+  let index = 0
+  let colDef = columns[index++]
+  console.log(colDef)
+  if(colDef.options==null){
+    return [[0, "desc"]]
+  } else {
+    colDef.options.map(function (option) {
+      if(option.order==="asc"){
+        [[0, "asc"]]
+      } else {
+        [[0, "desc"]]
+      } 
+    })
+  }
 }


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1166

# Expected behavior
- The users datatable is ordered in ascending order by netid
- All other datatables are still ordered in descending order

# Demo
| Users | Batch Process |
|---|---|
|![Screen Shot 2021-03-17 at 4 16 17 PM](https://user-images.githubusercontent.com/50561476/111550922-5b087300-873c-11eb-8ac1-b8d63888b990.png)|![Screen Shot 2021-03-17 at 4 16 54 PM](https://user-images.githubusercontent.com/50561476/111550943-6196ea80-873c-11eb-8bc9-7e5ae009865d.png)|

