### PR TITLE
1192 set dev users as admins

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -109,3 +109,12 @@ CSV.parse(user_csv, headers: false) do |row|
   end
   authorized_uids.push uid
 end
+
+case Rails.env
+when 'development'
+  # make users sysadmins
+  authorized_uids.each do |uid|
+    user = User.where(provider: "cas", uid: uid).first
+    user.add_role :sysadmin if user
+  end
+end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1195

# Expected Behavior
- users in the "authorization/cas_users.csv" file on S3 will be created as `sysadmin` in the local dev environment only
- we pushed the branch to test and followed the same steps in "testing instructions" below. the user was not made a sysadmin after running the seeds in the ecs container

# Demo
### on dev
https://user-images.githubusercontent.com/29032869/113777131-864d0500-96df-11eb-9e91-959daa4e5478.mp4

# Testing instructions
- sign in to the management app
- remove yourself as a sysadmin (through the UI or console)
- run the seeds in the container `bundle exec rails db:seed`
- verify in the ui that you're a sysadmin again