### PR TITLE
Do not allow CSV or Mets to alter existing ParentObject or ChildObjects that exist

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -40,5 +40,7 @@ class SetupMetadataJob < ApplicationJob
       GeneratePtiffJob.perform_later(child, current_batch_process)
       child.processing_event("Ptiff Queued", "ptiff-queued")
     end
+  rescue => child_create_error
+    parent_object.processing_event(child_create_error.message, "failed")
   end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -81,13 +81,18 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # database driven. This also makes object creation much faster.
   def create_child_records
     if from_mets
-      ChildObject.upsert_all(array_of_child_hashes_from_mets)
+      upsert_child_objects(array_of_child_hashes_from_mets)
     else
       return unless ladybird_json
       return self.child_object_count = 0 if ladybird_json["children"].empty?
-      ChildObject.upsert_all(array_of_child_hashes)
+      upsert_child_objects(array_of_child_hashes)
     end
     self.child_object_count = child_objects.size
+  end
+
+  def upsert_child_objects(child_objects_hash)
+    raise "One or more of the child objects exists, Unable to create children" if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
+    ChildObject.upsert_all(child_objects_hash)
   end
 
   def array_of_child_hashes_from_mets

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -91,8 +91,12 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def upsert_child_objects(child_objects_hash)
-    raise "One or more of the child objects exists, Unable to create children" if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
-    ChildObject.upsert_all(child_objects_hash)
+    if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
+      processing_event("One or more of the child objects existed", "failed")
+      raise "One or more of the child objects exists, Unable to create children"
+    end
+
+    ChildObject.insert_all(child_objects_hash)
   end
 
   def array_of_child_hashes_from_mets

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -91,10 +91,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def upsert_child_objects(child_objects_hash)
-    if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
-      processing_event("One or more of the child objects existed", "failed")
-      raise "One or more of the child objects exists, Unable to create children"
-    end
+    raise "One or more of the child objects exists, Unable to create children" if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
 
     ChildObject.insert_all(child_objects_hash)
   end

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe SetupMetadataJob, type: :job do
     let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source: metadata_source) }
 
     it 'notifies on save failure' do
-      allow(parent_object).to receive(:save!).and_raise('boom!')
-      expect(parent_object).to receive(:processing_event).twice
+      allow(parent_object).to receive(:default_fetch).and_raise('boom!')
+      expect(parent_object).to receive(:processing_event).once
       expect { metadata_job.perform(parent_object, batch_process) }.to raise_error('boom!')
     end
 

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -428,12 +428,12 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
             end
           end
 
-          it "throws exception in Job when trying to create parent object" do
+          it "does not alter child_object" do
+            original_updated_at = child_object.reload.updated_at
             allow(Rails.logger).to receive(:error) { :logger_mock }
             batch_process.file = csv_upload
-            expect do
-              batch_process.save
-            end.to raise_error("One or more of the child objects exists, Unable to create children")
+            batch_process.save
+            expect(child_object.reload.updated_at).to eq(original_updated_at)
           end
         end
       end

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
             expect(parent_object.reload.updated_at).to eq(original_updated_at)
           end
         end
-        
+
         describe "with a child object that had been previously created and user with editor role" do
           let(:admin_set) { FactoryBot.create(:admin_set) }
           let(:parent_object) { FactoryBot.create(:parent_object, oid: 1002, admin_set: admin_set) }

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       let(:batch_process_with_failure) { FactoryBot.create(:batch_process, user: user) }
 
       before do
+        stub_ptiffs_and_manifests
         stub_request(:get, "https://#{ENV['SAMPLE_BUCKET']}.s3.amazonaws.com/ladybird/#{parent_object.oid}.json")
           .to_return(status: 400, body: File.open(File.join(fixture_path, "metadata_cloud_no_record.json")))
       end

--- a/spec/system/batch_process_child_detail_spec.rb
+++ b/spec/system/batch_process_child_detail_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
   let(:user) { FactoryBot.create(:user, uid: 'johnsmith2530') }
   let(:brbl) { AdminSet.find_by_key('brbl') }
   let(:sml) { AdminSet.find_by_key('sml') }
