### PR TITLE
Display user roles on show page

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -6,3 +6,12 @@
   border-bottom: none;
   border-top: none;
 }
+
+.table.user-roles-table {
+  width: auto;
+  vertical-align: top;
+
+  th {
+    width: 300px;
+  }
+}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,5 +26,22 @@
   <%= @user.deactivated %>
 </p>
 
+<table class='table table-striped user-roles-table table-bordered'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'> Admin Set </th>
+      <th scope='col'> Role </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @user.roles.excluding(@user.roles.where(name: 'sysadmin')).each do |role| %>
+      <tr>
+        <td><%= link_to role.resource.label, admin_set_path(role.resource)  %></td>
+        <td><%= role.name %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
 <%= link_to 'Edit', edit_user_path(@user) %>
 <%= link_to 'Back', users_path %>

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe 'Users', type: :system, js: true do
     end
   end
 
+  describe 'are viewable' do
+    before do
+      visit users_path
+      click_on(user.uid.to_s)
+    end
+
+    it 'displays the users roles' do
+      admin_set = FactoryBot.create(:admin_set)
+      user.add_role(:editor, admin_set)
+
+      within('table', text: 'Admin Set') do
+        expect(page).to have_css('td', text: admin_set.label.to_s)
+        expect(page).to have_css('td', text: "editor")
+      end
+    end
+  end
+
   describe 'are editable' do
     it 'and require an email to be present' do
       visit users_path


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1170

# Expected behavior
The show page for a user contains a table that displays the roles that the user has in each admin set that they are associated with

# Demo
![Screen Shot 2021-03-24 at 10 11 19 AM](https://user-images.githubusercontent.com/50561476/112353752-4ae71b00-8c89-11eb-85bc-af3e6afa7903.png)

