### PR TITLE
Parent Object full_text? method

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -100,12 +100,9 @@ class ChildObject < ApplicationRecord
   end
 
   def remote_ocr_path
-    # What does this path look like? Currently there is only one directory - fulltext/
-    # Once we have the path we can use use this path in the remote_ocr method to check if the object that is returned has a content_type of txt
-
-    # return @remote_ptiff_path if @remote_ptiff_path
-    # pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
-    # @remote_ptiff_path = File.join("ptiffs", pairtree_path, File.basename(access_master_path))
+    return @remote_ocr_path if @remote_ocr_path
+    pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
+    @remote_ocr_path = File.join('fulltext', pairtree_path, "#{oid}.txt")
   end
 
   def pyramidal_tiff

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -44,7 +44,7 @@ class ChildObject < ApplicationRecord
   end
 
   def remote_ocr
-    S3Service.full_text_exists?(remote_oc_path)
+    S3Service.full_text_exists?(remote_ocr_path)
   end
 
   def access_master_path

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -43,6 +43,10 @@ class ChildObject < ApplicationRecord
     S3Service.remote_metadata(remote_ptiff_path)
   end
 
+  def remote_ocr
+    S3Service.full_text_exists?(remote_oc_path)
+  end
+
   def access_master_path
     return @access_master_path if @access_master_path
     image_mount = ENV['ACCESS_MASTER_MOUNT'] || "data"
@@ -93,6 +97,15 @@ class ChildObject < ApplicationRecord
     return @remote_ptiff_path if @remote_ptiff_path
     pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
     @remote_ptiff_path = File.join("ptiffs", pairtree_path, File.basename(access_master_path))
+  end
+
+  def remote_ocr_path
+    # What does this path look like? Currently there is only one directory - fulltext/
+    # Once we have the path we can use use this path in the remote_ocr method to check if the object that is returned has a content_type of txt
+
+    # return @remote_ptiff_path if @remote_ptiff_path
+    # pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
+    # @remote_ptiff_path = File.join("ptiffs", pairtree_path, File.basename(access_master_path))
   end
 
   def pyramidal_tiff

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -341,6 +341,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def full_text?
     # Iterate over the child objects and check the bucket to see if any children have a .txt file
     return false unless child_objects.any?
-    child_objects.map(&:remote_ocr)
+    child_objects.map(&:remote_ocr).include?(true)
   end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -339,8 +339,16 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def full_text?
-    # Iterate over the child objects and check the bucket to see if any children have a .txt file
+    # Iterate over the child objects and check the bucket to see if the first children have a .txt file
     return false unless child_objects.any?
-    child_objects.any?(&:remote_ocr)
+    child_objects.first.remote_ocr
+
+    # This will iterate over all child objects to check if they have a .txt file in the ocr bucket
+    # If any do not have a .txt file, the loop will exit and return false
+
+    # child_objects.each do |object|
+    #   return false unless object.remote_ocr
+    # end
+    # true
   end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -341,6 +341,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def full_text?
     return false unless child_objects.any?
     # Iterate over the child objects and check the bucket to see if any children have a .txt file (what does this structure look like?)
-    child_objects.map(&:full_text_exists?)
+    child_objects.map(&:remote_ocr)
   end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -337,4 +337,10 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def batch_connections_for(batch_process)
     batch_connections.where(batch_process: batch_process)
   end
+
+  def full_text?
+    return false unless child_objects.any?
+    # Iterate over the child objects and check the bucket to see if any children have a .txt file (what does this structure look like?)
+    child_objects.map(&:full_text_exists?)
+  end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -339,8 +339,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def full_text?
+    # Iterate over the child objects and check the bucket to see if any children have a .txt file
     return false unless child_objects.any?
-    # Iterate over the child objects and check the bucket to see if any children have a .txt file (what does this structure look like?)
     child_objects.map(&:remote_ocr)
   end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -341,6 +341,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def full_text?
     # Iterate over the child objects and check the bucket to see if any children have a .txt file
     return false unless child_objects.any?
-    child_objects.map(&:remote_ocr).include?(true)
+    child_objects.any?(&:remote_ocr)
   end
 end

--- a/app/services/s3_service.rb
+++ b/app/services/s3_service.rb
@@ -56,4 +56,12 @@ class S3Service
     object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
     object.exists?
   end
+
+  # We need to figure out the default bucket. This is just one of the ocr buckets but we should use an ENV variable
+  # The directories are set up on S3 but they are empty (yul-dc-ocr-test etc.)
+  # Update bucket from "yul-dc-ocr-test" when we have ENV variables set up
+  def self.full_text_exists?(remote_path, bucket = "yul-dc-ocr-test")
+    object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
+    return true if object.content_type == "txt"
+  end
 end

--- a/app/services/s3_service.rb
+++ b/app/services/s3_service.rb
@@ -57,12 +57,13 @@ class S3Service
     object.exists?
   end
 
-  # The directories are set up on S3 but they are empty (yul-dc-ocr-test etc.)
   def self.full_text_exists?(remote_path, bucket = ENV['OCR_DOWNLOAD_BUCKET'])
-    # TODO(alishaevn): remove the line below when we are able to access the env variable
-    bucket = 'yul-dc-ocr-test'
     object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
