### PR TITLE
1292 directory scan speed

### DIFF
--- a/app/lib/mets_directory_scanner.rb
+++ b/app/lib/mets_directory_scanner.rb
@@ -5,7 +5,7 @@ require 'find'
 class MetsDirectoryScanner
   def self.perform_scan # rubocop:disable Metrics/AbcSize
     MetsDirectoryScanner.scan_directories.each do |directory|
-      Dir.glob(File.join(directory, '**/*_mets.xml')) do |path|
+      Dir.glob(File.join(directory, '*/*_mets.xml')) do |path|
         next unless path =~ /.*_mets\.xml$/ && path !~ /.*xslt_result_mets\.xml$/
         check_file(path)
       end

--- a/app/lib/mets_directory_scanner.rb
+++ b/app/lib/mets_directory_scanner.rb
@@ -5,13 +5,7 @@ require 'find'
 class MetsDirectoryScanner
   def self.perform_scan # rubocop:disable Metrics/AbcSize
     MetsDirectoryScanner.scan_directories.each do |directory|
-      Find.find(directory) do |path|
-        if FileTest.directory?(path)
-          if File.basename(path).start_with?('.')
-            Find.prune # Don't look any further into this directory.
-          end
-          next
-        end
+      Dir.glob(File.join(directory, '**/*_mets.xml')) do |path|
         next unless path =~ /.*_mets\.xml$/ && path !~ /.*xslt_result_mets\.xml$/
         check_file(path)
       end


### PR DESCRIPTION
Uses Dir.glob instead of Find.find to look for mets files.
It only looks one directory deep off of scan directories when looking for the mets files.


Co-authored-by: Maggie Zhao <maggie.zhao@yale.edu>