### PR TITLE
delete other fields in the logical info

### DIFF
--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -101,11 +101,7 @@ class MetsDocument
 
   def logical_info(logical_div)
     {
-      dmdid: logical_div.xpath("@DMDID").inner_text,
-      logical_id: logical_div.xpath("@ID").inner_text,
-      caption: caption_info(logical_div),
-      type: logical_div.xpath("@TYPE").inner_text,
-      type_label: logical_div.xpath("@LABEL").inner_text
+      caption: caption_info(logical_div)
     }
   end
 

--- a/spec/models/mets_document_spec.rb
+++ b/spec/models/mets_document_spec.rb
@@ -181,10 +181,6 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true, prep_adm
     mets_doc = described_class.new(has_caption_file)
     expect(mets_doc.combined.first[:caption]).to eq "Swatch 1"
     expect(mets_doc.logical_divs.first[:caption]).to eq "Swatch 1"
-    expect(mets_doc.logical_divs.first[:type]).to eq "caption"
     expect(mets_doc.logical_divs.second[:caption]).to eq nil
-    expect(mets_doc.logical_divs.second[:type_label]).to eq "Swatch 2"
-    expect(mets_doc.logical_divs.last[:type]).to eq "cover"
-    expect(mets_doc.logical_divs.first[:dmdid]).to eq "DMDLOG_0001"
   end
 end


### PR DESCRIPTION
others fields in the logical_info should not be combined to child object hash.
Delete them. 
Quick fix for https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1276