### PR TITLE
Add "Child Objects" to management left menu

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -9,6 +9,7 @@
       <%= link_to 'Sets', admin_sets_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% end  %>
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <%= link_to 'Child Objects', child_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Preservation', preservica_ingests_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Notifications', notifications_path, class: 'list-group-item list-group-item-action bg-light' %>

--- a/spec/system/slide_bar_spec.rb
+++ b/spec/system/slide_bar_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'slidebar', type: :system, js: true do
+  before do
+    visit '/'
+  end
+
+  it 'has css' do
+    expect(page).to have_css '.list-group-item'
+    expect(page).to have_css '.list-group-item-action'
+  end
+
+  it 'has a list of choices when the user is not authenticated' do
+    expect(page).to have_content("Dashboard")
+    expect(page).to have_content("Parent Objects")
+    expect(page).to have_content("Child Objects")
+    expect(page).to have_content("Batch Process")
+    expect(page).to have_content("Preservation")
+    expect(page).to have_content("Notifications")
+  end
+end


### PR DESCRIPTION
**Story**

As a management user, I would like to be able to sort and filter child objects like I do the parents.

**Acceptance**
- [x] Display "Child Objects" in the left menu, below "Parent Objects"
- [x] The link should lead to https://collections.library.yale.edu/management/child_objects
 
**Current Slidebar**
![Screen Shot 2021-05-28 at 2.36.19 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/b5743d03-da77-4b73-a3fc-3ab85a7e9e8f)

**Proposed Slidebar Modification**
![image](https://user-images.githubusercontent.com/41123693/120385416-64de5300-c2f5-11eb-834b-a7afbeaf25b6.png)

------
**Feature Demo** 
https://user-images.githubusercontent.com/41123693/120385295-3c565900-c2f5-11eb-8003-c6c35714369a.mov

