### PR TITLE
1157 delete associated jobs when deleting parent object

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -12,7 +12,7 @@ class ChildObject < ApplicationRecord
   paginates_per 50
   attr_accessor :current_batch_process
   attr_accessor :current_batch_connection
-  after_destroy :delayed_job_deletion
+  after_destroy :delayed_jobs_deletion
 
   # Does not get called because we use upsert to create children
   # before_create :check_for_size_and_file

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -3,6 +3,7 @@
 class ChildObject < ApplicationRecord
   has_paper_trail
   include Statable
+  include Delayable
   belongs_to :parent_object, foreign_key: 'parent_object_oid', class_name: "ParentObject"
   has_many :batch_connections, as: :connectable
   has_many :batch_processes, through: :batch_connections
@@ -11,6 +12,7 @@ class ChildObject < ApplicationRecord
   paginates_per 50
   attr_accessor :current_batch_process
   attr_accessor :current_batch_connection
+  after_destroy :delayed_job_deletion
 
   # Does not get called because we use upsert to create children
   # before_create :check_for_size_and_file

--- a/app/models/concerns/delayable.rb
+++ b/app/models/concerns/delayable.rb
@@ -8,7 +8,7 @@ module Delayable
   end
 
   def setup_metadata_jobs
-    Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "job_class: SetupMetadataJob", "%#{self.class}/#{oid}%")
+    Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "job_class: %SetupMetadataJob%", "%#{self.class}/#{oid}%")
   end
 
   def delayed_jobs_deletion

--- a/app/models/concerns/delayable.rb
+++ b/app/models/concerns/delayable.rb
@@ -1,0 +1,15 @@
+module Delayable
+  extend ActiveSupport::Concern
+
+  def delayed_jobs
+    Delayed::Job.where("handler LIKE ?", "%#{self.class}/#{self.oid}%")
+  end
+
+  def setup_metadata_jobs
+    Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "job_class: SetupMetadataJob", "%#{self.class}/#{self.oid}%")
+  end
+
+  def delayed_jobs_deletion
+    self.delayed_jobs.destroy_all
+  end
+end

--- a/app/models/concerns/delayable.rb
+++ b/app/models/concerns/delayable.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 module Delayable
   extend ActiveSupport::Concern
 
   def delayed_jobs
-    Delayed::Job.where("handler LIKE ?", "%#{self.class}/#{self.oid}%")
+    Delayed::Job.where("handler LIKE ?", "%#{self.class}/#{oid}%")
   end
 
   def setup_metadata_jobs
-    Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "job_class: SetupMetadataJob", "%#{self.class}/#{self.oid}%")
+    Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "job_class: SetupMetadataJob", "%#{self.class}/#{oid}%")
   end
 
   def delayed_jobs_deletion
-    self.delayed_jobs.destroy_all
+    delayed_jobs.destroy_all
   end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -8,6 +8,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include SolrIndexable
   include Statable
   include PdfRepresentable
+  include Delayable
   has_many :dependent_objects
   has_many :child_objects, primary_key: 'oid', foreign_key: 'parent_object_oid', dependent: :destroy
   has_many :batch_connections, as: :connectable
@@ -22,6 +23,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   after_update :solr_index_job # we index from the fetch job on create
   after_destroy :solr_delete
   after_destroy :note_deletion
+  after_destroy :delayed_job_deletion
   paginates_per 50
 
   def self.visibilities

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -23,7 +23,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   after_update :solr_index_job # we index from the fetch job on create
   after_destroy :solr_delete
   after_destroy :note_deletion
-  after_destroy :delayed_job_deletion
+  after_destroy :delayed_jobs_deletion
   paginates_per 50
 
   def self.visibilities

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -4,58 +4,36 @@ require "rails_helper"
 RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
   let(:user) { FactoryBot.create(:user) }
   let(:batch_process) { BatchProcess.create(user_id: user.id) }
-  let(:parent_object) { FactoryBot.create(:parent_object) }
+  let(:parent_object) { FactoryBot.build(:parent_object, oid: '16685691') }
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "short_fixture_ids.csv")) }
 
-  # around do |example|
-  #   original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
-  #   original_access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
-  #   ENV["S3_SOURCE_BUCKET_NAME"] = "yale-test-image-samples"
-  #   ENV["ACCESS_MASTER_MOUNT"] = File.join("spec", "fixtures", "images", "access_masters")
-  #   example.run
-  #   ENV["S3_SOURCE_BUCKET_NAME"] = original_image_bucket
-  #   ENV["ACCESS_MASTER_MOUNT"] = original_access_master_mount
-  # end
+  around do |example|
+    perform_enqueued_jobs do
+      example.run
+    end
+  end
 
