### PR TITLE
Revert ancestor title join

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -68,7 +68,6 @@ class IiifPresentation
                 @parent_object&.authoritative_json&.[](field.to_s)
               end
       value = value.to_s unless value.nil? || value.is_a?(Array)
-      value = value.join(hash[:join_char]) if value.is_a?(Array) && hash[:join_char].present?
       values << metadata_pair(hash[:label], value) if value
     end
     values

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -128,12 +128,11 @@ METADATA_FIELDS = {
       'sourceDate_tesim'
     ]
   },
-  ancestorTitles: {
+  sourceNote: {
     label: 'Collection Note',
     solr_fields: [
-      'ancestorTitles_tesim'
-    ],
-    join_char: ' > '
+      'sourceNote_tesim'
+    ]
   },
   sourceEdition: {
     label: 'Collection Edition',


### PR DESCRIPTION
Co-Authored-By: Dr Eric DeJesus <eric.dejesus@yale.edu>

**Story**

The IIIF Manifest metadata should indicate the collection that contains the object.

**Acceptance**
- [ ] Add a field to the Manifest
  - Label is "Collection Note"
  - Value is the same as #1414.  It should be text only, not a link
  - See the mockup for position within the metadata field list.  **Note that the collection title/date fields will also need to be added, so position under Call Number for now.**

 ![Screen Shot 2021-06-28 at 1.43.57 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/2ac79413-0de6-4e45-9442-1b1af2ef6d8b)