### PR TITLE
1416 Reversed array for aspace collection field

### DIFF
--- a/app/models/iiif_presentation.rb
+++ b/app/models/iiif_presentation.rb
@@ -74,6 +74,13 @@ class IiifPresentation
     values
   end
 
+  def process_metadata_array(value, hash)
+    value = value.reverse if hash[:reverse_array]
+    value = value.join(hash[:join_char]) if hash[:join_char].present?
+
+    value
+  end
+
   def metadata_pair(label, value)
     value = [value] if value.is_a? String
     { 'label' => label, 'value' => value }

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -131,9 +131,11 @@ METADATA_FIELDS = {
   ancestorTitles: {
     label: 'Collection Note',
     solr_fields: [
+      'sourceNote_tesim',
       'ancestorTitles_tesim'
     ],
-    join_char: ' > '
+    join_char: ' > ',
+    reverse_array: true
   },
   sourceEdition: {
     label: 'Collection Edition',

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -131,10 +131,11 @@ METADATA_FIELDS = {
   ancestorTitles: {
     label: 'Collection Note',
     solr_fields: [
-      'sourceNote_tesim',
-      'ancestorTitles_tesim'
+      'ancestorTitles_tesim',
+      'sourceNote_tesim'
     ],
     join_char: ' > ',
+    digital_only: true,
     reverse_array: true
   },
   sourceEdition: {

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -135,7 +135,6 @@ METADATA_FIELDS = {
       'ancestorTitles_tesim'
     ],
     join_char: ' > ',
-    digital_only: true,
     reverse_array: true
   },
   sourceEdition: {


### PR DESCRIPTION
**Story**

The IIIF Manifest metadata should indicate the collection that contains the object.

**Acceptance**
- [x] Added the older collection note field back 
- [x]  Reversed the order of the array

**Actual Image**
![Screen Shot 2021-07-15 at 8.36.50 AM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/57e7eb90-9005-4299-8382-bd228f07b696)

**Proposed Breadcrumb Layout**
 ![Screen Shot 2021-06-28 at 1.43.57 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/2ac79413-0de6-4e45-9442-1b1af2ef6d8b)