### PR TITLE
Added the solr field ancestor title

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -38,6 +38,7 @@ module SolrIndexable
       alternativeTitle_tesim: json_to_index["alternativeTitle"],
       alternativeTitleDisplay_tesim: json_to_index["alternativeTitleDisplay"],
       ancestorDisplayStrings_tesim: json_to_index["ancestorDisplayStrings"],
+      ancestor_titles_hierarchy_ssim: ancestor_structure(json_to_index["ancestorTitles"]),
       ancestorTitles_tesim: json_to_index["ancestorTitles"],
       archivalSort_ssi: json_to_index["archivalSort"],
       archiveSpaceUri_ssi: aspace_uri,


### PR DESCRIPTION
Co-authored-by: Maggie Zhao maggie.zhao@yale.edu
Co-authored-by: Lakeisha Robinson <lakeisha.robinson@yale.edu>

**Story**

We have facets for Repository and Collection Title, but these are just the top two levels of the archival hierarchy.   There may be many additional levels present in the archive and users may wish to filter their search to objects at one of these lower levels.   

Consider a hierarchy like this one, displayed on the result page:
`Beinecke Rare Book and Manuscript Library (BRBL) > Carl Van Vechten Papers Relating to African American Arts and Letters (JWJ MSS 1050) > Photographs > Color Slides > Portraits`

We'd like users to be able to click any level and run a search for items at that level.  So clicking on Photographs would run a search for items that match:
`Beinecke Rare Book and Manuscript Library (BRBL) > Carl Van Vechten Papers Relating to African American Arts and Letters (JWJ MSS 1050) > Photographs`

To enable this we must first index the ancestor data appropriately.

See See https://cwiki.apache.org/confluence/display/SOLR/HierarchicalFaceting for examples of tokenizing and indexing multiple levels of hierarchy.  

**Acceptance**
- [x] Index the data into a new Solr field 'ancestor_titles_hierarchy_ssim` based on the AncestorTitles MC field.
- [x] Create tests to demonstrate retrieval of data records based on searches of different levels of the hierarchy, such as the "Photographs" example above.