### PR TITLE
1332 mgmt UI header

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,0 +1,29 @@
+/********************************************************
+DEFAULT DESKTOP STYLING
+********************************************************/
+@import 'theme/colors', 'theme/typography', 'theme/breakpoints';
+
+.main_yale_management_banner{
+  background-color: $yale_blue;
+  height: 80px;
+  padding: 1% 0 0 2%;
+  display: flex;
+  align-items: center;
+}
+
+.main_yale_management_banner h1{
+  color: $white;
+  font-family: $yale_new_roman;
+  font-size: 36px;
+}
+.sub_yale_management_banner{
+  height: 60px;
+  border-bottom: 2px solid $yale_blue;
+  border-color: rgba(4, 54, 105, 0.4);}
+
+.sub_yale_management_banner h2{
+  color: $yale_blue;
+  font-family: $mallory_light;
+  font-size: 26px;
+  padding: 1% 0 0 2%;
+}

--- a/app/assets/stylesheets/theme/colors.scss
+++ b/app/assets/stylesheets/theme/colors.scss
@@ -1,5 +1,6 @@
 $black: #000000;
 $white: #FFFFFF;
+$yale_blue: #043669;
 
 // HEADER AND SUBHEAD
 $header_bg: #043669;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,12 @@
+
+<div class="flex-container yale_management_banner" id="wrapper">
+  <div class="header yale_management_header_brand">
+    <div class="main_yale_management_banner">
+      <h1> Yale University Library </h1>
+    </div>
+    <div class="sub_yale_management_banner">
+      <h2>Digital Library Management Portal</h2>
+    </div>
+  </div>
+</div>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= render 'layouts/header' %>
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "postcss": "^8.2.15",
     "ssri": "^8.0.1",
     "tailwindcss": "^2.1.2",
-    "turbolinks": "^5.2.0",
-    "ws": "^6.2.2"
+    "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/spec/system/header_subheader_spec.rb
+++ b/spec/system/header_subheader_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'header and subheader', type: :system, js: true do
+  before do
+    visit '/'
+  end
+
+  context 'the header' do
+    it 'has css' do
+      expect(page).to have_css '.main_yale_management_banner'
+      expect(page).to have_css '.main_yale_management_banner h1'
+    end
+
+    it 'has text for Yale branding' do
+      expect(page).to have_content("Yale University Library")
+    end
+  end
+
+  context 'the subheader' do
+    it 'has css' do
+      expect(page).to have_css '.sub_yale_management_banner'
+      expect(page).to have_css '.sub_yale_management_banner h2'
+    end
+
+    it 'has text for Yale branding' do
+      expect(page).to have_content("Digital Library Management Portal")
+    end
+  end
+end


### PR DESCRIPTION
**Story:** 

This ticket is for the creation of the header/navigation bar and the subnav bar for the Management app.  

NOTE: this will be a global header, as it will appear on every page of the management app. Look and feel will be consistent with the YUL DL).

**Acceptance:**
- [x] Create a main header/nav bar with the YUL brand.
- [x] Create a subheader/subnav bar with the name of the application 
**Other Notes**
- [x] Main navbar color: #043669 (Yale Blue); font: YaleNew Roman, semibold; font-size: 2em

-----
DEMO: 
**Designed Image** 
![Screen Shot 2021-06-03 at 12.31.34 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/491afed1-8325-4b5e-b91c-e6f83b4795a0)


**Actual Image**
![image](https://user-images.githubusercontent.com/41123693/120687291-df32e280-c46f-11eb-8d46-09d2120d03a2.png)

