### PR TITLE
1216 preservation history datatable

### DIFF
--- a/app/assets/stylesheets/preservica_ingest.scss
+++ b/app/assets/stylesheets/preservica_ingest.scss
@@ -1,0 +1,4 @@
+#preservica-ingests-datatable {
+  border-bottom: none;
+  border-top: none;
+}

--- a/app/controllers/preservica_ingests_controller.rb
+++ b/app/controllers/preservica_ingests_controller.rb
@@ -1,0 +1,10 @@
+class PreservicaIngestsController < ApplicationController
+    # GET /preservica_ingest
+    # GET /preservica_ingest.json
+    def index
+      respond_to do |format|
+        format.html
+        format.json { render json: PreservicaIngestDatatable.new(params, view_context: view_context, current_ability: current_ability) }
+      end
+    end
+end

--- a/app/controllers/preservica_ingests_controller.rb
+++ b/app/controllers/preservica_ingests_controller.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class PreservicaIngestsController < ApplicationController
-    # GET /preservica_ingest
-    # GET /preservica_ingest.json
-    def index
-      respond_to do |format|
-        format.html
-        format.json { render json: PreservicaIngestDatatable.new(params, view_context: view_context, current_ability: current_ability) }
-      end
+  # GET /preservica_ingest
+  # GET /preservica_ingest.json
+  def index
+    respond_to do |format|
+      format.html
+      format.json { render json: PreservicaIngestDatatable.new(params, view_context: view_context, current_ability: current_ability) }
     end
+  end
 end

--- a/app/datatables/preservica_ingest_datatable.rb
+++ b/app/datatables/preservica_ingest_datatable.rb
@@ -3,16 +3,22 @@
 class PreservicaIngestDatatable < AjaxDatatablesRails::ActiveRecord
   extend Forwardable
 
-  def_delegators :@view, :link_to, :show_parent_preservica_ingest_path, :parent_object_path
+  def_delegators :@view
+
+  def initialize(params, opts = {})
+    @view = opts[:view_context]
+    @current_ability = opts[:current_ability]
+    super
+  end
 
   def view_columns
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      parent_oid: { source: "PreservicaIngest.parent_oid", orderable: true },
-      child_oid: { source: "PreservicaIngest.child_oid", orderable: true },
-      preservica_id: { source: "PreservicaIngest.preservica_id", orderable: true },
-      batch_process_id: { source: "PreservicaIngest.batch_process_id", orderable: true },
+      parent_oid: { source: "PreservicaIngest.parent_oid", searchable: true, orderable: true },
+      child_oid: { source: "PreservicaIngest.child_oid", searchable: true, orderable: true },
+      preservica_id: { source: "PreservicaIngest.preservica_id", searchable: true, orderable: false },
+      batch_process_id: { source: "PreservicaIngest.batch_process_id", searchable: true, orderable: true },
       timestamp: { source: "PreservicaIngest.ingest_time", orderable: true }
     }
   end
@@ -30,6 +36,6 @@ class PreservicaIngestDatatable < AjaxDatatablesRails::ActiveRecord
   end
 
   def get_raw_records # rubocop:disable Naming/AccessorMethodName
-    PreservicaIngest.all
+    PreservicaIngest.accessible_by(@current_ability, :read)
   end
 end

--- a/app/datatables/preservica_ingest_datatable.rb
+++ b/app/datatables/preservica_ingest_datatable.rb
@@ -1,27 +1,35 @@
+# frozen_string_literal: true
+
 class PreservicaIngestDatatable < AjaxDatatablesRails::ActiveRecord
+  extend Forwardable
+
+  def_delegators :@view, :link_to, :show_parent_preservica_ingest_path, :parent_object_path
 
   def view_columns
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      # id: { source: "User.id", cond: :eq },
-      # name: { source: "User.name", cond: :like }
+      parent_oid: { source: "PreservicaIngest.parent_oid", orderable: true },
+      child_oid: { source: "PreservicaIngest.child_oid", orderable: true },
+      preservica_id: { source: "PreservicaIngest.preservica_id", orderable: true },
+      batch_process_id: { source: "PreservicaIngest.batch_process_id", orderable: true },
+      timestamp: { source: "PreservicaIngest.ingest_time", orderable: true }
     }
   end
 
   def data
-    records.map do |record|
+    records.map do |preservica_ingest|
       {
-        # example:
-        # id: record.id,
-        # name: record.name
+        parent_oid: preservica_ingest.parent_oid,
+        child_oid: preservica_ingest.child_oid,
+        preservica_id: preservica_ingest.preservica_id,
+        batch_process_id: preservica_ingest.batch_process_id,
+        timestamp: preservica_ingest.ingest_time
       }
     end
   end
 
-  def get_raw_records
-    # insert query here
-    # User.all
+  def get_raw_records # rubocop:disable Naming/AccessorMethodName
+    PreservicaIngest.all
   end
-
 end

