### PR TITLE
1395-export-child-oid-sort-order

### DIFF
--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -4,20 +4,19 @@ module CsvExportable
   extend ActiveSupport::Concern
 
   def headers
-    ["parent_oid", "child_oid", "order", "parent_title", "label", "caption", "viewing_hint"]
+    ['parent_oid', 'child_oid', 'order', 'parent_title', 'label', 'caption', 'viewing_hint']
   end
 
   def output_csv
-    return nil unless batch_action == "export child oids"
+    return nil unless batch_action == 'export child oids'
+
     CSV.generate do |csv|
       csv << headers
       sorted_child_objects.each do |co|
-        if co.is_a?(Array)
-          csv << co
-        else
-          row = [co.parent_object.oid, co.oid, co.order, co.parent_object.authoritative_json["title"]&.first, co.label, co.caption, co.viewing_hint]
-          csv << row
-        end
+        next csv << co if co.is_a?(Array)
+
+        row = [co.parent_object.oid, co.oid, co.order, co.parent_object.authoritative_json['title']&.first, co.label, co.caption, co.viewing_hint]
+        csv << row
       end
     end
   end
@@ -29,31 +28,27 @@ module CsvExportable
       begin
         po = ParentObject.find(oid.to_i)
         next unless check_can_view(current_ability, index, po, arr, had_events)
-        po.child_objects.each do |co|
-          arr << co
-        end
+        po.child_objects.each { |co| arr << co }
       rescue ActiveRecord::RecordNotFound
         parent_not_found(index, oid, arr, had_events)
       end
     end
 
-    arr.sort_by { |co| [co.try(:order) || co[2], co.try(:oid) || co[1]] }
+    arr.sort_by { |co| [co.try(:parent_object_oid) || co[0], co.try(:order) || co[2]] }
   end
 
   def parent_not_found(index, oid, arr, had_events)
-    row = [nil, oid.to_i, 0, "Parent Not Found in database", "", ""]
+    row = [oid.to_i, nil, 0, 'Parent Not Found in database', '', '']
     batch_processing_event("Skipping row [#{index + 2}] due to parent not found: #{oid}", 'Skipped Row') unless had_events
     arr << row
   end
 
   def check_can_view(ability, index, parent_object, arr, had_events)
-    if ability.can?(:read, parent_object)
-      true
-    else
-      row = [nil, parent_object.oid.to_i, 0, "Access denied for parent object", "", ""]
-      batch_processing_event("Skipping row [#{index + 2}] due to parent permissions: #{parent_object.oid}", 'Skipped Row') unless had_events
-      arr << row
-      false
-    end
+    return true if ability.can?(:read, parent_object)
+
+    row = [parent_object.oid.to_i, nil, 0, 'Access denied for parent object', '', '']
+    batch_processing_event("Skipping row [#{index + 2}] due to parent permissions: #{parent_object.oid}", 'Skipped Row') unless had_events
+    arr << row
+    false
   end
 end

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -4,7 +4,7 @@ module CsvExportable
   extend ActiveSupport::Concern
 
   def headers
-    ["child_oid", "parent_oid", "order", "parent_title", "label", "caption", "viewing_hint"]
+    ["parent_oid", "child_oid", "order", "parent_title", "label", "caption", "viewing_hint"]
   end
 
   def output_csv
@@ -15,7 +15,7 @@ module CsvExportable
         if co.is_a?(Array)
           csv << co
         else
-          row = [co.oid, co.parent_object.oid, co.order, co.parent_object.authoritative_json["title"]&.first, co.label, co.caption, co.viewing_hint]
+          row = [co.parent_object.oid, co.oid, co.order, co.parent_object.authoritative_json["title"]&.first, co.label, co.caption, co.viewing_hint]
           csv << row
         end
       end

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -34,6 +34,7 @@ module CsvExportable
       end
     end
 
+    # sort first by the parent oid, then by the child objects order in the parent grouping
     arr.sort_by { |co| [co.try(:parent_object_oid) || co[0], co.try(:order) || co[2]] }
   end
 


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1395

# Expected behavior
- after running an "export child oids" batch process job, the csv that is created will have headers in the following order:
  - parent_oid
  - child_oid
  - order
  - parent_title
  - label
  - caption
  - viewing_hint
- the parent oids will be sorted first
- then, each child will be sorted in order according to its parent grouping

# Demo
![image](https://user-images.githubusercontent.com/29032869/124044750-f8717500-d9c2-11eb-8c4e-0b0c6cb92859.png)

