### PR TITLE
1456 Add solr field AncestorTitlesHierarchy

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -198,6 +198,23 @@ module SolrIndexable
     end.to_a
   end
 
+
+  def ancestor_structure(ancestor_title)
+    # Building the hierarchy structure
+    return nil unless ancestor_title&.is_a?(Array)
+    anc_struct = []
+    ancestor_title = ancestor_title.reverse
+    arr_size = 0
+    prev_string = ""
+    ancestor_title.each do |anc|
+      prev_string += (ancestor_title[arr_size - 1]).to_s + " > " unless arr_size.zero?
+      anc = prev_string + anc + " > "
+      anc_struct.push(anc)
+      arr_size += 1
+    end
+    anc_struct
+  end
+
   def generate_hash
     Digest::MD5.hexdigest oid.to_s
   end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -198,7 +198,6 @@ module SolrIndexable
     end.to_a
   end
 
-
   def ancestor_structure(ancestor_title)
     # Building the hierarchy structure
     return nil unless ancestor_title&.is_a?(Array)

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -39,6 +39,7 @@ module SolrIndexable
       alternativeTitleDisplay_tesim: json_to_index["alternativeTitleDisplay"],
       ancestorDisplayStrings_tesim: json_to_index["ancestorDisplayStrings"],
       ancestorTitles_tesim: json_to_index["ancestorTitles"],
+      ancestor_titles_hierarchy_ssim: ancestor_structure(json_to_index["ancestorTitles"]),
       archivalSort_ssi: json_to_index["archivalSort"],
       archiveSpaceUri_ssi: aspace_uri,
       callNumber_ssim: json_to_index["callNumber"],

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -170,6 +170,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
         expect(solr_document[:ancestorTitles_tesim]).to include "Oversize",
                                                                 "Abraham Lincoln collection (GEN MSS 257)",
                                                                 "Beinecke Rare Book and Manuscript Library (BRBL)"
+        expect(solr_document[:ancestor_titles_hierarchy_ssim].first).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > "
+        expect(solr_document[:ancestor_titles_hierarchy_ssim][1]).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257) > "
+        expect(solr_document[:ancestor_titles_hierarchy_ssim].last).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257) > Oversize > "
         expect(solr_document[:collection_title_ssi]).to include "Abraham Lincoln collection (GEN MSS 257)"
         expect(solr_document[:ancestorDisplayStrings_tesim]).to include "Oversize, n.d.",
                                                                         "Abraham Lincoln collection",


### PR DESCRIPTION
Co-authored-by: Lakeisha Robinson <lakeisha.robinson@yale.edu>
Co-authored-by: Frederick Rodriguez <frederick.rodriguez@yale.edu>

**Story**

We have facets for Repository and Collection Title, but these are just the top two levels of the archival hierarchy.   There may be many additional levels present in the archive and users may wish to filter their search to objects at one of these lower levels.   

Consider a hierarchy like this one, displayed on the result page:
`Beinecke Rare Book and Manuscript Library (BRBL) > Carl Van Vechten Papers Relating to African American Arts and Letters (JWJ MSS 1050) > Photographs > Color Slides > Portraits`

We'd like users to be able to click any level and run a search for items at that level.  So clicking on Photographs would run a search for items that match:
`Beinecke Rare Book and Manuscript Library (BRBL) > Carl Van Vechten Papers Relating to African American Arts and Letters (JWJ MSS 1050) > Photographs`

To enable this we must first index the ancestor data appropriately.

See See https://cwiki.apache.org/confluence/display/SOLR/HierarchicalFaceting for examples of tokenizing and indexing multiple levels of hierarchy.  

**Acceptance**
- [x] Index the data into a new Solr field 'ancestor_titles_hierarchy_ssim` based on the AncestorTitles MC field.
- [x] Create tests to demonstrate retrieval of data records based on searches of different levels of the hierarchy, such as the "Photographs" example above.