### PR TITLE
Display Bib and Barcode for Aspace authority items

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -240,6 +240,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def aspace_json=(a_record)
     super(a_record)
     self.last_aspace_update = DateTime.current if a_record.present?
+    self.bib = a_record["orbisBibId"]
+    self.barcode = a_record["orbisBarcode"]
   end
 
   def ladybird_cloud_url

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -399,9 +399,8 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
 
       it "correctly sets the bib and barcode on the parent object" do
-        parent_object.reload
-        expect(parent_object.aspace_json["orbisBibId"]).to eq "6805375"
-        expect(parent_object.aspace_json["orbisBarcode"]).to eq "39002091459793"
+        expect(parent_object.bib).to eq "6805375"
+        expect(parent_object.barcode).to eq "39002091459793"
       end
     end
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -379,6 +379,8 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         described_class.create(
           oid: "2012036",
           aspace_uri: "/repositories/11/archival_objects/555049",
+          bib: "6805375",
+          barcode: "39002091459793",
           authoritative_metadata_source_id: aspace,
           admin_set: FactoryBot.create(:admin_set)
         )
@@ -394,6 +396,12 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         expect(parent_object.aspace_json).not_to be nil
         expect(parent_object.aspace_json).not_to be_empty
         expect(parent_object.voyager_json).to be nil
+      end
+
+      it "correctly sets the bib and barcode on the parent object" do
+        parent_object.reload
+        expect(parent_object.aspace_json["orbisBibId"]).to eq "6805375"
+        expect(parent_object.aspace_json["orbisBarcode"]).to eq "39002091459793"
       end
     end
 


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1328

# Expected behavior
The bib and barcode should be set on the parent object when aspace json is applied.

# Demo
![Screen Shot 2021-06-15 at 10 48 24 AM](https://user-images.githubusercontent.com/50561476/122099767-3b2e2d00-cdc7-11eb-9c6a-8195e6cbd179.png)
