### PR TITLE
1294-switch-caption-and-label-fields

### DIFF
--- a/app/views/child_objects/_child_object.json.jbuilder
+++ b/app/views/child_objects/_child_object.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! child_object, :id, :oid, :caption, :label, :width, :height, :order, :parent_object_oid, :created_at, :updated_at
+json.extract! child_object, :id, :oid, :label, :caption, :width, :height, :order, :parent_object_oid, :created_at, :updated_at
 json.url child_object_url(child_object, format: :json)

--- a/app/views/child_objects/_form.html.erb
+++ b/app/views/child_objects/_form.html.erb
@@ -17,13 +17,13 @@
   </div>
 
   <div class="field">
-    <%= form.label :caption %>
-    <%= form.text_field :caption %>
+    <%= form.label :label %>
+    <%= form.text_field :label %>
   </div>
 
   <div class="field">
-    <%= form.label :label %>
-    <%= form.text_field :label %>
+    <%= form.label :caption %>
+    <%= form.text_field :caption %>
   </div>
 
   <div class="field">

--- a/app/views/child_objects/index.html.erb
+++ b/app/views/child_objects/index.html.erb
@@ -7,8 +7,8 @@
   <thead class="thead-dark">
     <tr>
       <th>Oid</th>
-      <th>Caption</th>
       <th>Label</th>
+      <th>Caption</th>
       <th>Width</th>
       <th>Height</th>
       <th>Order</th>
@@ -21,8 +21,8 @@
     <% @child_objects.each do |child_object| %>
       <tr>
         <td><%= child_object.oid %></td>
-        <td><%= child_object.caption %></td>
         <td><%= child_object.label %></td>
+        <td><%= child_object.caption %></td>
         <td><%= child_object.width %></td>
         <td><%= child_object.height %></td>
         <td><%= child_object.order %></td>

--- a/app/views/child_objects/show.html.erb
+++ b/app/views/child_objects/show.html.erb
@@ -6,13 +6,13 @@
 </p>
 
 <p>
-  <strong>Caption:</strong>
-  <%= @child_object.caption %>
+  <strong>Label:</strong>
+  <%= @child_object.label %>
 </p>
 
 <p>
-  <strong>Label:</strong>
-  <%= @child_object.label %>
+  <strong>Caption:</strong>
+  <%= @child_object.caption %>
 </p>
 
 <p>


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1294

# Expected behavior
- all instances of "label" and "caption" on a child object have been swapped so that "label" comes first

# Demo
| show | edit |
| --- | --- |
| <img width="600" alt="image" src="https://user-images.githubusercontent.com/29032869/118717320-c6bd9980-b7da-11eb-86df-528c0c85d9a3.png"> |<img width="711" alt="image" src="https://user-images.githubusercontent.com/29032869/118717374-d89f3c80-b7da-11eb-9ce7-9a45c4d047ce.png"> |

| list | new |
| --- | --- |
| <img width="1198" alt="image" src="https://user-images.githubusercontent.com/29032869/118717498-01273680-b7db-11eb-9066-28ebf9e32c8d.png"> | <img width="686" alt="image" src="https://user-images.githubusercontent.com/29032869/118717552-100de900-b7db-11eb-94c1-d4baa810f9f6.png"> |