+  
   describe "delayed_jobs" do
-    # around do |example|
-    #   perform_enqueued_jobs do
-    #     example.run
-    #   end
-    # end
 
     before do
-      # login_as(:user)
-      # stub_ptiffs_and_manifests
-      Delayed::Worker.delay_jobs = false
+      stub_metadata_cloud("16685691")
+      stub_ptiffs_and_manifests
     end
 
     it "returns delayed jobs associated with the parent object" do
-      batch_connection = batch_process.batch_connections.build(connectable: parent_object)
-      batch_connection.save
-      parent_object.current_batch_process = batch_process
-
-      SetupMetadataJob.perform_later(parent_object, batch_process, batch_connection)
-      expect(Delayed::Worker.new.work_off).to eq [1, 0]
-
-      # assert_enqueued_jobs 1
-      # expect do
-      #   SetupMetadataJob.perform_later(parent_object, batch_process, batch_connection)
-      # end.to change { parent_object.delayed_jobs.count }.by 1
-      # expect(parent_object.delayed_jobs).to eq 1
-
-      # batch_process.file = csv_upload
-      # batch_process.save!
+      batch_process.setup_for_background_jobs(parent_object, 'ladybird')
+      # batch_connection = batch_process.batch_connections.build(connectable: parent_object)
+      # batch_connection.save
+      # parent_object.current_batch_process = batch_process
+      # parent_object.current_batch_connection = batch_connection
       # byebug
-      # po = ParentObject.find(2034600)
-      # byebug
+      parent_object.save
+      # parent_object.setup_metadata_job
+      # SetupMetadataJob.perform(parent_object, batch_process, batch_connection)
+      byebug
+      # expect(parent_)
 
-      # end.to change { ParentObject.first.delayed_jobs.count }.by 4
-      #   puts "DelayedJobs >>> #{Delayed::Job.count}"
-      #   puts "DelayedJobs >>> #{Delayed::Job.count}"
-      #   byebug
-      #   expect(po.delayed_jobs.count).to eq(4)
-      #   expect(ParentObject.count).to eq(5)
     end
   end
 end

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 
 RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
   let(:parent_object) { FactoryBot.build(:parent_object, oid: '16685691') }
-  let!(:job) { Delayed::Job.create(handler: parent_object.to_gid)}
-  let!(:setup_job) { Delayed::Job.create(handler: "job_class: SetupMetadataJob\n#{parent_object.to_gid}")}
+  let!(:job) { Delayed::Job.create(handler: parent_object.to_gid) }
+  let!(:setup_job) { Delayed::Job.create(handler: "job_class: SetupMetadataJob\n#{parent_object.to_gid}") }
 
   describe 'delayed_jobs' do
     it 'returns delayed jobs associated with the parent object' do

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -2,17 +2,20 @@
 require "rails_helper"
 
 RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
-  let(:user) { FactoryBot.create(:user) }
-  let(:batch_process) { BatchProcess.create(user_id: user.id) }
   let(:parent_object) { FactoryBot.build(:parent_object, oid: '16685691') }
   let!(:job) { Delayed::Job.create(handler: parent_object.to_gid)}
+  let!(:setup_job) { Delayed::Job.create(handler: "job_class: SetupMetadataJob\n#{parent_object.to_gid}")}
 
   describe 'delayed_jobs' do
     it 'returns delayed jobs associated with the parent object' do
       expect(parent_object.delayed_jobs).to include(job)
     end
 
-    it 'can distinguish between SetupMetadaJobs and other job types'
+    it 'can distinguish between SetupMetadaJobs and other job types' do
+      expect(parent_object.delayed_jobs.count).to eq 2
+      expect(parent_object.setup_metadata_jobs.count).to eq 1
+      expect(parent_object.setup_metadata_jobs.first).to eq setup_job
+    end
 
     it 'will destroy all jobs from a given parent object when the parent object is destroyed'
   end

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -5,35 +5,15 @@ RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
   let(:user) { FactoryBot.create(:user) }
   let(:batch_process) { BatchProcess.create(user_id: user.id) }
   let(:parent_object) { FactoryBot.build(:parent_object, oid: '16685691') }
