### PR TITLE
Verify that a User has access to Admin Set for editing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/MethodLength:
 Metrics/ClassLength:
     Exclude:
       - 'app/models/iiif_presentation.rb'
+      - 'app/controllers/parent_objects_controller.rb'
 
 Rails/OutputSafety:
   Exclude:

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -58,7 +58,10 @@ class ParentObjectsController < ApplicationController
   # PATCH/PUT /parent_objects/1.json
   def update
     respond_to do |format|
-      if @parent_object.update(parent_object_params)
+      invalidate_admin_set_edit unless valid_admin_set_edit?
+      updated = valid_admin_set_edit? ? @parent_object.update(parent_object_params) : false
+
+      if updated
         format.html { redirect_to @parent_object, notice: 'Parent object was successfully updated.' }
         format.json { render :show, status: :ok, location: @parent_object }
       else
@@ -123,6 +126,14 @@ class ParentObjectsController < ApplicationController
   end
 
   private
+
+    def valid_admin_set_edit?
+      !parent_object_params[:admin_set] || (parent_object_params[:admin_set] && current_user.editor(parent_object_params[:admin_set]))
+    end
+
+    def invalidate_admin_set_edit
+      @parent_object.errors.add :admin_set, :invalid, message: "cannot be assigned to a set the User cannot edit"
+    end
 
     # Use callbacks to share common setup or constraints between actions.
     def set_parent_object

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -461,7 +461,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   context "when logged in with access to only some admin set roles", js: true do
     let(:user) { FactoryBot.create(:user) }
     let(:admin_set) { FactoryBot.create(:admin_set, key: "adminset") }
-    let(:admin_set2) { FactoryBot.create(:admin_set, key: "adminset2") }
+    let(:admin_set2) { FactoryBot.create(:admin_set, key: "adminset2", label: "AdminSet2") }
     let(:parent_object1) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
     let(:parent_object2) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
     let(:parent_object_no_access) { FactoryBot.create(:parent_object, oid: "2004549", admin_set_id: admin_set2.id) }
@@ -503,6 +503,14 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
     it "does not allow viewing of the child object the user does not has access to" do
       visit edit_parent_object_path("2004549")
       expect(page).to have_content("Access denied")
+    end
+
+    it "does not allow changing parent_object to admin_set user does not have access to" do
+      visit edit_parent_object_path("2002826")
+      select 'AdminSet2', from: "parent_object[admin_set]"
+      click_on("Update Parent object")
+
+      expect(page).to have_content "Admin set cannot be assigned to a set the User cannot edit"
     end
   end
 end


### PR DESCRIPTION
# Info #
Access restrictions do prevent updating a parent object to which the user does not have access.
However, it's possible to edit a parent object the user does have access to and assign it an AdminSet that the user does NOT have access to.

# Acceptance #
- [ ] User cannot give an admin set that they are not an editor of to Parent Objects