-  let(:parent_object) { FactoryBot.create(:parent_object, oid: 16_057_779, admin_set: brbl) }
-  let(:child_object) { FactoryBot.create(:child_object, parent_object: parent_object) }
+  # let(:parent_object) { FactoryBot.create(:parent_object, oid: 16_057_779, admin_set: brbl) }
+  # let(:child_object) { FactoryBot.create(:child_object, parent_object: parent_object) }
   let(:batch_process) do
     FactoryBot.create(
       :batch_process,
@@ -18,6 +18,9 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
   end
 
   describe 'with expected success' do
+    let(:child_oid) { batch_process.parent_objects.first.child_objects.first.oid }
+    let(:parent_oid) { batch_process.parent_objects.first.oid }
+
     around do |example|
       access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
       ENV["ACCESS_MASTER_MOUNT"] = "/data"
@@ -30,7 +33,8 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
       stub_metadata_cloud('16057779')
       stub_ptiffs_and_manifests
       login_as user
-      visit show_child_batch_process_path(child_oid: child_object.oid, id: batch_process.id, oid: child_object.parent_object_oid)
+      batch_process
+      visit show_child_batch_process_path(child_oid: child_oid, id: batch_process.id, oid: parent_oid)
     end
 
     describe 'with a csv import' do
@@ -39,11 +43,11 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
       end
 
       it 'has a link to the parent object page' do
-        expect(page).to have_link('16057779', href: "/batch_processes/#{batch_process.id}/parent_objects/16057779")
+        expect(page).to have_link(parent_oid.to_s, href: "/batch_processes/#{batch_process.id}/parent_objects/#{parent_oid}")
       end
 
       it 'has a link to the child object page' do
-        expect(page).to have_link('10736292 (current record)', href: '/child_objects/10736292')
+        expect(page).to have_link("#{child_oid} (current record)", href: "/child_objects/#{child_oid}")
       end
 
       it 'shows the status of the child object' do

--- a/spec/system/batch_process_child_detail_spec.rb
+++ b/spec/system/batch_process_child_detail_spec.rb
@@ -34,10 +34,13 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
       stub_ptiffs_and_manifests
       login_as user
       batch_process
-      visit show_child_batch_process_path(child_oid: child_oid, id: batch_process.id, oid: parent_oid)
     end
 
     describe 'with a csv import' do
+      before do
+        visit show_child_batch_process_path(child_oid: child_oid, id: batch_process.id, oid: parent_oid)
+      end
+
       it 'has a link to the batch process detail page' do
         expect(page).to have_link(batch_process&.id&.to_s, href: "/batch_processes/#{batch_process.id}")
       end

--- a/spec/system/batch_process_child_detail_spec.rb
+++ b/spec/system/batch_process_child_detail_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
   end
 
   describe 'with expected success' do
-    let(:child_oid) { batch_process.parent_objects.first.child_objects.first.oid }
-    let(:parent_oid) { batch_process.parent_objects.first.oid }
+    let(:child_oid) { batch_process.parent_objects.last.child_objects.first.oid }
+    let(:parent_oid) { batch_process.parent_objects.last.oid }
 
     around do |example|
       access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
@@ -33,7 +33,7 @@ RSpec.describe 'Batch Process Child detail page', type: :system, prep_metadata_s
       stub_metadata_cloud('16057779')
       stub_ptiffs_and_manifests
       login_as user
-      batch_process
+      batch_process.save!
     end
 
     describe 'with a csv import' do

--- a/spec/system/batch_process_detail_spec.rb
+++ b/spec/system/batch_process_detail_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
     stub_metadata_cloud("16057779")
     stub_metadata_cloud("15234629")
     login_as user
-    visit batch_process_path(batch_process)
   end
 
   context "when uploading a csv" do
@@ -41,6 +40,7 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
     end
 
     it "can see the details of the import" do
+      visit batch_process_path(batch_process)
       expect(page).to have_content(batch_process.id.to_s)
       expect(page).to have_content("johnsmith2530")
       expect(page).to have_link("small_short_fixture_ids.csv", href: "/batch_processes/#{batch_process.id}/download")
@@ -71,10 +71,12 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
     end
 
     it "can see the status of the parent object imports" do
+      visit batch_process_path(batch_process)
       expect(page).to have_content("Batch complete")
     end
 
     it "can see the overall status of the batch process" do
+      visit batch_process_path(batch_process)
       expect(batch_process.batch_status).to eq "Batch complete"
       expect(page).to have_content("Batch complete")
     end
@@ -118,6 +120,7 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
       )
     end
     it "can see the details of the import" do
+      visit batch_process_path(batch_process)
       expect(page).to have_content(batch_process.id.to_s)
       expect(page).to have_content("johnsmith2530")
       expect(page).to have_link("111860A_8394689_mets.xml", href: "/batch_processes/#{batch_process.id}/download")
@@ -137,6 +140,7 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
       )
     end
     it "can see the details of the import" do
+      visit batch_process_path(batch_process)
       expect(page).to have_content(batch_process.id.to_s)
       expect(page).to have_content("johnsmith2530")
       expect(page).to have_link("111860A_8394689_no_intranda_mets.xml", href: "/batch_processes/#{batch_process.id}/download")


### PR DESCRIPTION
Checks that parent objects do not exist before creating them from a CVS or Batch:
- ParentObject is not attached to batch or altered in any way
- Batch message is created indicating parent oid and line number of CSV, other parents are processed normally

Checks that child objects don't exist before inserting new ones.  If child does exist:
- ParentObject is failed for batch.  (Parent is created in this case, since it's needed for SetupMetadataJob, and children are not known until SetupMetadataJob).