### PR TITLE
1396 Removed New Parent Object button from Parent Object page

### DIFF
--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -5,7 +5,6 @@
   </div>
   <div class='col'>
     <div class='float-right button-list'>
-      <%= link_to 'New Parent Object', new_parent_object_path, class: 'btn button primary-button' %>
       <%= button_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn button secondary-button', id: 'reindex',
         data:( ParentObject.cannot_reindex ? nil : { confirm: 'Are you sure you want to proceed? This action will reindex the entire contents of the system.' }),
         disabled: !(can? :reindex_all, ParentObject)

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -28,36 +28,6 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     select("Create Parent Objects")
   end
 
-  context "having created a parent_object via the UI" do
-    before do
-      stub_metadata_cloud("16057779")
-      visit parent_objects_path
-      click_on("New Parent Object")
-      # expect needed to ensure the New Parent Page loads before filling in the oid
-      expect(page).to have_xpath("//input[@name='parent_object[oid]']")
-      fill_in('Oid', with: "16057779")
-      select('Beinecke Library')
-      click_on("Create Parent object")
-      # expect needed to ensure that the parent object form was processed by the server before running tests
-      expect(page).to have_content('Parent object was successfully created.')
-    end
-    it "can still successfully see the batch_process page" do
-      visit batch_processes_path
-      click_on(BatchProcess.last.id.to_s, match: :first)
-      expect(page.body).to have_link(BatchProcess.last.id.to_s, href: "/batch_processes/#{BatchProcess.last.id}")
-    end
-    context "deleting a parent object" do
-      it "can still load the batch_process page" do
-        po = ParentObject.find(16_057_779)
-        po.delete
-        expect(po.destroyed?).to be true
-        visit batch_processes_path
-        click_on(BatchProcess.last.id.to_s)
-        expect(page.body).to have_link(BatchProcess.last.id.to_s, href: "/batch_processes/#{BatchProcess.last.id}")
-      end
-    end
-  end
-
   context "when uploading a csv" do
     it "uploads and increases csv count and gives a success message" do
       expect(BatchProcess.count).to eq 0

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   end
   context "a parent object with an extent of digitization" do
     before do
-      visit parent_objects_path
-      click_on("New Parent Object")
+      visit "parent_objects/new"
       stub_metadata_cloud("10001192")
       fill_in('Oid', with: "10001192")
       select('Beinecke Library')
@@ -50,7 +49,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   context "creating a new ParentObject based on oid" do
     before do
       visit parent_objects_path
-      click_on("New Parent Object")
+      visit "parent_objects/new"
     end
 
     context "setting non-required values" do
@@ -383,16 +382,6 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
     end
   end
 
-  context "pages has a New Parent Object button with an action event" do
-    before do
-      visit parent_objects_path
-    end
-
-    it "has a New Parent Object button" do
-      click_on("New Parent Object")
-    end
-  end
-
   describe "index page", js: true do
     context 'datatable' do
       let(:parent_object1) { FactoryBot.create(:parent_object, oid: 2_034_600, admin_set: AdminSet.find_by_key('brbl')) }
@@ -477,8 +466,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   context "when logged in without admin set roles" do
     before do
       user.remove_role(:editor, AdminSet.find_by_key('brbl'))
-      visit parent_objects_path
-      click_on("New Parent Object")
+      visit "parent_objects/new"
       stub_metadata_cloud("10001192")
       fill_in('Oid', with: "10001192")
       select('Beinecke Library')


### PR DESCRIPTION
**Story**

Beinecke DSU has noted that they can create new, arbitrary parent OIDs using the "New Parent Object" option on the Parent Objects page.   This is not good as it may have resulted in duplicate OIDs. 

**Acceptance**
- [x]  Remove "New Parent Object" button from Parent Object page'
- [x]  Made some modifications to test

----
**Current Image**
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/26747e7b-3de0-4877-b16a-fd4848991586)

**Proposed Image**
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/563deb93-290d-4269-b0e4-6711a20f04a7)