-    return true if object.exists? && object.content_type == 'text/plain'
+    begin
+      return true if object.exists? && object.content_type == 'text/plain'
+    rescue Aws::S3::Errors::Forbidden
+      false
+    end
     false
   end
 end

--- a/app/services/s3_service.rb
+++ b/app/services/s3_service.rb
@@ -63,5 +63,6 @@ class S3Service
     bucket = 'yul-dc-ocr-test'
     object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
     return true if object.exists? && object.content_type == 'text/plain'
+    false
   end
 end

--- a/app/services/s3_service.rb
+++ b/app/services/s3_service.rb
@@ -57,11 +57,11 @@ class S3Service
     object.exists?
   end
 
-  # We need to figure out the default bucket. This is just one of the ocr buckets but we should use an ENV variable
   # The directories are set up on S3 but they are empty (yul-dc-ocr-test etc.)
-  # Update bucket from "yul-dc-ocr-test" when we have ENV variables set up
-  def self.full_text_exists?(remote_path, bucket = "yul-dc-ocr-test")
+  def self.full_text_exists?(remote_path, bucket = ENV['OCR_DOWNLOAD_BUCKET'])
+    # TODO(alishaevn): remove the line below when we are able to access the env variable
+    bucket = 'yul-dc-ocr-test'
     object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
-    return true if object.content_type == "txt"
+    return true if object.exists? && object.content_type == 'text/plain'
   end
 end

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -77,11 +77,6 @@
 </p>
 
 <p>
-  <strong>Full Text Available:</strong>
-  <%= @parent_object.full_text? %>
-</p>
-
-<p>
   <strong>Display Layout / Viewing Hint:</strong>
   <%= @parent_object.display_layout %>
 </p>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -77,6 +77,11 @@
 </p>
 
 <p>
+  <strong>Full Text Available:</strong>
+  <%= @parent_object.full_text? %>
+</p>
+
+<p>
   <strong>Display Layout / Viewing Hint:</strong>
   <%= @parent_object.display_layout %>
 </p>

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
 
       it "can determine if any of it's children have fulltext availability" do
-        expect(parent_object.full_text?).to include(true)
+        expect(parent_object.full_text?).to eq(true)
       end
     end
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -296,11 +296,11 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
     end
 
-    context "a parent object" do
+    context "a parent object with children" do
       let(:parent_object) { described_class.create(oid: "2004628", admin_set: FactoryBot.create(:admin_set)) }
       before do
         stub_metadata_cloud("2004628")
-        stub_request(:head, "https://yul-dc-ocr-test.s3.amazonaws.com/fulltext/89/45/67/89/456789.txt")
+        stub_request(:head, "https://yul-dc-ocr-test.s3.amazonaws.com/fulltext/03/10/42/00/1042003.txt")
         .to_return(status: 200, headers: { 'Content-Type' => 'text/plain' })
       end
 

--- a/spec/services/s3_service_spec.rb
+++ b/spec/services/s3_service_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe S3Service, type: :has_vcr do
       .to_return(status: 200, headers: { 'X-Amz-Meta-Width' => '100',
                                          'X-Amz-Meta-Height' => '200',
                                          'Content-Type' => 'image/tiff' })
+    stub_request(:head, "https://yul-dc-ocr-test.s3.amazonaws.com/fulltext/43/10/14/54/1014543.txt")
+      .to_return(status: 200, headers: { 'Content-Type' => 'text/plain' })
     stub_request(:head, "https://yale-test-image-samples.s3.amazonaws.com/originals/1014543.tif")
       .to_return(status: 200, body: "")
     stub_request(:head, "https://yale-test-image-samples.s3.amazonaws.com/originals/fake.tif")
@@ -38,6 +40,7 @@ RSpec.describe S3Service, type: :has_vcr do
     original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
     ENV['SAMPLE_BUCKET'] = "yul-test-samples"
     ENV["S3_SOURCE_BUCKET_NAME"] = "yale-test-image-samples"
+    ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
     example.run
     ENV['SAMPLE_BUCKET'] = original_metadata_sample_bucket
     ENV["S3_SOURCE_BUCKET_NAME"] = original_image_bucket
@@ -96,5 +99,11 @@ RSpec.describe S3Service, type: :has_vcr do
   it "can retrieve the metadata from S3" do
     remote_path = "tests/fake_ptiff.tif"
     expect(described_class.remote_metadata(remote_path)).to include(width: "100", height: "200")
+  end
+
+  it "can tell if full text exists on an object" do
+    child_object_oid = "1014543"
+    remote_path = "fulltext/43/10/14/54/#{child_object_oid}.txt"
+    expect(described_class.full_text_exists?(remote_path)).to eq(true)
   end
 end


### PR DESCRIPTION
co-author: alisha evans <alisha@notch8.com>
co-author: dylan salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1258

# Expected behavior
- A ```full_text?``` method on a ParentObject returns true if a .txt file exists in the OCR bucket for the first child OID.
- This value is displayed on the ParentObject's show page, e.g. "Full Text Available: true"

# Demo
![Screen Shot 2021-05-07 at 8 38 52 AM](https://user-images.githubusercontent.com/50561476/117474370-b3bfe500-af0f-11eb-8090-46034f43b3e3.png)
![Screen Shot 2021-05-07 at 8 38 25 AM](https://user-images.githubusercontent.com/50561476/117474422-bb7f8980-af0f-11eb-8a6d-9b882a260370.png)
