### PR TITLE
Adds public view link to parent object show page

### DIFF
--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -156,4 +156,5 @@
   <%= link_to 'Edit', edit_parent_object_path(@parent_object) %> |
 <% end %>
 <%= link_to 'Solr Document', solr_document_parent_object_path("#{@parent_object.oid}"), target: '_blank' %> |
+<%= link_to 'Public View', @parent_object.dl_show_url, target: '_blank' %> |
 <%= link_to 'Back', parent_objects_path %>

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -191,6 +191,11 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         expect(document["dateStructured_ssim"]).not_to be
       end
 
+      it 'has a Public View link' do
+        po = ParentObject.find_by(oid: "2012036")
+        expect(page).to have_link("Public View", href: po.dl_show_url)
+      end
+
       it 'shows error if creating parent with oid that exists' do
         visit new_parent_object_path
         fill_in('Oid', with: "2012036")


### PR DESCRIPTION
# Summary
Adds a 'Public View' button to the Parent object's show page.  Link opens in new tab.

# Related Ticket
[1404](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1404)

# Screenshot / Video
<details>

![image](https://user-images.githubusercontent.com/36549923/124189111-14355380-da75-11eb-9891-766361b50cbd.png)
https://share.getcloudapp.com/wbu6D8GW
</details>
