### PR TITLE
Add logs for manifest actions

### DIFF
--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -11,6 +11,8 @@ class GenerateManifestJob < ApplicationJob
     parent_object.current_batch_process = current_batch_process
     parent_object.current_batch_connection = current_batch_connection
     generate_manifest(parent_object)
+    update_manifest_log(parent_object)
+
     index_to_solr(parent_object)
     GeneratePdfJob.perform_later(parent_object, current_batch_process, current_batch_connection)
   end
@@ -32,6 +34,19 @@ class GenerateManifestJob < ApplicationJob
   rescue => e
     parent_object.processing_event("IIIF Manifest generation failed due to #{e.message}", "failed")
     raise # this reraises the error after we document it
+  end
+
+  def update_manifest_log(parent_object)
+    ## logs create if checksum is nil
+    if parent_object.create_manifest_log?
+      parent_object.create_manifest_log
+    else
+      # #checks if checksum is different before update
+      updated_checksum = Digest::SHA1.hexdigest parent_object.iiif_manifest.to_yaml
+      parent_object.manifest_logs << { status: "Update", timestamp: Time.zone.now } unless updated_checksum.eql? parent_object.manifest_checksum
+    end
+
+    parent_object.save!
   end
 
   def index_to_solr(parent_object)

--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -42,8 +42,12 @@ class GenerateManifestJob < ApplicationJob
       parent_object.create_manifest_log
     else
       # #checks if checksum is different before update
-      updated_checksum = Digest::SHA1.hexdigest parent_object.iiif_manifest.to_yaml
-      parent_object.manifest_logs << { status: "Update", timestamp: Time.zone.now } unless updated_checksum.eql? parent_object.manifest_checksum
+      updated_checksum = parent_object.iiif_presentation.checksum
+
+      unless parent_object.manifest_checksum.eql? updated_checksum
+        parent_object.manifest_logs << { status: "Update", timestamp: Time.zone.now } unless updated_checksum.eql? parent_object.manifest_checksum
+        parent_object.manifest_checksum = updated_checksum
+      end
     end
 
     parent_object.save!

--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -167,4 +167,8 @@ class IiifPresentation
   def manifest_path
     @manifest_path ||= "manifests/#{pairtree_path}/#{oid}.json" if pairtree_path && oid
   end
+
+  def checksum
+    Digest::SHA1.hexdigest manifest.to_json
+  end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -302,7 +302,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def create_manifest_log
     self.manifest_logs ||= []
     self.manifest_logs << { status: "Create", timestamp: Time.zone.now }
-    self.manifest_checksum = Digest::SHA1.hexdigest iiif_manifest.to_yaml
+    self.manifest_checksum = iiif_presentation.checksum
   end
 
   def manifest_completed?

--- a/db/migrate/20210429171426_add_manifest_logs_to_parent_objects.rb
+++ b/db/migrate/20210429171426_add_manifest_logs_to_parent_objects.rb
@@ -1,0 +1,5 @@
+class AddManifestLogsToParentObjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:parent_objects, :manifest_logs, :text)
+  end
+end

