### PR TITLE
1416 Add "Collection Note" field to IIIF Manifest

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -37,6 +37,7 @@ module SolrIndexable
       accessRestrictions_tesim: json_to_index["accessRestrictions"],
       alternativeTitle_tesim: json_to_index["alternativeTitle"],
       alternativeTitleDisplay_tesim: json_to_index["alternativeTitleDisplay"],
+      ancestorTitles_tesim: json_to_index["ancestorTitles"],
       archiveSpaceUri_ssi: aspace_uri,
       callNumber_ssim: json_to_index["callNumber"],
       callNumber_tesim: json_to_index["callNumber"],

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -131,7 +131,7 @@ METADATA_FIELDS = {
   sourceNote: {
     label: 'Collection Note',
     solr_fields: [
-      'sourceNote_tesim'
+      'ancestorTitles_tesim'
     ]
   },
   sourceEdition: {


### PR DESCRIPTION
Co-Authored-By: Dr Eric DeJesus <eric.dejesus@yale.edu>

**Story**

The IIIF Manifest metadata should indicate the collection that contains the object.

**Acceptance**
- [ ] Add a field to the Manifest
  - Label is "Collection Note"
  - Value is the same as #1414.  It should be text only, not a link
  - See the mockup for position within the metadata field list.  **Note that the collection title/date fields will also need to be added, so position under Call Number for now.**

 ![Screen Shot 2021-06-28 at 1.43.57 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/2ac79413-0de6-4e45-9442-1b1af2ef6d8b)