### PR TITLE
1402 move po update metadata to show page

### DIFF
--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -15,9 +15,23 @@ DEFAULT DESKTOP STYLING
   font-weight: bold;
 }
 
-.delete-item-button {
-  color: $delete_button_text;
+.delete-item-button,
+.update-item-button {
   background-color: $white;
   border: 2px solid $delete_button_border;
   border-radius: 7px;
+}
+
+.delete-item-button {
+  color: $delete_button_text;
+}
+
+.update-item-container {
+  display: grid;
+  grid-template-columns: 0.75fr 1fr;
+  padding-top: 10px;
+}
+
+.update-item-button {
+  color: $black;
 }

--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -3,10 +3,14 @@ DEFAULT DESKTOP STYLING
 ********************************************************/
 @import 'theme/colors', 'theme/typography', 'theme/breakpoints';
 
-.delete-item-container {
+.delete-item-container,
+.update-item-container {
   display: grid;
-  grid-template-columns: 0.25fr 1fr;
   padding-top: 10px;
+}
+
+.delete-item-container {
+  grid-template-columns: 0.25fr 1fr;
 }
 
 .delete-item-label {
@@ -27,9 +31,7 @@ DEFAULT DESKTOP STYLING
 }
 
 .update-item-container {
-  display: grid;
   grid-template-columns: 0.75fr 1fr;
-  padding-top: 10px;
 }
 
 .update-item-button {

--- a/app/assets/stylesheets/theme/colors.scss
+++ b/app/assets/stylesheets/theme/colors.scss
@@ -20,7 +20,7 @@ $sidebar_sign_out: #043669;
 $primary_button: #049A0A;
 $secondary_button: #707070;
 $delete_button_text: #DC143C;
-$delete_button_border: #D9D9D9; // hover or selected
+$delete_button_border: #D9D9D9;
 
 // TABLE / DATATABLE
 $table_border: #707070;

--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -32,7 +32,7 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
       last_id_update: { source: "ParentObject.last_id_update", orderable: true },
       visibility: { source: "ParentObject.visibility", cond: :string_eq, searchable: true, options: ["Public", "Yale Community Only", "Private"], orderable: true },
       extent_of_digitization: { source: "ParentObject.extent_of_digitization", cond: :string_eq, searchable: true, options: ["Completely digitized", "Partially digitized"], orderable: true },
-      digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true },
+      digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true }
     }
   end
   # rubocop: enable Metrics/MethodLength

--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -33,7 +33,6 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
       visibility: { source: "ParentObject.visibility", cond: :string_eq, searchable: true, options: ["Public", "Yale Community Only", "Private"], orderable: true },
       extent_of_digitization: { source: "ParentObject.extent_of_digitization", cond: :string_eq, searchable: true, options: ["Completely digitized", "Partially digitized"], orderable: true },
       digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true },
-      actions: { source: "ParentObject.oid", cond: :null_value, searchable: false, orderable: false }
     }
   end
   # rubocop: enable Metrics/MethodLength
@@ -58,7 +57,6 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
         visibility: parent_object.visibility,
         extent_of_digitization: parent_object.extent_of_digitization,
         digitization_note: parent_object.digitization_note,
-        actions: actions(parent_object).html_safe,
         DT_RowId: parent_object.oid
       }
     end
@@ -71,12 +69,6 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
     result << with_icon('fa fa-pencil-alt', edit_parent_object_path(parent_object)) if @current_ability.can? :edit, parent_object
     result << with_icon('fa fa-eye', parent_object.dl_show_url)
     result.join(' ')
-  end
-
-  def actions(parent_object)
-    actions = []
-    actions << link_to('Update Metadata', update_metadata_parent_object_path(parent_object), method: :post) if @current_ability.can? :update, parent_object
-    actions.join('<br>')
   end
 
   def with_icon(class_name, path, options = {})

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -38,7 +38,6 @@
           <th scope='col'>Visibility</th>
           <th scope='col'>Extent of digitization</th>
           <th scope='col'>Digitization note</th>
-          <th scope='col'>Actions</th>
         </tr>
       </thead>
       <tbody class='datatable-body'>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -96,6 +96,18 @@
   <%= @parent_object.authoritative_metadata_source.display_name %>
 </p>
 
+<% if can? :update, @parent_object %>
+  <div class='update-item-container'>
+    <p>
+      <strong>Update Metadata for this Object:</strong><br>
+      <small>Update the metadata for this object from the authoritative metadata source.<small>
+    </p>
+    <div>
+      <%= link_to 'Update this item', update_metadata_parent_object_path(@parent_object), method: :post, class: 'btn button update-item-button' %>
+    </div>
+  </div>
+<% end %>
+
 <p>
   <strong>Child Count:</strong>
   <%= @parent_object.child_object_ids.count %>

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
     # rubocop:disable Metrics/LineLength
     expect(output).to include(
       DT_RowId: 2_034_600,
-      actions: '<a data-method="post" href="/parent_objects/2034600/update_metadata">Update Metadata</a>',
       admin_set: 'brbl',
       aspace_uri: nil,
       authoritative_source: 'ladybird',

--- a/spec/support/datatables_helper.rb
+++ b/spec/support/datatables_helper.rb
@@ -75,15 +75,10 @@ def parent_object_datatable_view_mock # rubocop:disable Metrics/AbcSize
   # rubocop:disable RSpec/AnyInstance
   allow_any_instance_of(ParentObject).to receive(:child_object_count).and_return(4)
   # rubocop:enable RSpec/AnyInstance
-  allow(@datatable_view_mock).to receive(:update_metadata_parent_object_path).and_return('/parent_objects/2034600/update_metadata')
   allow(@datatable_view_mock).to receive(:link_to).with(anything, '/parent_objects/2034600')
                                                   .and_return('<a href="/parent_objects/2034600">2034600</a>')
   allow(@datatable_view_mock).to receive(:link_to).with('/parent_objects/2034600/edit', {})
-  .and_return('<a href="/management/parent_objects/2034600/edit"><i class="fa fa-pencil-alt"></i></a>')
-  allow(@datatable_view_mock).to receive(:link_to).with('/parent_objects/2034600', method: :delete, data: { confirm: 'Are you sure?' })
-                                                  .and_return('<a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href="/parent_objects/2034600"><i class="fa fa-trash"></i></a>')
-  allow(@datatable_view_mock).to receive(:link_to).with('Update Metadata', '/parent_objects/2034600/update_metadata', method: :post)
-                                                  .and_return('<a data-method="post" href="/parent_objects/2034600/update_metadata">Update Metadata</a>')
+                                                  .and_return('<a href="/management/parent_objects/2034600/edit"><i class="fa fa-pencil-alt"></i></a>')
   allow(@datatable_view_mock).to receive(:link_to).with('http://localhost:3000/catalog/2034600', {})
                                                   .and_return('<a href="http://localhost:3000/catalog/2034600">1</a>')
   @datatable_view_mock


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1402

# Expected behavior
- the "actions" column is removed entirely from the parent datatable since the "update metadata" link was the last thing in it
- an "update metadata" label, help text and button show underneath the "Authoritative Metadata source" section of the parent object show page

# Demo
![image](https://user-images.githubusercontent.com/29032869/123858020-e1a22400-d8d7-11eb-952d-586dbff16f03.png)
