### PR TITLE
Don't nil missing columns in reassociate batch

### DIFF
--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -31,9 +31,9 @@ module Reassociatable
   end
 
   def reassociate_child(co, po, row)
-    co.order = row["order"]
-    co.label = row["label"]
-    co.caption = row["caption"]
+    co.order = row["order"] unless row["order"].nil?
+    co.label = row["label"] unless row["label"].nil?
+    co.caption = row["caption"] unless row["caption"].nil?
     co.parent_object = po
     processing_event_for_child(co)
     co.save!

--- a/spec/fixtures/reassociation_example_missing_column.csv
+++ b/spec/fixtures/reassociation_example_missing_column.csv
@@ -1,0 +1,2 @@
+child_oid,parent_oid,parent_title,viewing_hint
+1011398,2002826,Roe,

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -126,6 +126,21 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(parent_object.reload.child_object_count).to eq(0)
         expect(parent_object_old_one.reload.child_object_count).to eq(3)
       end
+
+      it "does not update label, caption, or order if not in csv" do
+        co = ChildObject.find(1_011_398)
+        co.label = "TEST LABEL STAY SAME"
+        co.caption = "TEST LABEL STAY SAME2"
+        co.order = 3_445_234
+        co.save
+        page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_missing_column.csv")
+        select("Reassociate Child Oids")
+        click_button("Submit")
+        expect(page).to have_content("Your job is queued for processing in the background")
+        expect(co.reload.label).to eq("TEST LABEL STAY SAME")
+        expect(co.caption).to eq("TEST LABEL STAY SAME2")
+        expect(co.order).to eq(3_445_234)
+      end
     end
 
     context "outputting csv" do


### PR DESCRIPTION
Missing columns in the csv were causing fields to be set as nil.
This changes re-associate job to not set order, caption, or label on the child if they are not in the CSV header.

n.b. If the header is present, but the value is blank, the job will blank out the value on the child.