### PR TITLE
1375 Add seeAlso link to iiif manifests

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -41,6 +41,7 @@ class IiifPresentation
     @manifest = IIIF::Presentation::Manifest.new(seed)
     @manifest["related"] = related
     @manifest["rendering"] = rendering
+    @manifest["seeAlso"] = see_also
     @manifest["metadata"] = metadata
     @manifest["attribution"] = "Yale University Library"
     @manifest.sequences << sequence
@@ -93,6 +94,16 @@ class IiifPresentation
         "@id" => "#{pdf_base_url}/#{@oid}.pdf",
         "format" => "application/pdf",
         "label" => "Download as PDF"
+      }
+    ]
+  end
+
+  def see_also
+    [
+      {
+        "@id" => "https://collections.library.yale.edu/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=oai:collections.library.yale.edu:#{oid}",
+        "format" => "application/mods+xml",
+        "profile" => "http://www.loc.gov/mods/v3"
       }
     ]
   end

--- a/spec/models/iiif_presentation_spec.rb
+++ b/spec/models/iiif_presentation_spec.rb
@@ -103,6 +103,16 @@ RSpec.describe IiifPresentation, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["rendering"].first["label"]).to eq "Download as PDF"
     end
 
+    it "has a seeAlso in the manifest" do
+      expect(iiif_presentation.manifest["seeAlso"].class).to eq Array
+      expect(iiif_presentation.manifest["seeAlso"].first.class).to eq Hash
+      # rubocop:disable Metrics/LineLength
+      expect(iiif_presentation.manifest["seeAlso"].first["@id"]).to eq "https://collections.library.yale.edu/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=oai:collections.library.yale.edu:#{oid}"
+      # rubocop:enable Metrics/LineLength
+      expect(iiif_presentation.manifest["seeAlso"].first["format"]).to eq "application/mods+xml"
+      expect(iiif_presentation.manifest["seeAlso"].first["profile"]).to eq "http://www.loc.gov/mods/v3"
+    end
+
     it "has metadata in the manifest" do
       expect(iiif_presentation.manifest["metadata"].class).to eq Array
       expect(iiif_presentation.manifest["metadata"].first.class).to eq Hash


### PR DESCRIPTION
Co-Authored-By: Martin Lovell <martin.lovell@yale.edu>

**Story**

IIIF Manifests may contain a `seeAlso` property that links to a structured metadata file.   We'd like to link to the MODS XML records that are published from the OAI provider that was added to the site.

Example:

```
"seeAlso":
    {
      "@id": "https://collections.library.yale.edu/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=oai:collections.library.yale.edu:3",
      "format": "application/mods+xml",
      "profile": "http://www.loc.gov/mods/v3"
    }
```

**Acceptance**
- [ ] The `seeAlso` property is included in Manifests

IIIF Presentation spec:  https://iiif.io/api/presentation/2.1/#seealso