### PR TITLE
Require AdminSet for Parent Object

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -13,7 +13,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :batch_connections, as: :connectable
   has_many :batch_processes, through: :batch_connections
   belongs_to :authoritative_metadata_source, class_name: "MetadataSource"
-  belongs_to :admin_set, optional: true
+  belongs_to :admin_set
   attr_accessor :metadata_update
   attr_accessor :current_batch_process
   attr_accessor :current_batch_connection

--- a/app/views/parent_objects/select_thumbnail.html.erb
+++ b/app/views/parent_objects/select_thumbnail.html.erb
@@ -16,6 +16,7 @@
       <%= child_object.order %>
       <%= form.radio_button :representative_child_oid, child_object.oid %>
       <%= form.label(:representative_child_oid, image_tag(child_object.thumbnail_url))  %>
+      <%= form.hidden_field :admin_set, value: child_object.admin_set.key %>
     <% end %>
   </div>
 

--- a/spec/factories/parent_objects.rb
+++ b/spec/factories/parent_objects.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :parent_object do
+    admin_set { FactoryBot.create(:admin_set) }
     oid { "2004628" }
     authoritative_metadata_source_id { "1" }
     factory :parent_object_with_bib do

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -209,14 +209,12 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       end
 
       it "has relationship to parent admin set through parent property" do
-        expect(child_object.admin_set).to be_nil
         child_object.parent_object.admin_set = AdminSet.find_by_key("sml")
         child_object.parent_object.save!
         expect(child_object.reload.admin_set.key).to eq("sml")
       end
 
       it "has relationship to parent admin set through child property" do
-        expect(child_object.parent_object.admin_set).to be_nil
         child_object.admin_set = AdminSet.find_by_key("sml")
         child_object.save!
         expect(child_object.parent_object.reload.admin_set.key).to eq("sml")

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     end
     # rubocop:disable RSpec/AnyInstance
     it "checks for solr success" do
-      po_actual = ParentObject.create(oid: 2_034_600)
+      po_actual = ParentObject.create(oid: 2_034_600, admin_set: FactoryBot.create(:admin_set))
       allow_any_instance_of(ParentObject).to receive(:solr_index).and_return("responseHeader" => { "status" => 404, "QTime" => 106 })
       batch_connection = batch_process.batch_connections.build(connectable: po_actual)
       gn = GenerateManifestJob.new
@@ -156,10 +156,17 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       expect(parent_object_restricted.visibility).to eq "Restricted Access"
     end
 
-    let(:parent_object_public) { described_class.create(oid: "2005512", visibility: "Public") }
+    let(:parent_object_public) { described_class.create(oid: "2005512", visibility: "Public", admin_set: FactoryBot.create(:admin_set)) }
     it "Public visibility does validate" do
       expect(parent_object_public.valid?).to eq true
       expect(parent_object_public.visibility).to eq "Public"
+    end
+  end
+
+  context "When trying to create a ParentObject" do
+    it "requires an admin_set to be valid" do
+      parent_object = ParentObject.new(oid: "2004628", authoritative_metadata_source_id: "1")
+      expect(parent_object).to_not be_valid
     end
   end
 
@@ -199,7 +206,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     end
 
     context "a newly created ParentObject with just the oid and default authoritative_metadata_source (Ladybird for now)" do
-      let(:parent_object) { described_class.create(oid: "2005512") }
+      let(:parent_object) { described_class.create(oid: "2005512", admin_set: FactoryBot.create(:admin_set)) }
       before do
         stub_metadata_cloud("2005512", "ladybird")
         stub_metadata_cloud("V-2005512", "ils")
@@ -256,7 +263,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     end
 
     context "a newly created ParentObject with Voyager as authoritative_metadata_source" do
-      let(:parent_object) { described_class.create(oid: "2004628", bib: '3163155', authoritative_metadata_source_id: voyager) }
+      let(:parent_object) { described_class.create(oid: "2004628", bib: '3163155', authoritative_metadata_source_id: voyager, admin_set: FactoryBot.create(:admin_set)) }
 
       it "pulls from the MetadataCloud for Voyager" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq voyager
@@ -272,7 +279,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     end
 
     context "a newly created ParentObject with ArchiveSpace as authoritative_metadata_source" do
-      let(:parent_object) { described_class.create(oid: "2012036", aspace_uri: "/repositories/11/archival_objects/555049", authoritative_metadata_source_id: aspace) }
+      let(:parent_object) { described_class.create(oid: "2012036", aspace_uri: "/repositories/11/archival_objects/555049", authoritative_metadata_source_id: aspace, admin_set: FactoryBot.create(:admin_set)) }
       before do
         stub_metadata_cloud("2012036", "ladybird")
         stub_metadata_cloud("AS-2012036", "aspace")

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
   context "When trying to create a ParentObject" do
     it "requires an admin_set to be valid" do
       parent_object = ParentObject.new(oid: "2004628", authoritative_metadata_source_id: "1")
-      expect(parent_object).to_not be_valid
+      expect(parent_object).not_to be_valid
     end
   end
 
@@ -279,7 +279,14 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     end
 
     context "a newly created ParentObject with ArchiveSpace as authoritative_metadata_source" do
-      let(:parent_object) { described_class.create(oid: "2012036", aspace_uri: "/repositories/11/archival_objects/555049", authoritative_metadata_source_id: aspace, admin_set: FactoryBot.create(:admin_set)) }
+      let(:parent_object) do
+        described_class.create(
+          oid: "2012036",
+          aspace_uri: "/repositories/11/archival_objects/555049",
+          authoritative_metadata_source_id: aspace,
+          admin_set: FactoryBot.create(:admin_set)
+        )
+      end
       before do
         stub_metadata_cloud("2012036", "ladybird")
         stub_metadata_cloud("AS-2012036", "aspace")

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
     context "with valid parameters" do
       let(:new_attributes) do
         {
-          authoritative_metadata_source_id: 2
+          authoritative_metadata_source_id: 2,
+          admin_set: 'brbl'
         }
       end
 


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1155

# Expected behavior
When creating a Parent Object an admin_set is required.
When running the Create Parent Objects import, if the admin_set column is blank or does not match an existing AdminSet key, the row will be skipped and the parent object will not be created.

# Demo 
![Screen Shot 2021-03-23 at 3 50 08 PM](https://user-images.githubusercontent.com/50561476/112229030-774e5900-8bef-11eb-8e5d-66912c9bb03f.png)
