### PR TITLE
Added related property to iiif manifests

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -39,6 +39,7 @@ class IiifPresentation
   def manifest
     return @manifest if @manifest
     @manifest = IIIF::Presentation::Manifest.new(seed)
+    @manifest["related"] = related
     @manifest["rendering"] = rendering
     @manifest["metadata"] = metadata
     @manifest["attribution"] = "Yale University Library"
@@ -74,6 +75,16 @@ class IiifPresentation
   def metadata_pair(label, value)
     value = [value] if value.is_a? String
     { 'label' => label, 'value' => value }
+  end
+
+  def related
+    [
+      {
+        "@id" => "https://collections.library.yale.edu/catalog/#{@oid}",
+        "format" => "text/html",
+        "label" => "Yale Digital Collections page"
+      }
+    ]
   end
 
   def rendering

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
       expect(iiif_presentation.manifest.sequences.class).to eq Array
     end
 
+    it "has a related in the manifest" do
+      expect(iiif_presentation.manifest["related"].class).to eq Array
+      expect(iiif_presentation.manifest["related"].first.class).to eq Hash
+      expect(iiif_presentation.manifest["related"].first["@id"]).to eq "https://collections.library.yale.edu/catalog/#{oid}"
+      expect(iiif_presentation.manifest["related"].first["format"]).to eq "text/html"
+      expect(iiif_presentation.manifest["related"].first["label"]).to eq "Yale Digital Collections page"
+    end
+
     it "has a rendering in the manifest" do
       expect(iiif_presentation.manifest["rendering"].class).to eq Array
       expect(iiif_presentation.manifest["rendering"].first.class).to eq Hash


### PR DESCRIPTION
Co-Authored-By: Martin Lovell <martin.lovell@yale.edu>

**Story**

The IIIF Manifest property `related` can contain a link to a related web page.  In our case, we'd like to provide a link to the catalog page.   For the spec, see IIIF Presentation API: https://iiif.io/api/presentation/2.1/#related

Example:
```
 "related":{
    "@id": "https://collections.library.yale.edu/catalog/2004518",
    "format": "text/html",
    "label": "Yale Digital Collections page"
  }
```

**Acceptance**
- [ ] IIIF Manifests are created with the `related` property