--- a/db/migrate/20210429171457_add_manifest_checksum_to_parent_objects.rb
+++ b/db/migrate/20210429171457_add_manifest_checksum_to_parent_objects.rb
@@ -1,0 +1,5 @@
+class AddManifestChecksumToParentObjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :parent_objects, :manifest_checksum, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_204716) do
+ActiveRecord::Schema.define(version: 2021_04_29_171457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,6 +163,8 @@ ActiveRecord::Schema.define(version: 2021_04_07_204716) do
     t.string "extent_of_digitization"
     t.datetime "last_mets_update"
     t.bigint "admin_set_id"
+    t.text "manifest_logs"
+    t.string "manifest_checksum"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -579,7 +579,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           expect(parent_object.manifest_logs.first[:status]).to eq "Create"
 
           parent_object.visibility = "Private"
-          parent_object.remove_instance_variable(:@iiif_manifest)
           parent_object.remove_instance_variable(:@iiif_presentation)
           parent_object.generate_manifest = true
           parent_object.save!
@@ -603,7 +602,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           expect(parent_object.manifest_logs.first[:status]).to eq "Create"
 
           parent_object.representative_child_oid = 1_329_644
-          parent_object.remove_instance_variable(:@iiif_manifest)
           parent_object.remove_instance_variable(:@iiif_presentation)
           parent_object.generate_manifest = true
           parent_object.save!
@@ -615,7 +613,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         end
         it 'does not have "Update" action for the same manifest' do
           handle_manifest_gen(parent_object)
-          parent_object.remove_instance_variable(:@iiif_manifest)
           parent_object.remove_instance_variable(:@iiif_presentation)
           parent_object.generate_manifest = true
           parent_object.save!
@@ -633,7 +630,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           expect(parent_object.manifest_logs.first[:status]).to eq "Create"
 
           parent_object.visibility = "Private"
-          parent_object.remove_instance_variable(:@iiif_manifest)
           parent_object.remove_instance_variable(:@iiif_presentation)
           parent_object.generate_manifest = true
           parent_object.save!

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -21,11 +21,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     stub_metadata_cloud("2005512", "ladybird")
     stub_metadata_cloud("V-2004628", "ils")
     stub_metadata_cloud("2034600", "ladybird")
+
     stub_metadata_cloud("16414889")
     stub_metadata_cloud("14716192")
     stub_metadata_cloud("16854285")
     stub_metadata_cloud("16057779")
     stub_ptiffs_and_manifests
+    stub_request(:any, /localhost:8182*/).to_return(body: '{"service_id": 123123, "width": 10, "height": 10}')
   end
 
   context "with four child objects", :has_vcr do
@@ -538,9 +540,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
   end
 
   context 'a Parent Object' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:parent_object) { FactoryBot.build(:parent_object, oid: 2_107_188, visibility: "Public") }
     it 'finds batch connections to the batch process' do
-      user = FactoryBot.create(:user)
-      parent_object = FactoryBot.create(:parent_object, oid: 2_003_431)
       batch_process = BatchProcess.new(oid: parent_object.oid, user: user)
       batch_process.batch_connections.build(connectable: parent_object)
       batch_process.save!
@@ -548,5 +550,105 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
 
       expect(parent_object.batch_connections_for(batch_process)).to eq(batch_connection)
     end