--- a/app/datatables/preservica_ingest_datatable.rb
+++ b/app/datatables/preservica_ingest_datatable.rb
@@ -17,7 +17,8 @@ class PreservicaIngestDatatable < AjaxDatatablesRails::ActiveRecord
     @view_columns ||= {
       parent_oid: { source: "PreservicaIngest.parent_oid", searchable: true, orderable: true },
       child_oid: { source: "PreservicaIngest.child_oid", searchable: true, orderable: true },
-      preservica_id: { source: "PreservicaIngest.preservica_id", searchable: true, orderable: false },
+      parent_preservica_id: { source: "PreservicaIngest.preservica_id", searchable: true, orderable: false },
+      child_preservica_id: { source: "PreservicaIngest.preservica_id", searchable: true, orderable: false },
       batch_process_id: { source: "PreservicaIngest.batch_process_id", searchable: true, orderable: true },
       timestamp: { source: "PreservicaIngest.ingest_time", orderable: true }
     }
@@ -28,7 +29,8 @@ class PreservicaIngestDatatable < AjaxDatatablesRails::ActiveRecord
       {
         parent_oid: preservica_ingest.parent_oid,
         child_oid: preservica_ingest.child_oid,
-        preservica_id: preservica_ingest.preservica_id,
+        parent_preservica_id: preservica_ingest.preservica_id,
+        child_preservica_id: preservica_ingest.preservica_child_id,
         batch_process_id: preservica_ingest.batch_process_id,
         timestamp: preservica_ingest.ingest_time
       }

--- a/app/datatables/preservica_ingest_datatable.rb
+++ b/app/datatables/preservica_ingest_datatable.rb
@@ -1,0 +1,27 @@
+class PreservicaIngestDatatable < AjaxDatatablesRails::ActiveRecord
+
+  def view_columns
+    # Declare strings in this format: ModelName.column_name
+    # or in aliased_join_table.column_name format
+    @view_columns ||= {
+      # id: { source: "User.id", cond: :eq },
+      # name: { source: "User.name", cond: :like }
+    }
+  end
+
+  def data
+    records.map do |record|
+      {
+        # example:
+        # id: record.id,
+        # name: record.name
+      }
+    end
+  end
+
+  def get_raw_records
+    # insert query here
+    # User.all
+  end
+
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,6 +11,7 @@ class Ability
       can :crud, AdminSet
       can :read, ParentObject
       can :read, ChildObject
+      can :read, PreservicaIngest
       can :reindex_all, ParentObject
       can :update_metadata, ParentObject
       can :trigger_mets_scan, ParentObject

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -10,6 +10,7 @@
     <% end  %>
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <%= link_to 'Preservation', preservica_ingests_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Notifications', notifications_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% if current_user&.sysadmin %>
       <%= link_to 'Delayed Job Dashboard', delayed_job_web_path, class: 'list-group-item list-group-item-action bg-light' %>

--- a/app/views/preservica_ingests/index.html.erb
+++ b/app/views/preservica_ingests/index.html.erb
@@ -1,4 +1,4 @@
-<p id="notice"><%= notice %></p>
+<p id='notice'><%= notice %></p>
 <div class='row'>
   <div class='col'>
     <h1>Preservica Ingests</h1>
@@ -6,10 +6,14 @@
 </div>
 <div class='row'>
   <div class='col overflow-auto'>
-    <table id="preservica-ingests-datatable" class="is-datatable table table-responsive table-bordered table-striped" data-source="<%= preservica_ingests_path(format: :json) %>">
-      <thead  class="thead-dark">
+    <table id='preservica-ingests-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= preservica_ingests_path(format: :json) %>'>
+      <thead  class='thead-dark'>
         <tr>
-          <th scope="col">Parent Oid</th>
+          <th scope='col'>Parent OID</th>
+          <th scope='col'>Child OID</th>
+          <th scope='col'>Preservica ID</th>
+          <th scope='col'>Batch Process ID</th>
+          <th scope='col'>Timestamp</th>
         </tr>
       </thead>
       <tbody>
@@ -18,6 +22,6 @@
   </div>
 </div>
 
-<div id="preservica-ingests-data" class='d-none datatable-data'>
+<div id='preservica-ingests-data' class='d-none datatable-data'>
   <%= PreservicaIngestDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
 </div>

--- a/app/views/preservica_ingests/index.html.erb
+++ b/app/views/preservica_ingests/index.html.erb
@@ -1,0 +1,23 @@
+<p id="notice"><%= notice %></p>
+<div class='row'>
+  <div class='col'>
+    <h1>Preservica Ingests</h1>
+  </div>
+</div>
+<div class='row'>
+  <div class='col overflow-auto'>
+    <table id="preservica-ingests-datatable" class="is-datatable table table-responsive table-bordered table-striped" data-source="<%= preservica_ingests_path(format: :json) %>">
+      <thead  class="thead-dark">
+        <tr>
+          <th scope="col">Parent Oid</th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div id="preservica-ingests-data" class='d-none datatable-data'>
+  <%= PreservicaIngestDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
+</div>

