### PR TITLE
Store the state of datatables and populate filters

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -119,3 +119,7 @@ DEFAULT DESKTOP STYLING
     font-family: $mallory_book;
   }
 }
+
+.clear-filters-button {
+  margin-right: 8px
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -35,6 +35,7 @@ import "@fortawesome/fontawesome-free/js/all.js";
 // const imagePath = (name) => images(name, true)
 let dataTable;
 $( document ).on('turbolinks:load', function() {
+  let initialColumnSearchValues = [];
   if($('.is-datatable').length > 0 && !$('.is-datatable').hasClass('dataTable')){
     let columns = JSON.parse($(".datatable-data").text());
     // load the information about which columns are visible for this page
@@ -54,11 +55,12 @@ $( document ).on('turbolinks:load', function() {
       let colVisibilityMap = {}
       dataTable.api().columns().every(function () {
         let column = this;
+        let searchInit = initialColumnSearchValues[index];
         let colDef = columns[index++];
         colVisibilityMap[colDef.data] = {hidden:!column.visible()};
         if (!column.visible()) return;
         if (colDef.searchable) {
-          let th = $("<th/>");
+          let th = $("<th class='datatable-search-row'/>");
           let input = null;
           if (colDef.options) {
             input = $("<select><option>All</option>" + colDef.options.map(function (option) {
@@ -82,6 +84,7 @@ $( document ).on('turbolinks:load', function() {
             }
           });
           searchRow.append(th.append(input));
+          input.val(searchInit);
         } else {
           searchRow.append("<th />");
         }
@@ -96,7 +99,8 @@ $( document ).on('turbolinks:load', function() {
     dataTable = $('.is-datatable').dataTable({
       "deferLoading":true,
       "processing": true,
-      "serverSide": true,
+      "serverSide": true,        
+      "stateSave": true,
       "ajax": {
         "url": $('.is-datatable').data('source')
       },
@@ -107,16 +111,28 @@ $( document ).on('turbolinks:load', function() {
       "lengthMenu": [[50, 100, 500, -1], [50, 100, 500, "All"]],
       "sDom":hasSearch?'Blrtip':'<"row"<"col-sm-12 col-md-6"l><"col-sm-12 col-md-6"f>>rtip',
       buttons: [
-          {
+        {
+          text: "Clear Filters",
+          className: "clear-filters-button",
+          action: () => {
+            dataTable.api().columns().search('').visible( true, true ).order('asc' ).state.clear().draw() ;
+            $(".datatable-search-row input").val("");
+          }
+        },
+        {
           extend: 'colvis',
           text: "\u25EB"
-        },
+        }
       ],
       // pagingType is optional, if you want full pagination controls.
       // Check dataTables documentation to learn more about
       // available options.
       initComplete: function () {
         if (hasSearch) onColumnsUpdate(this);
+      },
+      stateLoaded: function (e, setting, data) {
+        // load the search settings when state is loaded by the datatable to fill in the inputs.
+        setting.columns.forEach((c) => initialColumnSearchValues.push(c.search.search));      
       }
 
     })

--- a/spec/system/parent_object_list_spec.rb
+++ b/spec/system/parent_object_list_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep_admin_sets: true do
+  context "parent objects datatable page", js: true do
+    let(:user) { FactoryBot.create(:user) }
+    let(:admin_set) { FactoryBot.create(:admin_set, key: "adminset") }
+    let(:parent_object1) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
+    let(:parent_object2) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
+
+    before do
+      parent_object1
+      parent_object2
+      user.add_role(:editor, admin_set)
+      login_as user
+    end
+
+    it "displays parent objects without filter" do
+      visit parent_objects_path
+      expect(page).to have_content("2002826")
+      expect(page).to have_content("2004548")
+    end
+
+    it "filters when filter box is filled" do
+      visit parent_objects_path
+      find("input[placeholder='OID']").set("2002")
+      expect(page).to have_content("2002826")
+      expect(page).not_to have_content("2004548")
+    end
+
+    it "retains filters and fills filter boxes on refresh" do
+      visit parent_objects_path
+      find("input[placeholder='OID']").set("2002")
+      expect(page).to have_content("2002826")
+      expect(page).not_to have_content("2004548")
+      visit current_path
+      expect(page).to have_content("2002826")
+      expect(page).not_to have_content("2004548")
+      expect(find("input[placeholder='OID']").value).to eq("2002")
+    end
+
+    it "clears filter when Clear Filters is clicked" do
+      visit parent_objects_path
+      find("input[placeholder='OID']").set("2002")
+      expect(page).to have_content("2002826")
+      expect(page).not_to have_content("2004548")
+      click_on("Clear Filters")
+      expect(page).to have_content("2002826")
+      expect(page).to have_content("2004548")
+    end
+  end
+end


### PR DESCRIPTION
- Stores the state of the datatable using the built in "stateSave" option for datatables.
- Fills the filter boxes/selects with the filters being applied when the state is restored by the datatable.
- Adds a "Clear Filters" button so that users can clear the filters.  (This is especially important because if there is a hidden column with a filter, it could be difficult to clear, and refreshing the page will no longer clear filters.)

![FilterRetain](https://user-images.githubusercontent.com/32851993/124015330-8b55e380-d9b2-11eb-8335-647da6a27f05.gif)
