### PR TITLE
Create blank parent from parent objects page

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -21,6 +21,8 @@ class ParentObjectsController < ApplicationController
   # GET /parent_objects/new
   def new
     @parent_object = ParentObject.new
+    @parent_object.oid = OidMinterService.generate_oids(1).first
+    @parent_object.authoritative_metadata_source = MetadataSource.find_by(metadata_cloud_name: 'aspace')
   end
 
   # GET /parent_objects/1/edit

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,14 +8,7 @@ class Ability
     return unless user
     can :create_new, ParentObject if user.roles.find_by(name: :editor)
     if user.has_role? :sysadmin
-      can :manage, User
-      can :crud, AdminSet
-      can :read, ParentObject
-      can :read, ChildObject
-      can :read, PreservicaIngest
-      can :reindex_all, ParentObject
-      can :update_metadata, ParentObject
-      can :trigger_mets_scan, ParentObject
+      apply_sysadmin_abilities
     else
       can :read, ParentObject, admin_set: { roles: { name: viewer_roles, users: { id: user.id } } }
       can :read, ChildObject, parent_object: { admin_set: { roles: { name: viewer_roles, users: { id: user.id } } } }
@@ -23,6 +16,17 @@ class Ability
     can :add_member, AdminSet, roles: { name: editor_roles, users: { id: user.id } }
     can [:crud], ChildObject, parent_object: { admin_set: { roles: { name: editor_roles, users: { id: user.id } } } }
     can [:crud], ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
+  end
+
+  def apply_sysadmin_abilities
+    can :manage, User
+    can :crud, AdminSet
+    can :read, ParentObject
+    can :read, ChildObject
+    can :read, PreservicaIngest
+    can :reindex_all, ParentObject
+    can :update_metadata, ParentObject
+    can :trigger_mets_scan, ParentObject
   end
 
   def viewer_roles

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
   def initialize(user)
     alias_action :create, :read, :update, :destroy, to: :crud
     return unless user
+    can :create_new, ParentObject if user.roles.find_by(name: :editor)
     if user.has_role? :sysadmin
       can :manage, User
       can :crud, AdminSet

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="form-row">
     <div class="col-med-3">
       <%= form.label :oid %>
-      <%= self.action_name == "edit" ? form.text_field(:oid, disabled: true) : form.text_field(:oid, readonly: true ) %>
+      <%= self.action_name == "edit" ? form.text_field(:oid, disabled: true) : form.text_field(:oid, readonly: !(current_user&.sysadmin) ) %>
     </div>
 
     <div class="col-med-3">

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="form-row">
     <div class="col-med-3">
       <%= form.label :oid %>
-      <%= self.action_name == "edit" ? form.text_field(:oid, disabled: true) : form.text_field(:oid, disabled: false) %>
+      <%= self.action_name == "edit" ? form.text_field(:oid, disabled: true) : form.text_field(:oid, readonly: true ) %>
     </div>
 
     <div class="col-med-3">

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -13,6 +13,10 @@
         id: 'update_metadata', data:{confirm: 'Are you sure you want to proceed?  This action will update metadata for the entire contents of the system.'},
         disabled: !(can? :update_metadata, ParentObject)
       %>
+      <%= button_to 'New Parent', new_parent_object_path, method: 'get', class: 'btn button secondary-button',
+                    id: 'new_parent',
+                    disabled: !(can? :create_new, ParentObject)
+      %>
     </div>
   </div>
 </div>

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -505,6 +505,11 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       it "does allow create parent" do
         expect(page).to have_button('New Parent', disabled: false)
       end
+
+      it "does not allow editing of oid for non-sysadmin" do
+        click_on "New Parent"
+        expect(page).to have_selector("#parent_object_oid[readonly]")
+      end
     end
   end
 

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       stub_metadata_cloud("10001192")
       fill_in('Oid', with: "10001192")
       select('Beinecke Library')
+      select('Ladybird')
     end
 
     it "sets the expected fields in the database" do
@@ -51,7 +52,6 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   end
   context "creating a new ParentObject based on oid" do
     before do
-      visit parent_objects_path
       visit "parent_objects/new"
     end
 
@@ -60,6 +60,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         stub_metadata_cloud("2012036")
         fill_in('Oid', with: "2012036")
         select('Beinecke Library')
+        select('Ladybird')
       end
 
       it "includes reference to documentation for IIIF values" do
@@ -119,6 +120,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         stub_metadata_cloud("2012036")
         fill_in('Oid', with: "2012036")
         select("Beinecke Library")
+        select('Ladybird')
         click_on("Create Parent object")
       end
 
@@ -213,6 +215,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       before do
         stub_metadata_cloud("2005512")
         fill_in('Oid', with: "2005512")
+        select('Ladybird')
         click_on("Create Parent object")
       end
 
@@ -325,6 +328,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         stub_metadata_cloud("V-2004628", "ils")
         fill_in('Oid', with: "2004628")
         select('Beinecke Library')
+        select('Ladybird')
         click_on("Create Parent object")
       end
 
@@ -355,6 +359,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
           stub_metadata_cloud("V-10000016189097", "ils")
           fill_in('Oid', with: "10000016189097")
           select("Beinecke Library")
+          select("Ladybird")
           click_on("Create Parent object")
         end
         it "adds the visibility for private objects" do
@@ -368,6 +373,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
           stub_metadata_cloud("V-20000016189097", "ils")
           fill_in('Oid', with: "20000016189097")
           select("Beinecke Library")
+          select('Ladybird')
           click_on("Create Parent object")
         end
         it "adds the visibility for non-public objects" do
@@ -509,6 +515,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       stub_metadata_cloud("10001192")
       fill_in('Oid', with: "10001192")
       select('Beinecke Library')
+      select('Ladybird')
     end
     it "does not allow creation of new parent with wrong admin set" do
       click_on("Create Parent object")

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -469,6 +469,37 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         expect(page).to have_button('Reindex', disabled: true)
       end
     end
+
+    context "logged in without any editor rights" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        brbl = AdminSet.find_by_key('brbl')
+        sml = AdminSet.find_by_key('sml')
+        user.remove_role(:editor, brbl) if brbl
+        user.remove_role(:editor, sml) if sml
+        login_as user
+        visit parent_objects_path
+      end
+
+      it "does allow create parent" do
+        expect(page).to have_button('New Parent', disabled: true)
+      end
+    end
+
+    context "logged in with editor rights" do
+      let(:user) { FactoryBot.create(:user) }
+      let(:admin_set) { FactoryBot.create(:admin_set, key: "adminset") }
+
+      before do
+        login_as user
+        visit parent_objects_path
+      end
+
+      it "does allow create parent" do
+        expect(page).to have_button('New Parent', disabled: false)
+      end
+    end
   end
 
   context "when logged in without admin set roles" do


### PR DESCRIPTION
Adds button for authorized users to create a new blank parent object.
The object is assigned a newly minted oid.