-  let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "short_fixture_ids.csv")) }
+  let!(:job) { Delayed::Job.create(handler: parent_object.to_gid)}
 
-  around do |example|
-    perform_enqueued_jobs do
-      example.run
-    end
-  end
-
-  
-  describe "delayed_jobs" do
-
-    before do
-      stub_metadata_cloud("16685691")
-      stub_ptiffs_and_manifests
+  describe 'delayed_jobs' do
+    it 'returns delayed jobs associated with the parent object' do
+      expect(parent_object.delayed_jobs).to include(job)
     end
 
-    it "returns delayed jobs associated with the parent object" do
-      batch_process.setup_for_background_jobs(parent_object, 'ladybird')
-      # batch_connection = batch_process.batch_connections.build(connectable: parent_object)
-      # batch_connection.save
-      # parent_object.current_batch_process = batch_process
-      # parent_object.current_batch_connection = batch_connection
-      # byebug
-      parent_object.save
-      # parent_object.setup_metadata_job
-      # SetupMetadataJob.perform(parent_object, batch_process, batch_connection)
-      byebug
-      # expect(parent_)
+    it 'can distinguish between SetupMetadaJobs and other job types'
 
-    end
+    it 'will destroy all jobs from a given parent object when the parent object is destroyed'
   end
 end

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
       expect(parent_object.setup_metadata_jobs.first).to eq setup_job
     end
 
-    it 'will destroy all jobs from a given parent object when the parent object is destroyed'
+    it 'will destroy all jobs from a given parent object when the parent object is destroyed' do
+      expect(parent_object.delayed_jobs.count).to eq 2
+      parent_object.destroy
+      expect(parent_object.delayed_jobs.count).to eq 0
+    end
   end
 end

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:batch_process) { BatchProcess.create(user_id: user.id) }
+  let(:parent_object) { FactoryBot.create(:parent_object) }
+  let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "short_fixture_ids.csv")) }
+
+  # around do |example|
+  #   original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
+  #   original_access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
+  #   ENV["S3_SOURCE_BUCKET_NAME"] = "yale-test-image-samples"
+  #   ENV["ACCESS_MASTER_MOUNT"] = File.join("spec", "fixtures", "images", "access_masters")
+  #   example.run
+  #   ENV["S3_SOURCE_BUCKET_NAME"] = original_image_bucket
+  #   ENV["ACCESS_MASTER_MOUNT"] = original_access_master_mount
+  # end
+
+  describe "delayed_jobs" do
+    # around do |example|
+    #   perform_enqueued_jobs do
+    #     example.run
+    #   end
+    # end
+
+    before do
+      # login_as(:user)
+      # stub_ptiffs_and_manifests
+      Delayed::Worker.delay_jobs = false
+    end
+
+    it "returns delayed jobs associated with the parent object" do
+      batch_connection = batch_process.batch_connections.build(connectable: parent_object)
+      batch_connection.save
+      parent_object.current_batch_process = batch_process
+
+      SetupMetadataJob.perform_later(parent_object, batch_process, batch_connection)
+      expect(Delayed::Worker.new.work_off).to eq [1, 0]
+
+      # assert_enqueued_jobs 1
+      # expect do
+      #   SetupMetadataJob.perform_later(parent_object, batch_process, batch_connection)
+      # end.to change { parent_object.delayed_jobs.count }.by 1
+      # expect(parent_object.delayed_jobs).to eq 1
+
+      # batch_process.file = csv_upload
+      # batch_process.save!
+      # byebug
+      # po = ParentObject.find(2034600)
+      # byebug
+
+      # end.to change { ParentObject.first.delayed_jobs.count }.by 4
+      #   puts "DelayedJobs >>> #{Delayed::Job.count}"
+      #   puts "DelayedJobs >>> #{Delayed::Job.count}"
+      #   byebug
+      #   expect(po.delayed_jobs.count).to eq(4)
+      #   expect(ParentObject.count).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>
Co-author: Steve Fox <steve@curationexperts.com>
Co-auther: Rob Kaufam <rob@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1157

# Expected behavior
- when a parent object is deleted, its and its child object delayed jobs are also deleted
- the batch process status remains "in progress"
- `batch_connection.status` still shows in progress
(the final 2 points were discussed in sprint planning on 04/06/2021 and mike/rebecca will discuss if/how to address it)