### PR TITLE
Redesign of mgmt ui nav menu

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -19,7 +19,8 @@ DEFAULT DESKTOP STYLING
 .sub_yale_management_banner{
   height: 50px;
   border-bottom: 2px solid $yale_blue;
-  border-color: rgba(4, 54, 105, 0.4);}
+  border-color: rgba(4, 54, 105, 0.4);
+}
 
 .sub_yale_management_banner h2{
   color: $yale_blue;

--- a/app/assets/stylesheets/sidebar.scss
+++ b/app/assets/stylesheets/sidebar.scss
@@ -14,6 +14,7 @@ DEFAULT DESKTOP STYLING
   -moz-transition: margin .25s ease-out;
   -o-transition: margin .25s ease-out;
   transition: margin .25s ease-out;
+  border-right: 1px none #dee2e6 !important;
 }
 
 #sidebar-wrapper .sidebar-heading {
@@ -21,10 +22,44 @@ DEFAULT DESKTOP STYLING
   font-size: 1.2rem;
 }
 
-#sidebar-wrapper .list-group {
-  width: 15rem;
+.sidebar_yale{
+  width: 22%;
 }
 
+#sidebar-wrapper .list-group{
+  font-family: $mallory_book;
+  text-transform: uppercase;
+  font-size: 16px;
+}
+#sidebar-wrapper .flex-column{
+  width: auto;
+}
+
+#sidebar-wrapper .top-menu-item{
+  margin-top: 8%;
+}
+
+#sidebar-wrapper .list-group-item{
+  padding: 1rem 2.25rem;
+  border: 1px none rgba(0, 0, 0, 0.125);
+  color: $sidebar_links;
+}
+
+#sidebar-wrapper .border-right{
+    border-right: 1px none #dee2e6 !important;
+}
+
+#sidebar-wrapper .list-group-item:hover{
+  color: $sidebar_active_link;
+  background-color: $sidebar_hover !important;
+}
+
+#sidebar-wrapper .sign-button{
+  text-transform: capitalize;
+  color: $sidebar_sign_out;
+}
+
+//Body
 #page-content-wrapper {
   min-width: 100vw;
   margin: 33px;

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,7 +1,6 @@
-<div class="bg-light border-right" id="sidebar-wrapper">
-  <div class="sidebar-heading">Management</div>
-  <div class="list-group list-group-flush">
-    <%= link_to 'Dashboard', root_path, class: 'list-group-item list-group-item-action bg-light' %>
+<div class="bg-light border-right sidebar_yale" id="sidebar-wrapper">
+  <div class="flex-column list-group list-group-flush">
+    <%= link_to 'Dashboard', root_path, class: 'list-group-item list-group-item-action bg-light top-menu-item' %>
     <% if can? :manage, User %>
       <%= link_to 'Users', users_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% end  %>
@@ -17,13 +16,11 @@
       <%= link_to 'Delayed Job Dashboard', delayed_job_web_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% end %>
     <% if current_user %>
-      <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'list-group-item list-group-item-action bg-light' %>
+      <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'list-group-item list-group-item-action bg-light sign-button' %>
     <% else %>
       <!-- In order to address CVE-2015-9284 https://github.com/advisories/GHSA-ww4x-rwq6-qpgf the
           Sign In link *must* use post method, not get -->
-      <%= button_to 'Sign In', user_cas_omniauth_authorize_path, class: 'list-group-item list-group-item-action bg-light' %>
+      <%= button_to 'Sign In', user_cas_omniauth_authorize_path, class: 'list-group-item list-group-item-action bg-light sign-button' %>
     <% end %>
-
   </div>
-
 </div>

--- a/spec/system/delayed_job_spec.rb
+++ b/spec/system/delayed_job_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Delayed Jobs', type: :system, js: true do
 
     it 'are accessible through the delayed jobs dashboard menu item' do
       visit root_path
-      expect(page).to have_content('Delayed Job Dashboard')
+      expect(page).to have_content('DELAYED JOB DASHBOARD')
     end
     it 'are accessible manually through the delayed jobs endpoint' do
       visit delayed_job_web_path

--- a/spec/system/slide_bar_spec.rb
+++ b/spec/system/slide_bar_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'slidebar', type: :system, js: true do
+RSpec.describe 'the management application has sidebar', type: :system, js: true do
   before do
     visit '/'
   end
@@ -9,14 +9,24 @@ RSpec.describe 'slidebar', type: :system, js: true do
   it 'has css' do
     expect(page).to have_css '.list-group-item'
     expect(page).to have_css '.list-group-item-action'
+    expect(page).to have_css '.top-menu-item'
+    expect(page).to have_css '.flex-column'
+    expect(page).to have_css '.list-group'
+    expect(page).to have_css '.sidebar_yale'
+    expect(page).to have_css '.border-right'
+    expect(page).to have_css '.sign-button'
   end
 
   it 'has a list of choices when the user is not authenticated' do
-    expect(page).to have_content("Dashboard")
-    expect(page).to have_content("Parent Objects")
-    expect(page).to have_content("Child Objects")
-    expect(page).to have_content("Batch Process")
-    expect(page).to have_content("Preservation")
-    expect(page).to have_content("Notifications")
+    expect(page).to have_content("DASHBOARD")
+    expect(page).to have_content("PARENT OBJECTS")
+    expect(page).to have_content("CHILD OBJECTS")
+    expect(page).to have_content("BATCH PROCESS")
+    expect(page).to have_content("PRESERVATION")
+    expect(page).to have_content("NOTIFICATIONS")
+  end
+
+  it "item with hovering is visible to the user" do
+    find('.sidebar_yale').hover
   end
 end


### PR DESCRIPTION
**Story:** 

Give the current Management app sidebar a look and feel that is consistent with the current DL UI. 

**Acceptance:** 
- [x] Use approved Yale font (Mallory) for nav links
- [x] Use color for link and div to indicate current page (selected) - see design mockup. Color palette is attached for reference.  (https://xd.adobe.com/view/8f11c305-11c3-4fa2-8955-4f74f1f08942-da42/)


**Propose Design**
![image](https://user-images.githubusercontent.com/41123693/120861145-db2cc080-c554-11eb-9f71-78c8eba2bb20.png)

**Actual Design**
![NavMenuDesignv2](https://user-images.githubusercontent.com/41123693/120861794-dddbe580-c555-11eb-9d62-3b9c823eef3e.png)
