### PR TITLE
1401 move parent obj delete to show page

### DIFF
--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -1,0 +1,23 @@
+/********************************************************
+DEFAULT DESKTOP STYLING
+********************************************************/
+@import 'theme/colors', 'theme/typography', 'theme/breakpoints';
+
+.delete-item-container {
+  display: grid;
+  grid-template-columns: 0.25fr 1fr;
+  padding-top: 10px;
+}
+
+.delete-item-label {
+  margin-bottom: 6px;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.delete-item-button {
+  color: $delete_button_text;
+  background-color: $white;
+  border: 2px solid $delete_button_border;
+  border-radius: 7px;
+}

--- a/app/assets/stylesheets/theme/colors.scss
+++ b/app/assets/stylesheets/theme/colors.scss
@@ -19,6 +19,8 @@ $sidebar_sign_out: #043669;
 // BUTTON
 $primary_button: #049A0A;
 $secondary_button: #707070;
+$delete_button_text: #DC143C;
+$delete_button_border: #D9D9D9; // hover or selected
 
 // TABLE / DATATABLE
 $table_border: #707070;

--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -75,7 +75,6 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
 
   def actions(parent_object)
     actions = []
-    actions << with_icon('fa fa-trash', parent_object_path(parent_object), method: :delete, data: { confirm: 'Are you sure?' }) if @current_ability.can? :destroy, parent_object
     actions << link_to('Update Metadata', update_metadata_parent_object_path(parent_object), method: :post) if @current_ability.can? :update, parent_object
     actions.join('<br>')
   end

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -106,7 +106,7 @@
     <div class="child-list">
       <ol>
         <% @parent_object.child_objects.map do |child| %>
-          <li><%= link_to( "#{child.label || 'no label'} /  #{child.caption || 'no caption'} (#{child.width}, #{child.height})", "#{child_objects_path}/#{child.oid}") %></li>
+          <li><%= link_to( "#{child.label || 'no label'} / #{child.caption || 'no caption'} (#{child.width}, #{child.height})", "#{child_objects_path}/#{child.oid}") %></li>
         <% end %>
       </ol>
     </div>
@@ -125,9 +125,21 @@
 </p>
 
 <p>
-    <strong>Solr Record:</strong>
-    <%= render 'solr_document', parent_object: @parent_object %>
+  <strong>Solr Record:</strong>
+  <%= render 'solr_document', parent_object: @parent_object %>
 </p>
+
+<% if can? :destroy, @parent_object %>
+  <div class='delete-item-container'>
+    <div>
+      <p class='delete-item-label'>Delete this Item</p>
+      <p>Permanently delete this item</p>
+    </div>
+    <div>
+      <%= link_to 'Delete this item', parent_object_path(@parent_object), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn button delete-item-button' %>
+    </div>
+  </div>
+<% end %>
 <% if can? :edit, @parent_object %>
   <%= link_to 'Edit', edit_parent_object_path(@parent_object) %> |
 <% end %>

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
     # rubocop:disable Metrics/LineLength
     expect(output).to include(
       DT_RowId: 2_034_600,
-      actions: '<a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href="/parent_objects/2034600"><i class="fa fa-trash"></i></a><br><a data-method="post" href="/parent_objects/2034600/update_metadata">Update Metadata</a>',
+      actions: '<a data-method="post" href="/parent_objects/2034600/update_metadata">Update Metadata</a>',
       admin_set: 'brbl',
       aspace_uri: nil,
       authoritative_source: 'ladybird',


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1401

# Expected behavior
- the "delete" icon is removed from the "actions" column on the parent datatable
- a delete label, help text and button show at the bottom of the parent object show page

# Demo
![image](https://user-images.githubusercontent.com/29032869/123846190-e95acc00-d8c9-11eb-8c92-0114cb1fa278.png)
