### PR TITLE
936 disable reindex button when job in process

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -83,10 +83,14 @@ class ParentObjectsController < ApplicationController
 
   def reindex
     authorize!(:reindex_all, ParentObject)
-    ParentObject.solr_index
-    respond_to do |format|
-      format.html { redirect_to parent_objects_url, notice: 'Parent objects have been reindexed.' }
-      format.json { head :no_content }
+    if ParentObject.cannot_reindex
+      redirect_back(fallback_location: root_path, notice: 'There is already a Reindex job in progress, please wait for that job to complete before submitting a new reindex request')
+    else
+      ParentObject.solr_index
+      respond_to do |format|
+        format.html { redirect_to parent_objects_url, notice: 'Parent objects have been reindexed.' }
+        format.json { head :no_content }
+      end
     end
   end
 

--- a/app/models/concerns/delayable.rb
+++ b/app/models/concerns/delayable.rb
@@ -11,6 +11,12 @@ module Delayable
     Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "job_class: %SetupMetadataJob%", "%#{self.class}/#{oid}%")
   end
 
+  def solr_reindex_jobs
+    Delayed::Job.where("handler LIKE ?", "%job_class: SolrReindexAllJob%")
+  end
+
+  module_function :solr_reindex_jobs
+
   def delayed_jobs_deletion
     delayed_jobs.destroy_all
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -56,6 +56,10 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     from_ladybird_for_the_first_time? || from_mets_for_the_first_time?
   end
 
+  def self.cannot_reindex
+    return true if Delayable.solr_reindex_jobs.count > 0
+  end
+
   # Returns true if last_ladybird_update has changed from nil to some value, indicating initial ladybird fetch
   def from_ladybird_for_the_first_time?
     return true if changes["last_ladybird_update"] &&

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -57,7 +57,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.cannot_reindex
-    return true if Delayable.solr_reindex_jobs.count > 0
+    return true if Delayable.solr_reindex_jobs.count.positive?
   end
 
   # Returns true if last_ladybird_update has changed from nil to some value, indicating initial ladybird fetch

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -6,7 +6,7 @@
   <div class='col'>
     <div class='float-right button-list'>
       <%= link_to 'New Parent Object', new_parent_object_path, class: 'btn btn-primary' %>
-      <%= button_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn btn-secondary', id: 'reindex', data:{confirm: "Are you sure you want to proceed? This action will reindex the entire contents of the system."}, disabled: !(can? :reindex_all, ParentObject) %>
+      <%= button_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn btn-secondary', id: 'reindex', data:( ParentObject.cannot_reindex ? nil : { confirm: "Are you sure you want to proceed? This action will reindex the entire contents of the system." }), disabled: !(can? :reindex_all, ParentObject) %>
       <%= button_to 'Update Metadata', all_metadata_parent_objects_path, method: 'post', class: 'btn btn-secondary',id: 'update_metadata', data:{confirm: "Are you sure you want to proceed?  This action will update metadata for the entire contents of the system."}, disabled: !(can? :update_metadata, ParentObject) %>
     </div>
   </div>

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
   let(:parent_object) { FactoryBot.build(:parent_object, oid: '16685691') }
   let!(:job) { Delayed::Job.create(handler: parent_object.to_gid) }
   let!(:setup_job) { Delayed::Job.create(handler: "job_class: SetupMetadataJob\n#{parent_object.to_gid}") }
+  let!(:reindex_job) { Delayed::Job.create(handler: "job_class: SolrReindexAllJob\n") }
 
   describe 'delayed_jobs' do
     it 'returns delayed jobs associated with the parent object' do
@@ -12,9 +13,11 @@ RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
     end
 
     it 'can distinguish between SetupMetadaJobs and other job types' do
-      expect(parent_object.delayed_jobs.count).to eq 2
+      expect(Delayed::Job.count).to eq 3
       expect(parent_object.setup_metadata_jobs.count).to eq 1
       expect(parent_object.setup_metadata_jobs.first).to eq setup_job
+      expect(Delayable.solr_reindex_jobs.count).to eq 1
+      expect(Delayable.solr_reindex_jobs.first).to eq reindex_job
     end
 
     it 'will destroy all jobs from a given parent object when the parent object is destroyed' do

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -396,6 +396,13 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         visit parent_objects_path
       end
 
+      it "does not Reindex if a reindex job is already in progress" do
+        allow(ParentObject).to receive(:cannot_reindex).and_return(:true)
+        click_on("Reindex")
+        page.driver.browser.switch_to.alert.accept
+        expect(page.body).to include 'There is already a Reindex job in progress, please wait for that job to complete before submitting a new reindex request'
+      end
+
       it "does not Reindex without confirmation" do
         expect(ParentObject).not_to receive(:solr_index)
         click_on("Reindex")


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/936

# Expected behavior
- Clicking the "Reindex" button while there is an existing reindex job triggers a message -> "There is already a Reindex job in progress, please wait for that job to complete before submitting a new reindex request".
- Clicking the "Reindex" button while there is an existing reindex job does not ask you to re-confirm.
- Clicking the "Reindex" button while there is an existing reindex job does not queue a new reindex job. 

# demo

https://user-images.githubusercontent.com/50561476/114787363-84fd8700-9d34-11eb-9628-dac0f3dfb3c2.mp4



