### PR TITLE
view icon now opens object in a new tab

### DIFF
--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -69,7 +69,7 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
     result = []
     result << link_to(parent_object.oid, parent_object_path(parent_object))
     result << with_icon('fa fa-pencil-alt', edit_parent_object_path(parent_object)) if @current_ability.can? :edit, parent_object
-    result << with_icon('fa fa-eye', parent_object.dl_show_url)
+    result << with_icon('fa fa-eye', parent_object.dl_show_url, target: :_blank)
     result.join(' ')
   end
 

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
       last_id_update: nil,
       last_ladybird_update: nil,
       last_voyager_update: nil,
-      oid: '<a href="/parent_objects/2034600">2034600</a> <a href="/management/parent_objects/2034600/edit"><i class="fa fa-pencil-alt"></i></a> <a href="http://localhost:3000/catalog/2034600">1</a>',
+      oid: '<a href="/parent_objects/2034600">2034600</a> <a href="/management/parent_objects/2034600/edit"><i class="fa fa-pencil-alt"></i></a> <a target="_blank" href="http://localhost:3000/catalog/2034600">1</a>',
       visibility: 'Private'
     )
     # rubocop:enable Metrics/LineLength

--- a/spec/support/datatables_helper.rb
+++ b/spec/support/datatables_helper.rb
@@ -79,8 +79,8 @@ def parent_object_datatable_view_mock # rubocop:disable Metrics/AbcSize
                                                   .and_return('<a href="/parent_objects/2034600">2034600</a>')
   allow(@datatable_view_mock).to receive(:link_to).with('/parent_objects/2034600/edit', {})
                                                   .and_return('<a href="/management/parent_objects/2034600/edit"><i class="fa fa-pencil-alt"></i></a>')
-  allow(@datatable_view_mock).to receive(:link_to).with('http://localhost:3000/catalog/2034600', {})
-                                                  .and_return('<a href="http://localhost:3000/catalog/2034600">1</a>')
+  allow(@datatable_view_mock).to receive(:link_to).with('http://localhost:3000/catalog/2034600', target: :_blank)
+                                                  .and_return('<a target="_blank" href="http://localhost:3000/catalog/2034600">1</a>')
   @datatable_view_mock
 end
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1399  

Clicking the "eye" icon view link will now open a new tab:  
![Screen Recording 2021-06-30 at 11 45 40 AM](https://user-images.githubusercontent.com/24666568/124014750-c21f0000-d998-11eb-887b-0cec66d51047.gif)
