### PR TITLE
add call_number in export child csv

### DIFF
--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -4,7 +4,7 @@ module CsvExportable
   extend ActiveSupport::Concern
 
   def headers
-    ['parent_oid', 'child_oid', 'order', 'parent_title', 'label', 'caption', 'viewing_hint']
+    ['parent_oid', 'child_oid', 'order', 'parent_title', 'call_number', 'label', 'caption', 'viewing_hint']
   end
 
   def output_csv
@@ -15,7 +15,7 @@ module CsvExportable
       sorted_child_objects.each do |co|
         next csv << co if co.is_a?(Array)
 
-        row = [co.parent_object.oid, co.oid, co.order, co.parent_object.authoritative_json['title']&.first, co.label, co.caption, co.viewing_hint]
+        row = [co.parent_object.oid, co.oid, co.order, co.parent_object.authoritative_json['title']&.first, co.parent_object.call_number, co.label, co.caption, co.viewing_hint]
         csv << row
       end
     end

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.file_name).to eq "short_fixture_ids.csv"
         expect(BatchProcess.last.batch_action).to eq "export child oids"
         expect(BatchProcess.last.output_csv).to include "1126257"
+        expect(BatchProcess.last.output_csv).to include "JWJ"
         expect(BatchProcess.last.output_csv).to include '2005512,,0,Access denied for parent object,"",""'
         expect(BatchProcess.last.output_csv).not_to include "1030368" # child of 2005512
         expect(BatchProcess.last.batch_ingest_events.count).to eq 4


### PR DESCRIPTION
parent_title was already in the export child csv
add call_number export
Acceptance
The batch job exports include:

 

- [x] The parent object's call number, in a column with the header call_number

https://user-images.githubusercontent.com/46331329/125692958-4f8ce242-e29f-471b-922b-4c82817e22a2.mov

