### PR TITLE
1318 remove solr field

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -181,7 +181,7 @@ module SolrIndexable
     {
       id: child_object.oid,
       parent_ssi: parent_object.oid,
-      child_fulltext_tesim: child_object_full_text,
+      child_fulltext_tesim: child_object_full_text
     }
   end
 

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -182,7 +182,6 @@ module SolrIndexable
       id: child_object.oid,
       parent_ssi: parent_object.oid,
       child_fulltext_tesim: child_object_full_text,
-      parent_visibility_ssi: parent_object.visibility
     }
   end
 


### PR DESCRIPTION
Removed parent visibility solr field

Martin Lovell <martin.lovell@yale.edu>

**Story**
We do not use the parent_visibility_ssi Solr field in the full-text feature code and the field should not have index data.

**Acceptance** 
 - [ ] Remove the field from the feature branch

