### PR TITLE
923 thumbnail start canvas

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -101,7 +101,7 @@ class IiifPresentation
     )
     image["resource"] = image_resource
 
-    @manifest['thumbnail'] = [image] if child_as_thumbnail?(child[:oid])
+    @manifest['thumbnail'] = [image_resource] if child_is_thumbnail?(child[:oid])
     images << image
   end
 
@@ -118,7 +118,7 @@ class IiifPresentation
       canvas['viewingHint'] = child.viewing_hint unless child.viewing_hint == ""
       add_metadata_to_canvas(canvas, child)
 
-      @manifest["startCanvas"] = canvas['@id'] if child_as_start_canvas? child.oid, index
+      @manifest["startCanvas"] = canvas['@id'] if child_is_start_canvas? child.oid, index
       canvases << canvas
     end
   end
@@ -132,15 +132,15 @@ class IiifPresentation
     canvas
   end
 
-  def child_as_start_canvas?(child, index)
+  def child_is_start_canvas?(child, index)
     return true if index.eql? 0 # set the first child as start canvas
-    return false unless child_as_thumbnail? child
+    return false unless child_is_thumbnail? child
     child_oids = @parent_object.child_objects.map { |child_cur| child_cur[:oid] }
 
     child_oids.index(child) < 10 # only set if the rep. child is one of the first 10
   end
 
-  def child_as_thumbnail?(child)
+  def child_is_thumbnail?(child)
     @parent_object.representative_child.oid.eql? child # checks if child is the rep
   end
 

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
     end
   end
 
-  describe 'iiif presentation representative children', :vpn_true do
+  describe 'iiif presentation representative children', :vpn_only do
     let(:oid_rep) { 2_055_095 }
     let(:parent_object_rep) { FactoryBot.create(:parent_object, oid: oid_rep, viewing_direction: "left-to-right", display_layout: "individuals", bib: "12834515") }
 


### PR DESCRIPTION
**Background**
1. The IIIF Manifest can supply a `thumbnail` property so that viewers can display a preferred image rather than just the first image of the first canvas. https://iiif.io/api/presentation/2.1/#thumbnail

2. The IIIF Manifest can contain a `startCanvas` property so that the viewer can start on the first 'interesting' Canvas of the work. https://iiif.io/api/presentation/2.1/#startcanvas

**Acceptance**

- [x] Provide the "representative thumbnail" image's IIIF Image service as the `thumbnail` for the manifest; otherwise use the first child to create the thumbnail link.
- [x] If the ChildObject corresponding to the "representative thumbnail" is one of the first 10 children for that Parent, set its Canvas ID as the Manifest's  `startCanvas`.