### PR TITLE
1442 Queue metadata update after form update

### DIFF
--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -22,7 +22,7 @@
                   AdminSet.all.map { |admin_set|
                     [admin_set.label, admin_set.key]
                   } << ["None",nil],
-                  selected: parent_object.admin_set&.key || ["None", nil], 
+                  selected: parent_object.admin_set&.key || ["None", nil],
                   required: true
           )
        %>
@@ -114,6 +114,6 @@
   </div>
   <br>
   <div class="actions">
-    <%= form.submit %>
+    <%= form.submit(@parent_object.new_record? ? 'Create Parent object' : 'Save Parent Object And Update Metadata') %>
   </div>
 <% end %>

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -123,6 +123,16 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
         expect(parent_object.authoritative_metadata_source_id).to eq 2
       end
 
+      it "queues metadata update after it updates parent_object" do
+        parent_object = ParentObject.create! valid_attributes
+        # rubocop:disable RSpec/AnyInstance
+        expect_any_instance_of(ParentObjectsController).to receive(:queue_parent_metadata_update)
+        # rubocop:enable RSpec/AnyInstance
+        patch parent_object_url(parent_object), params: { parent_object: new_attributes }
+        parent_object.reload
+        expect(parent_object.authoritative_metadata_source_id).to eq 2
+      end
+
       it "redirects to the parent_object" do
         parent_object = ParentObject.create! valid_attributes
         patch parent_object_url(parent_object), params: { parent_object: new_attributes }

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
+UPDATE_PARENT_OBJECT_BUTTON = 'Save Parent Object And Update Metadata'
+
 RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep_admin_sets: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
   before do
@@ -83,7 +85,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         click_on("Edit")
         expect(page).to have_field("Rights statement")
         fill_in("Rights statement", with: "This is a rights statement")
-        click_on("Update Parent object")
+        click_on(UPDATE_PARENT_OBJECT_BUTTON)
         expect(page).to have_content("This is a rights statement")
       end
 
@@ -137,7 +139,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       it "can change the visibility via the UI" do
         click_on("Edit")
         select("Yale Community Only")
-        click_on("Update Parent object")
+        click_on(UPDATE_PARENT_OBJECT_BUTTON)
         expect(page.body).to include "Yale Community Only"
         click_on("Back")
         click_on("Update Metadata")
@@ -149,7 +151,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         visit parent_object_path(2_012_036)
         click_on("Edit")
         select 'Sterling', from: "parent_object[admin_set]"
-        click_on("Update Parent object")
+        click_on(UPDATE_PARENT_OBJECT_BUTTON)
 
         visit parent_object_path(2_012_036)
         expect(page).to have_content "Sterling"
@@ -533,7 +535,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
     it "does not allow changing parent_object to admin_set user does not have access to" do
       visit edit_parent_object_path("2002826")
       select 'AdminSet2', from: "parent_object[admin_set]"
-      click_on("Update Parent object")
+      click_on(UPDATE_PARENT_OBJECT_BUTTON)
 
       expect(page).to have_content "Admin set cannot be assigned to a set the User cannot edit"
     end


### PR DESCRIPTION
Kick off update metadata workflow after saving a parent object using the management form.

![MetadataQueAfterSave](https://user-images.githubusercontent.com/32851993/125653285-7c42a2c7-fc47-452f-a7d4-f1792ebea9f6.gif)
