### PR TITLE
Add languageCode -> languageCode_ssim mapping

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -79,6 +79,7 @@ module SolrIndexable
       indexedBy_tsim: json_to_index["indexedBy"],
       label_tesim: child_labels,
       language_ssim: json_to_index["language"],
+      languageCode_ssim: json_to_index["languageCode"],
       localRecordNumber_ssim: json_to_index["localRecordNumber"],
       material_tesim: json_to_index["material"],
       number_of_pages_ss: json_to_index["numberOfPages"],

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SolrIndexable, type: :model do
+  let(:solr_indexable) { ParentObject.new }
+
+  before do
+    allow(solr_indexable).to receive(:manifest_completed?).and_return(true)
+  end
+
+  it "indexes language and languageCode" do
+    solr_document = solr_indexable.to_solr('languageCode' => ['eng'], 'language' => ['English'])
+    expect(solr_document[:languageCode_ssim]).to eq(['eng'])
+    expect(solr_document[:language_ssim]).to eq(['English'])
+  end
+end


### PR DESCRIPTION
Adds mapping from languageCode from authoritative JSON to the solr record as languageCode_ssim.

(Reindex required for this PR to take effect.)