### PR TITLE
Create sitemap in management application

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -73,6 +73,7 @@ module SolrIndexable
       genre_ssim: json_to_index["genre"],
       genre_tesim: json_to_index["genre"],
       geoSubject_ssim: json_to_index["geoSubject"],
+      hashed_id_ssi: generate_hash,
       identifierMfhd_ssim: json_to_index["identifierMfhd"],
       imageCount_isi: child_object_count,
       indexedBy_tsim: json_to_index["indexedBy"],
@@ -169,4 +170,9 @@ module SolrIndexable
       end
     end.to_a
   end
+
+  def generate_hash()
+    Digest::MD5.hexdigest oid.to_s
+  end
+
 end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -171,8 +171,7 @@ module SolrIndexable
     end.to_a
   end
 
-  def generate_hash()
+  def generate_hash
     Digest::MD5.hexdigest oid.to_s
   end
-
 end


### PR DESCRIPTION
Co-author: Martin Lovell <martin.lovell@yale.edu>

Blacklight Application: 
https://github.com/yalelibrary/yul-dc-blacklight/pull/496

**Story**

We'd like users to be able to discover all of the content via Google.  To improve the chances that our content will be indexed, we should offer a sitemap.

**Acceptance**
- [x] The site makes a sitemap available
- [x] The sitemap includes only objects with `Public` and `Yale Community Only` access. (see #1179 for a similar issue for the OAI provider)
- [x] The sitemap does not include objects with `Private`.
- For each item, the sitemap includes:
   - [x] URI
   - [x] last modified date
   - [x] the thumbnail image **if publicly accessible** as the first `<image>` 
   - [x] additional images **if publicly accessible** (number TBD) as subsequent image entries
- [x] Sitemap linked to from `robots.txt` (see https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap#addsitemap )
