### PR TITLE
Add has_fulltext_ssi for Parent Object full text availability

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -75,6 +75,7 @@ module SolrIndexable
       genre_tesim: json_to_index["genre"],
       geoSubject_ssim: json_to_index["geoSubject"],
       hashed_id_ssi: generate_hash,
+      has_fulltext_ssi: "No",
       identifierMfhd_ssim: json_to_index["identifierMfhd"],
       imageCount_isi: child_object_count,
       indexedBy_tsim: json_to_index["indexedBy"],
@@ -161,6 +162,8 @@ module SolrIndexable
     solr_document = to_solr(json_to_index)
     child_solr_documents = child_object_solr_documents
     solr_document[:fulltext_tesim] = child_solr_documents.map { |child_solr_document| child_solr_document[:child_fulltext_tesim] } unless solr_document.nil? || child_solr_documents.nil?
+    solr_document = append_full_text_status(solr_document)
+
     [solr_document, child_solr_documents]
   end
 
@@ -201,6 +204,14 @@ module SolrIndexable
         set << date.to_i
       end
     end.to_a
+  end
+
+  def append_full_text_status(solr_document)
+    return unless solr_document
+    present = solr_document.try(:[], "fulltext_tesim".to_sym).try("present?") ? "Yes" : "No"
+    solr_document[:has_fulltext_ssi] = present
+
+    solr_document
   end
 
   def generate_hash

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           solr_document = parent_of_four.to_solr_full_text.first
           expect(solr_document).not_to be_nil
           expect(solr_document[:fulltext_tesim].to_s).to include("много трудившейся")
+          expect(solr_document[:has_fulltext_ssi].to_s).to eq "Yes"
         end
       end
     end


### PR DESCRIPTION
- In management
   - [x] Parent Objects without full text should set the value  `No` in the Solr field
   - [x] Parent Objects with full text should set the value `Yes` in the Solr field