### PR TITLE
1150-revisit-user-bootstrap-process

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,7 @@ puts "MetadataSources verified"
       label: "Sterling Memorial Library",
       summary: "Sterling Memorial Library",
       homepage: "https://web.library.yale.edu/building/sterling-library"
-    }    
+    }
 ].each do |obj|
   admin_set = AdminSet.where(key: obj[:key]).first
   if admin_set.nil?
@@ -101,10 +101,10 @@ CSV.parse(user_csv, headers: false) do |row|
         last_name:"last_name"
     )
   else
-    @user.deactivated = false
-    @user.email = "#{@user.uid}@connect.yale.edu"
-    @user.first_name = "first_name"
-    @user.last_name = "last_name"
+    @user.deactivated ||= false
+    @user.email ||= "#{@user.uid}@connect.yale.edu"
+    @user.first_name ||= "first_name"
+    @user.last_name ||= "last_name"
     @user.save!
   end
   authorized_uids.push uid
@@ -114,9 +114,4 @@ end
   User.where(uid: old_uid).each do |user|
     user.deactivate!
   end
-end
-# make users sysadmins
-authorized_uids.each do |uid|
-  user = User.where(provider: "cas", uid: uid).first
-  user.add_role :sysadmin if user
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -109,9 +109,3 @@ CSV.parse(user_csv, headers: false) do |row|
   end
   authorized_uids.push uid
 end
-(prior_uids - authorized_uids).each do |old_uid|
-  Rails.logger.info("Deactivating user with uid #{old_uid}")
-  User.where(uid: old_uid).each do |user|
-    user.deactivate!
-  end
-end


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>
Co-author: Steve Fox <steve@curationexperts.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1150

# Expected behavior
- when reseeding the database, the following will not be overridden for an existing user:
  - first and last name
  - email
  - sysadmin status
  - active/inactive status
- existing users in the app are no longer deactivated if they aren't in the csv
- new users are not automatically given `sysadmin` privileges

# Demo

https://user-images.githubusercontent.com/29032869/113031305-66e43400-9143-11eb-91b5-4b0f76355eac.mp4