+
+    describe 'manifest logs', :vpn_only do
+      let(:generate_manifest_job) { GenerateManifestJob.new }
+
+      before do
+        stub_request(:head, "https://#{ENV['SAMPLE_BUCKET']}.s3.amazonaws.com/manifests/00/20/34/60/2034600.json")
+            .to_return(status: 200)
+        stub_request(:head, "https://#{ENV['SAMPLE_BUCKET']}.s3.amazonaws.com/manifests/12/20/05/51/2005512.json")
+            .to_return(status: 200)
+        stub_request(:head, "https://#{ENV['SAMPLE_BUCKET']}.s3.amazonaws.com/manifests/89/16/41/48/89/16414889.json")
+            .to_return(status: 200)
+        stub_request(:head, "https://#{ENV['SAMPLE_BUCKET']}.s3.amazonaws.com/manifests/92/14/71/61/92/14716192.json")
+            .to_return(status: 200)
+        stub_request(:head, "https://#{ENV['SAMPLE_BUCKET']}.s3.amazonaws.com/manifests/85/16/85/42/85/16854285.json")
+            .to_return(status: 200)
+      end
+
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
+      end
+
+      context 'creating manifest' do
+        it '"Create" action proceeds a "Delete" action' do
+          handle_manifest_gen(parent_object)
+          expect(parent_object.manifest_logs.first[:status]).to eq "Create"
+
+          parent_object.visibility = "Private"
+          parent_object.remove_instance_variable(:@iiif_manifest)
+          parent_object.remove_instance_variable(:@iiif_presentation)
+          parent_object.generate_manifest = true
+          parent_object.save!
+
+          handle_manifest_gen(parent_object)
+
+          expect(parent_object.manifest_logs.length).to eq 3
+          expect(parent_object.manifest_logs.first[:status]).to eq "Create"
+          expect(parent_object.manifest_logs[1][:status]).to eq "Delete"
+          expect(parent_object.manifest_logs.last[:status]).to eq "Create"
+        end
+        it 'has a "Create" action for new parents' do
+          handle_manifest_gen(parent_object)
+          expect(parent_object.manifest_logs.first[:status]).to eq "Create"
+        end
+      end
+
+      context 'updating manifest' do
+        it 'has "Update" action for a different manifest' do
+          handle_manifest_gen(parent_object)
+          expect(parent_object.manifest_logs.first[:status]).to eq "Create"
+
+          parent_object.representative_child_oid = 1_329_644
+          parent_object.remove_instance_variable(:@iiif_manifest)
+          parent_object.remove_instance_variable(:@iiif_presentation)
+          parent_object.generate_manifest = true
+          parent_object.save!
+
+          handle_manifest_gen(parent_object)
+
+          expect(parent_object.manifest_logs.length).to eq 2
+          expect(parent_object.manifest_logs.last[:status]).to eq "Update"
+        end
+        it 'does not have "Update" action for the same manifest' do
+          handle_manifest_gen(parent_object)
+          parent_object.remove_instance_variable(:@iiif_manifest)
+          parent_object.remove_instance_variable(:@iiif_presentation)
+          parent_object.generate_manifest = true
+          parent_object.save!
+
+          handle_manifest_gen(parent_object)
+
+          expect(parent_object.manifest_logs.length).to eq 1
+          expect(parent_object.manifest_logs.last[:status]).to eq "Create"
+        end
+      end
+
+      context 'delete manifest' do
+        it 'has a "Delete" action when changing parent to private' do
+          handle_manifest_gen(parent_object)
+          expect(parent_object.manifest_logs.first[:status]).to eq "Create"
+
+          parent_object.visibility = "Private"
+          parent_object.remove_instance_variable(:@iiif_manifest)
+          parent_object.remove_instance_variable(:@iiif_presentation)
+          parent_object.generate_manifest = true
+          parent_object.save!
+
+          expect(parent_object.manifest_logs.length).to eq 2
+          expect(parent_object.manifest_logs.last[:status]).to eq "Delete"
+        end
+      end
+    end
   end
+end
+
+def handle_manifest_gen(parent_object)
+  batch_process = BatchProcess.new(oid: parent_object.oid, user: user)
+  batch_process.batch_connections.build(connectable: parent_object)
+  batch_process.save
+  generate_manifest_job.perform(parent_object, batch_process)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,9 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  config.before do
+    stub_request(:any, /localhost:8182*/).to_return(body: '{"service_id": 123123, "width": 10, "height": 10}')
+  end
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:


### PR DESCRIPTION
yalelibrary/YUL-DC#1238

**Story**

For each Parent Object, we need to track changes to its associated IIIF Manifest.   This data will be used to generate an Activity Stream as described in the  IIIF Change Discovery API https://iiif.io/api/discovery/   Essentially this requires a log of CRUD actions on the Manifest, presented in chronological order.

Note: we'll eventually decide where/how to generate the ActivityStreams, but that's for another ticket.  This may involve creating a database table to log this data, or sending it to another system.

**Acceptance**
-  Create a log entry for each of the events below.  
   - [x] `Create` when a Manifest is first published, or published from a deleted or non-accessible  (i.e., not Public or YCO)  state
   - [x] `Update` when a Manifest is updated
      - [x] Changes that do not change the contents of the Manifest should not create an Update event.   (Store manifest checksum on the parent object and use that for comparison.)
   - [x] `Delete` when a Manifest is deleted or the Parent is made inaccessible (i.e., not Public or YCO)
   - [x] A timestamp is logged for each event.


