### PR TITLE
Mark rights statement as html_safe

### DIFF
--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -63,7 +63,7 @@
 
 <p>
   <strong>Rights Statement:</strong>
-  <div class='rights-statement'><%= @parent_object.rights_statement.html_safe %></div>
+  <div class='rights-statement'><%= @parent_object.rights_statement&.html_safe %></div>
 </p>
 
 <p>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -63,7 +63,7 @@
 
 <p>
   <strong>Rights Statement:</strong>
-  <div class='rights-statement'><%= @parent_object.rights_statement %></div>
+  <div class='rights-statement'><%= @parent_object.rights_statement.html_safe %></div>
 </p>
 
 <p>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -63,7 +63,7 @@
 
 <p>
   <strong>Rights Statement:</strong>
-  <div class='rights-statement'><%= @parent_object.rights_statement&.html_safe %></div>
+  <div class='rights-statement'><%= sanitize @parent_object.rights_statement, tags: %w(a), attributes: %w(href) %></div>
 </p>
 
 <p>


### PR DESCRIPTION
Co-author: Alisha Evans <alisha@notch8.com>
Co-author: Dylan Salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1103

# Expected behavior
- The Rights field displays HTML links as links
- Only a tags and their href attribute should come through; All other tags are scrubbed. 

# demo
| before | after |
|---|---|
|![Screen Shot 2021-04-07 at 9 40 42 AM](https://user-images.githubusercontent.com/50561476/113903050-6708b300-9785-11eb-82db-4b2370a3896a.png)|![Screen Shot 2021-04-07 at 9 40 10 AM](https://user-images.githubusercontent.com/50561476/113903085-6e2fc100-9785-11eb-9147-1b33e508e701.png)|
 
