### PR TITLE
Add additional caption logical

### DIFF
--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -71,11 +71,21 @@ class MetsDocument
 
   # Combines the physical info and file info for a given image
   def combined
-    zipped = combined_logical_link_hash.nil? ? files.zip(physical_divs) : files.zip(combined_logical_link_physical_hash)
+    zipped = add_nil_caption.nil? ? files.zip(physical_divs) : files.zip(add_nil_caption)
     zipped.map { |file, physical_div| file.merge(physical_div) }
   end
 
   # merge into physical divs
+  def add_nil_caption
+    if combined_logical_link_hash.nil? == true
+      nil
+    else
+      combined_logical_link_physical_hash.each do |i|
+        i[:caption] = i[:caption].nil? ? nil : i[:caption]
+      end
+    end
+  end
+
   def combined_logical_link_physical_hash
     index = combined_logical_link_hash.group_by { |entry| entry[:physical_id] } unless combined_logical_link_hash.nil?
     physical_divs.map { |entry| (index[entry[:physical_id]] || []).reduce(entry, :merge) } unless combined_logical_link_hash.nil?

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -88,7 +88,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def create_child_records
     if from_mets
       upsert_child_objects(array_of_child_hashes_from_mets)
-      # byebug
       upsert_preservica_ingest_child_objects(array_preservica_hashes_from_mets)
 
     else

--- a/spec/fixtures/goobi/metadata/16172421/Not_all_images_caption_mets.xml
+++ b/spec/fixtures/goobi/metadata/16172421/Not_all_images_caption_mets.xml
@@ -646,6 +646,7 @@
   </mets:fileSec>
   <mets:structMap TYPE="LOGICAL">
     <mets:div ADMID="AMD" DMDID="DMDLOG_0000" ID="LOG_0000" LABEL="The Chilocco beacon" TYPE="ILSObject">
+      <mets:div DMDID="DMDLOG_0001" ID="LOG_0001" LABEL="test test" TYPE="Acknowledge" />
       <mets:div DMDID="DMDLOG_0001" ID="LOG_0001" LABEL="[V.1:no.1(1900:Nov.)]" TYPE="caption" />
       <mets:div DMDID="DMDLOG_0002" ID="LOG_0002" LABEL="[V.1:no.2(1900:Dec.)]" TYPE="caption" />
       <mets:div DMDID="DMDLOG_0003" ID="LOG_0003" LABEL="[V.1:no.3(1901:Jan.)]" TYPE="caption" />

--- a/spec/models/mets_document_spec.rb
+++ b/spec/models/mets_document_spec.rb
@@ -197,12 +197,13 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true, prep_adm
     mets_doc = described_class.new(has_test_not_all_caption_file)
     expect(mets_doc.combined.first[:caption]).to eq nil # first image does not have caption based on the structLink
     expect(mets_doc.combined[3][:caption]).to eq "[V.1:no.1(1900:Nov.)]" # first image has the caption
-    expect(mets_doc.logical_divs[3][:caption]).to eq "[V.1:no.4(1901:Feb.)]"
+    expect(mets_doc.logical_divs[4][:caption]).to eq "[V.1:no.4(1901:Feb.)]"
   end
 
   it "return nil for no logical/caption div" do
     mets_doc = described_class.new(has_test_no_caption_file)
-    expect(mets_doc.combined.first[:caption]).to eq nil
+    expect(mets_doc.logical_divs).to be_empty
+    expect(mets_doc.combined.first[:caption]). to eq nil
     expect(mets_doc.combined[3][:caption]).to eq nil
   end
 end


### PR DESCRIPTION

Co-authored-by: Frederick Rodriguez <frederick.rodriguez@yale.edu>

When one of the images does not have caption, :caption=> nil should be in the hash, otherwise should have "must be the same keys" error. 
The second child is expected to have nil as the screenshot

<img width="1738" alt="Screen Shot 2021-05-25 at 12 04 41 PM" src="https://user-images.githubusercontent.com/46331329/119530889-6f2aab00-bd51-11eb-8d2b-9422bdfbf7a6.png">