### PR TITLE
1156 order child oids on export

### DIFF
--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -8,38 +8,50 @@ module CsvExportable
   end
 
   def output_csv
-    had_events = batch_ingest_events_count.positive?
     return nil unless batch_action == "export child oids"
     CSV.generate do |csv|
       csv << headers
-      oids.each_with_index do |oid, index|
-        begin
-          po = ParentObject.find(oid.to_i)
-          next unless check_can_view(current_ability, index, po, csv, had_events)
-          po.child_objects.each do |co|
-            row = [co.oid, po.oid, co.order, po.authoritative_json["title"]&.first, co.label, co.caption, co.viewing_hint]
-            csv << row
-          end
-        rescue ActiveRecord::RecordNotFound
-          parent_not_found(index, oid, csv, had_events)
+      sorted_child_objects.each do |co|
+        if co.is_a?(Array)
+          csv << co
+        else
+          row = [co.oid, co.parent_object.oid, co.order, co.parent_object.authoritative_json["title"]&.first, co.label, co.caption, co.viewing_hint]
+          csv << row
         end
       end
     end
   end
 
-  def parent_not_found(index, oid, csv, had_events)
-    row = ["----", oid, "", "Parent Not Found in database", "", ""]
-    batch_processing_event("Skipping row [#{index}] due to parent not found: #{oid}", 'Skipped Row') unless had_events
-    csv << row
+  def sorted_child_objects
+    had_events = batch_ingest_events_count.positive?
+    arr = []
+    oids.each_with_index do |oid, index|
+      begin
+        po = ParentObject.find(oid.to_i)
+        next unless check_can_view(current_ability, index, po, arr, had_events)
+        po.child_objects.each do |co|
+          arr << co
+        end
+      rescue ActiveRecord::RecordNotFound
+        parent_not_found(index, oid, arr, had_events)
+      end
+    end
+    arr.sort_by { |co| [co.try(:order) ? co.order : co[2], co.try(:oid) ? co.oid : co[0]] }
   end
 
-  def check_can_view(ability, index, parent_object, csv, had_events)
+  def parent_not_found(index, oid, arr, had_events)
+    row = [nil, oid, 0, "Parent Not Found in database", "", ""]
+    batch_processing_event("Skipping row [#{index}] due to parent not found: #{oid}", 'Skipped Row') unless had_events
+    arr << row
+  end
+
+  def check_can_view(ability, index, parent_object, arr, had_events)
     if ability.can?(:read, parent_object)
       true
     else
-      row = ["----", parent_object.oid, "", "Access denied for parent object", "", ""]
+      row = [nil, parent_object.oid, 0, "Access denied for parent object", "", ""]
       batch_processing_event("Skipping row [#{index}] due to parent permissions: #{parent_object.oid}", 'Skipped Row') unless had_events
-      csv << row
+      arr << row
       false
     end
   end

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -37,11 +37,11 @@ module CsvExportable
       end
     end
 
-    arr.sort_by { |co| [co.try(:order) || co[2], co.try(:oid) || co[0]] }
+    arr.sort_by { |co| [co.try(:order) || co[2], co.try(:oid) || co[1]] }
   end
 
   def parent_not_found(index, oid, arr, had_events)
-    row = [nil, oid, 0, "Parent Not Found in database", "", ""]
+    row = [nil, oid.to_i, 0, "Parent Not Found in database", "", ""]
     batch_processing_event("Skipping row [#{index + 2}] due to parent not found: #{oid}", 'Skipped Row') unless had_events
     arr << row
   end
@@ -50,7 +50,7 @@ module CsvExportable
     if ability.can?(:read, parent_object)
       true
     else
-      row = [nil, parent_object.oid, 0, "Access denied for parent object", "", ""]
+      row = [nil, parent_object.oid.to_i, 0, "Access denied for parent object", "", ""]
       batch_processing_event("Skipping row [#{index + 2}] due to parent permissions: #{parent_object.oid}", 'Skipped Row') unless had_events
       arr << row
       false

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -36,12 +36,13 @@ module CsvExportable
         parent_not_found(index, oid, arr, had_events)
       end
     end
-    arr.sort_by { |co| [co.try(:order) ? co.order : co[2], co.try(:oid) ? co.oid : co[0]] }
+
+    arr.sort_by { |co| [co.try(:order) || co[2], co.try(:oid) || co[0]] }
   end
 
   def parent_not_found(index, oid, arr, had_events)
     row = [nil, oid, 0, "Parent Not Found in database", "", ""]
-    batch_processing_event("Skipping row [#{index}] due to parent not found: #{oid}", 'Skipped Row') unless had_events
+    batch_processing_event("Skipping row [#{index + 2}] due to parent not found: #{oid}", 'Skipped Row') unless had_events
     arr << row
   end
 
@@ -50,7 +51,7 @@ module CsvExportable
       true
     else
       row = [nil, parent_object.oid, 0, "Access denied for parent object", "", ""]
-      batch_processing_event("Skipping row [#{index}] due to parent permissions: #{parent_object.oid}", 'Skipped Row') unless had_events
+      batch_processing_event("Skipping row [#{index + 2}] due to parent permissions: #{parent_object.oid}", 'Skipped Row') unless had_events
       arr << row
       false
     end

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -171,10 +171,17 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
         expect(BatchProcess.last.batch_action).to eq "export child oids"
         expect(BatchProcess.last.output_csv).to include "1126257"
-        expect(BatchProcess.last.output_csv).to include '2005512,"",Access denied for parent object'
+        expect(BatchProcess.last.output_csv).to include '2005512,0,Access denied for parent object'
         expect(BatchProcess.last.output_csv).not_to include "1030368" # child of 2005512
         expect(BatchProcess.last.batch_ingest_events.count).to eq 4
-        expect(BatchProcess.last.batch_ingest_events.map(&:reason)).to include "Skipping row [1] due to parent permissions: 2005512"
+        expect(BatchProcess.last.batch_ingest_events.map(&:reason)).to include "Skipping row [3] due to parent permissions: 2005512"
+
+        sorted_child_objects = BatchProcess.last.sorted_child_objects
+        expect(sorted_child_objects[0]).to include 2_005_512
+        expect(sorted_child_objects[1]).to include 14_716_192
+        expect(sorted_child_objects[2]).to include 16_414_889
+        expect(sorted_child_objects[3]).to include 16_854_285
+        expect(sorted_child_objects[4]).to be_a(ChildObject)
 
         click_on(BatchProcess.last.id.to_s)
         expect(page).to have_link("short_fixture_ids.csv", href: "/batch_processes/#{BatchProcess.last.id}/download")


### PR DESCRIPTION
co-author: alisha evans <alisha@notch8.com>
co-author: dylan salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1156

# Expected behavior
- if the parent of a child object can't be found, it's order will be 0 so that it appears at the top of the csv
- if the user doesn't have permission to view the parent object, it's order will be 0 so that it appears at the top of the csv
- exported csv's of child oid's will first sort by the order number associated with that child
- if multiple children have the same order, that grouping will be sorted according to the child oid numbers

# Demo
![image](https://user-images.githubusercontent.com/29032869/112402842-82c28280-8cca-11eb-8f6d-1cb353f31466.png)
