### PR TITLE
add dropdown of extent digitization datatable

### DIFF
--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -31,8 +31,8 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
       last_aspace_update: { source: "ParentObject.last_aspace_update", orderable: true },
       last_id_update: { source: "ParentObject.last_id_update", orderable: true },
       visibility: { source: "ParentObject.visibility", cond: :string_eq, searchable: true, options: ["Public", "Yale Community Only", "Private"], orderable: true },
-      extent_of_digitization: { source: "ParentObject.extent_of_digitization", orderable: true },
-      digitization_note: { source: "ParentObject.digitization_note", orderable: true },
+      extent_of_digitization: { source: "ParentObject.extent_of_digitization", cond: :string_eq, searchable: true, options: ["Completely digitized", "Partially digitized"], orderable: true },
+      digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true },
       actions: { source: "ParentObject.oid", cond: :null_value, searchable: false, orderable: false }
     }
   end

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -27,8 +27,10 @@ class MetsDocument
   end
 
   def extent_of_dig
-    eodig = @mets.xpath("//mods:part").first.inner_text
-    return nil unless eodig.include?("digitized")
+    eodig = @mets.xpath("//mods:part").first&.inner_text
+    unless eodig.nil?
+      return nil unless eodig.include?("digitized")
+    end
     eodig
   end
 

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -27,7 +27,7 @@ class MetsDocument
   end
 
   def extent_of_dig
-    eodig = @mets.xpath("//mods:part").inner_text
+    eodig = @mets.xpath("//mods:part").first.inner_text
     return nil unless eodig.include?("digitized")
     eodig
   end

--- a/spec/fixtures/goobi/metadata/eodig.xml
+++ b/spec/fixtures/goobi/metadata/eodig.xml
@@ -19,6 +19,13 @@
           </mods:recordInfo>
           <mods:part>Completely digitized</mods:part>
           <mods:classification authority="ivdcc">DefaultCollection</mods:classification>
+          <mods:part>
+            <mods>
+              <detail>
+                <mods:number>File 19004</mods:number>
+              </detail>
+            </mods>
+          </mods:part>
           <mods:originInfo>
             <mods:dateIssued keyDate="no">-1918.</mods:dateIssued>
             <mods:dateIssued keyDate="yes">1878</mods:dateIssued>

--- a/spec/models/mets_document_spec.rb
+++ b/spec/models/mets_document_spec.rb
@@ -50,11 +50,6 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true, prep_adm
       expect(mets_doc.valid_mets?).to be_falsey
     end
 
-    it "returns actual value Extent of digitization when present" do
-      mets_doc = described_class.new(has_digitized)
-      expect(mets_doc.extent_of_dig).to eq "Completely digitized"
-    end
-
     it "returns false when rights statement is not present" do
       mets_doc = described_class.new(no_rights_file)
       expect(mets_doc.valid_mets?).to be_falsey
@@ -212,6 +207,11 @@ RSpec.describe MetsDocument, type: :model, prep_metadata_sources: true, prep_adm
     expect(mets_doc.logical_divs).to be_empty
     expect(mets_doc.combined.first[:caption]). to eq nil
     expect(mets_doc.combined[3][:caption]).to eq nil
+  end
+
+  it "returns actual value Extent of digitization when present" do
+    mets_doc = described_class.new(has_digitized)
+    expect(mets_doc.extent_of_dig).to eq "Completely digitized"
   end
 
   it "returns empty digitization note " do


### PR DESCRIPTION
1. add drop down of extent of digitization in the parent object datatable
2. add search input box of digitization note
3. only parse the first xpath of mods:part because the containing group also uses the same xpath 

https://user-images.githubusercontent.com/46331329/121529066-0a668600-c9ca-11eb-87b7-e2f63b2759ff.mov

