### PR TITLE
1117-restrict-delayed-job-access-to-sysadmins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
     render plain: "Access denied", status: 401
   end
 
+  def access_denied
+    render(plain: 'Access denied', status: 401)
+  end
+
   protected
 
     def authenticate_user!

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -11,7 +11,9 @@
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Notifications', notifications_path, class: 'list-group-item list-group-item-action bg-light' %>
-    <%= link_to 'Delayed Job Dashboard', delayed_job_web_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <% if current_user&.sysadmin %>
+      <%= link_to 'Delayed Job Dashboard', delayed_job_web_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <% end %>
     <% if current_user %>
       <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'list-group-item list-group-item-action bg-light' %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   get 'api/oid/new(/:number)', to: 'oid_minter#generate_oids', as: :new_oid
 
-  authenticated :user do
+  authenticated :user, -> user { user.sysadmin } do
     mount DelayedJobWeb, at: "/delayed_job"
   end
   # fall back if not authenticated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get 'api/oid/new(/:number)', to: 'oid_minter#generate_oids', as: :new_oid
 
   devise_scope :user do
-    authenticated :user, -> user { user.sysadmin } do
+    authenticated :user, ->(user) { user.sysadmin } do
       mount DelayedJobWeb, at: '/delayed_job'
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,9 +50,16 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   get 'api/oid/new(/:number)', to: 'oid_minter#generate_oids', as: :new_oid
 
-  authenticated :user, -> user { user.sysadmin } do
-    mount DelayedJobWeb, at: "/delayed_job"
+  devise_scope :user do
+    authenticated :user, -> user { user.sysadmin } do
+      mount DelayedJobWeb, at: '/delayed_job'
+    end
+
+    authenticated :user do
+      get '/*delayed_job', to: 'application#access_denied'
+    end
   end
+
   # fall back if not authenticated
   get '/delayed_job', to: redirect('/management/users/auth/cas')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     end
 
     authenticated :user do
+      # authenticated user without the sysadmin role
       get '/*delayed_job', to: 'application#access_denied'
     end
   end

--- a/spec/system/delayed_job_spec.rb
+++ b/spec/system/delayed_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Delayed Jobs', type: :system, js: true do
+  let(:sysadmin_user) { FactoryBot.create(:sysadmin_user) }
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'as a logged out visitor' do
+    it 'are inaccessible through the delayed jobs dashboard menu item' do
+      visit root_path
+      expect(page).not_to have_content('Delayed Job Dashboard')
+    end
+    # TODO(alishaevn): figure out why this spec is failing
+    xit 'are inaccessible manually through the delayed jobs endpoint' do
+      visit delayed_job_web_path
+      # visit delayed_job_path
+      # byebug
+      # this spec keeps failing with:
+      # ActionController::RoutingError: No route matches [GET] "/management/users/auth/cas"
+      expect(current_path).to eq(user_cas_omniauth_authorize_path)
+      expect(page).to have_content('Not found. Authentication passthru.')
+    end
+  end
+
+  context 'as a logged in user who is not a sysadmin' do
+    before do
+      login_as user
+    end
+
+    it 'are inaccessible through the delayed jobs dashboard menu item' do
+      visit root_path
+      expect(page).not_to have_content('Delayed Job Dashboard')
+    end
+    it 'are inaccessible manually through the delayed jobs endpoint' do
+      visit delayed_job_web_path
+      expect(current_path).to eq(delayed_job_web_path)
+      expect(page).to have_content('Access denied')
+    end
+  end
+
+  context 'as a logged in user who is a sysadmin' do
+    before do
+      login_as sysadmin_user
+    end
+
+    it 'are accessible through the delayed jobs dashboard menu item' do
+      visit root_path
+      expect(page).to have_content('Delayed Job Dashboard')
+    end
+    it 'are accessible manually through the delayed jobs endpoint' do
+      visit delayed_job_web_path
+      expect(page).to have_content('Overview')
+    end
+  end
+end


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1117

# Expected behavior
- signed out users:
  - cannot see the "delayed job dashboard" menu item
  - are redirected to `/management/users/auth/cas` if they try to manually access `/delayed_job` or any other endpoints after it (overview, etc.)
- authenticated users who are _not_ sysadmin's
  - cannot see the "delayed job dashboard" menu item
  - are shown an "access denied" page if they try to manually access `/delayed_job` or any other endpoints after it (overview, etc.)
- authenticated users who _are_ sysadmin's
  - can see the "delayed job dashboard" menu item and be taken to the overview page if they click it
  - are able to manually access `/delayed_job` and any other endpoints after it (overview, etc.)

# Demo
https://user-images.githubusercontent.com/29032869/112187668-89180800-8bbf-11eb-9cb5-fa01c7955969.mp4

# Resources
- https://github.com/ejschmitt/delayed_job_web#authenticating-with-devise-and-warden
- https://stackoverflow.com/a/38779554/8079848
- https://stackoverflow.com/a/37174557/8079848
- https://guides.rubyonrails.org/routing.html#route-globbing-and-wildcard-segments