### PR TITLE
Styled global footer

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,0 +1,12 @@
+/********************************************************
+DEFAULT DESKTOP STYLING
+********************************************************/
+@import 'theme/colors', 'theme/typography', 'theme/breakpoints';
+
+.yale_management_header_footer{
+  background-color: $white;
+  height: 70px;
+  padding: 1% 0 0 2%;
+  border-top: 2px solid $white;
+  border-color: rgba(209, 209, 209, 0.4);
+}

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,7 @@
-<div class="branch-name">
-  Branch: <span title="SHA:<%=GIT_SHA%>"><%=ENV['MANAGEMENT_VERSION']||GIT_BRANCH%></span>
-  <br>
-  Deployed:<%=DEPLOYED_AT%>
+<div class="flex-container yale_management_footer" id="wrapper">
+  <div class="footer yale_management_header_footer branch-name">
+    Branch: <span title="SHA:<%=GIT_SHA%>"><%=ENV['MANAGEMENT_VERSION']||GIT_BRANCH%></span>
+    <br>
+    Deployed:<%=DEPLOYED_AT%>
+  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,32 +1,32 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>YulDcManagement</title>
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
+<head>
+  <title>YulDcManagement</title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 
-    <%= render 'layouts/header' %>
+  <%= render 'layouts/header' %>
 
-  </head>
+</head>
 
-  <body>
-    <div class="d-flex" id="wrapper">
+<body>
+<div class="d-flex" id="wrapper">
 
-      <%= render 'layouts/sidebar' %>
-      <div id="page-content-wrapper">
-        <div class="main-content d-flex flex-column">
-          <div class="flex-grow-1">
-          <%= yield %>
-          </div>
-          <div>
-          <%= render 'layouts/footer' %>
-          </div>
-        </div>
+  <%= render 'layouts/sidebar' %>
+  <div id="page-content-wrapper">
+    <div class="main-content d-flex flex-column">
+      <div class="flex-grow-1">
+        <%= yield %>
       </div>
     </div>
-  </body>
+  </div>
+</div>
+</body>
+<div>
+  <%= render 'layouts/footer' %>
+</div>
 </html>

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe 'footer', type: :system do
 
   it 'has css' do
     expect(page).to have_css '.branch-name'
-    expect(page).to have_css '.yale_management_header_footer'f
+    expect(page).to have_css '.yale_management_header_footer'
   end
 end

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe 'footer', type: :system do
 
   it 'has css' do
     expect(page).to have_css '.branch-name'
+    expect(page).to have_css '.yale_management_header_footer'f
   end
 end


### PR DESCRIPTION
**Story:** 

Create a global footer for versioning info, so that it will be clear that this information applies to the whole app and not to whatever is on the current page. (See attached design mockup for reference)

![Screen Shot 2021-05-28 at 2.35.22 PM.png](https://images.zenhubusercontent.com/604a2edec7bb2836333e6ec0/2b9be5f7-0d2d-45e6-92d0-feab1b97b80d)

Acceptance: 

- [ ] Create a global footer with left-aligned versioning info (same as the current app, but moved into a specific region on the page)

----
**Actual Modification**
![image](https://user-images.githubusercontent.com/41123693/120709395-cbe14080-c48a-11eb-8122-d71a879a8592.png)