--- a/app/views/preservica_ingests/index.html.erb
+++ b/app/views/preservica_ingests/index.html.erb
@@ -7,7 +7,7 @@
 <div class='row'>
   <div class='col overflow-auto'>
     <table id='preservica-ingests-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= preservica_ingests_path(format: :json) %>'>
-      <thead  class='thead-dark'>
+      <thead class='thead-dark'>
         <tr>
           <th scope='col'>Parent OID</th>
           <th scope='col'>Child OID</th>

--- a/app/views/preservica_ingests/index.html.erb
+++ b/app/views/preservica_ingests/index.html.erb
@@ -11,7 +11,8 @@
         <tr>
           <th scope='col'>Parent OID</th>
           <th scope='col'>Child OID</th>
-          <th scope='col'>Preservica ID</th>
+          <th scope='col'>Parent Preservica ID</th>
+          <th scope='col'>Child Preservica ID</th>
           <th scope='col'>Batch Process ID</th>
           <th scope='col'>Timestamp</th>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resources :users, only: [:index, :edit, :update, :show, :new, :create]
   resources :child_objects
   resources :admin_sets
+  resources :preservica_ingests
 
   resources :parent_objects do
     collection do

--- a/spec/datatables/preservica_ingest_datatable_spec.rb
+++ b/spec/datatables/preservica_ingest_datatable_spec.rb
@@ -12,4 +12,30 @@ RSpec.describe PreservicaIngestDatatable, type: :datatable, prep_metadata_source
     expect(output).to eq([])
   end
 
+  describe 'mets xml import' do
+    let(:goobi_path) { 'spec/fixtures/goobi/metadata/30000317_20201203_140947/111860A_8394689_mets.xml' }
+    let(:mets_xml) { File.open(goobi_path).read }
+    let(:batch_process_xml) do
+      FactoryBot.create(
+        :batch_process,
+        user: user,
+        mets_xml: mets_xml,
+        file_name: 'meta.xml'
+      )
+    end
+
+    it 'renders data with proper permissions' do
+      batch_process_xml
+      output = PreservicaIngestDatatable.new(datatable_sample_params(columns), current_ability: Ability.new(user)).data
+
+      expect(output.size).to eq(1)
+      expect(output[0]).to include(
+        batch_process_id: batch_process_xml.id,
+        child_oid: nil,
+        parent_oid: 30_000_317,
+        preservica_id: 'b9afab50-9f22-4505-ada6-807dd7d05733'
+      )
+      expect(output[0][:timestamp]).to be_within(3.seconds).of(batch_process_xml.created_at)
+    end
+  end
 end

--- a/spec/datatables/preservica_ingest_datatable_spec.rb
+++ b/spec/datatables/preservica_ingest_datatable_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PreservicaIngestDatatable, type: :datatable, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
-  columns = ['parent_oid', 'child_oid', 'preservica_id', 'batch_process_id', 'timestamp']
+  columns = ['parent_oid', 'child_oid', 'parent_preservica_id', 'parent_preservica_id', 'batch_process_id', 'timestamp']
 
   it 'can handle an empty model set' do
     output = PreservicaIngestDatatable.new(datatable_sample_params(columns), current_ability: Ability.new(user)).data
@@ -33,7 +33,8 @@ RSpec.describe PreservicaIngestDatatable, type: :datatable, prep_metadata_source
         batch_process_id: batch_process_xml.id,
         child_oid: nil,
         parent_oid: 30_000_317,
-        preservica_id: 'b9afab50-9f22-4505-ada6-807dd7d05733'
+        parent_preservica_id: 'b9afab50-9f22-4505-ada6-807dd7d05733',
+        child_preservica_id: nil
       )
       expect(output[0][:timestamp]).to be_within(3.seconds).of(batch_process_xml.created_at)
     end

--- a/spec/datatables/preservica_ingest_datatable_spec.rb
+++ b/spec/datatables/preservica_ingest_datatable_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PreservicaIngestDatatable, type: :datatable, prep_metadata_sources: true do
+  let(:user) { FactoryBot.create(:sysadmin_user) }
+  columns = ['parent_oid', 'child_oid', 'preservica_id', 'batch_process_id', 'timestamp']
+
+  it 'can handle an empty model set' do
+    output = PreservicaIngestDatatable.new(datatable_sample_params(columns), current_ability: Ability.new(user)).data
+
+    expect(output).to eq([])
+  end
+
+end


### PR DESCRIPTION
co-author: alisha evans <alisha@notch8.com>
co-author: dylan salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1216

# Expected behavior
- A new "Preservation" menu item appears on the left menu on the Management home page
- The item links to a page that contains a datatable
- The datatable shows the following columns:
    - parent OID [searchable, sortable]
    - child OID (if a child object) [searchable, sortable]
    - Preservica ID [searchable]
    - the associated batch process ID (if available) [searchable, sortable]
    - the ingest timestamp [searchable]
- Sysadmins can see all data

# Demo
![image](https://user-images.githubusercontent.com/29032869/116477107-06731000-a831-11eb-8e34-56ad5792deb7.png)
