### PR TITLE
Queue update metadata jobs in a job in batches, to avoid timeout

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -99,10 +99,7 @@ class ParentObjectsController < ApplicationController
 
   def all_metadata
     authorize!(:update_metadata, ParentObject)
-    ParentObject.find_each do |po|
-      po.metadata_update = true
-      po.setup_metadata_job
-    end
+    UpdateAllMetadataJob.perform_later
     respond_to do |format|
       format.html { redirect_to parent_objects_url, notice: 'Parent objects have been queued for metadata update.' }
       format.json { head :no_content }

--- a/app/jobs/update_all_metadata_job.rb
+++ b/app/jobs/update_all_metadata_job.rb
@@ -10,12 +10,11 @@ class UpdateAllMetadataJob < ApplicationJob
   def perform(start_position = 0)
     parent_objects = ParentObject.order(:oid).offset(start_position).limit(UpdateAllMetadataJob.job_limit)
     last_job = parent_objects.count < UpdateAllMetadataJob.job_limit
-    if parent_objects.count.positive?
-      parent_objects.each do |po|
-        po.metadata_update = true
-        po.setup_metadata_job
-      end
-      UpdateAllMetadataJob.perform_later(start_position + parent_objects.count) unless last_job
+    return unless parent_objects.count.positive?
+    parent_objects.each do |po|
+      po.metadata_update = true
+      po.setup_metadata_job
     end
+    UpdateAllMetadataJob.perform_later(start_position + parent_objects.count) unless last_job
   end
 end

--- a/app/jobs/update_all_metadata_job.rb
+++ b/app/jobs/update_all_metadata_job.rb
@@ -10,7 +10,7 @@ class UpdateAllMetadataJob < ApplicationJob
   def perform(start_position = 0)
     parent_objects = ParentObject.order(:oid).offset(start_position).limit(UpdateAllMetadataJob.job_limit)
     last_job = parent_objects.count < UpdateAllMetadataJob.job_limit
-    return unless parent_objects.count.positive?
+    return unless parent_objects.count.positive?  # stop if nothing is found
     parent_objects.each do |po|
       po.metadata_update = true
       po.setup_metadata_job

--- a/app/jobs/update_all_metadata_job.rb
+++ b/app/jobs/update_all_metadata_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UpdateAllMetadataJob < ApplicationJob
+  queue_as :metadata
+
+  def self.job_limit
+    5000
+  end
+
+  def perform(start_position = 0)
+    parent_objects = ParentObject.order(:oid).offset(start_position).limit(UpdateAllMetadataJob.job_limit)
+    last_job = parent_objects.count < UpdateAllMetadataJob.job_limit
+    if parent_objects.count.positive?
+      parent_objects.each do |po|
+        po.metadata_update = true
+        po.setup_metadata_job
+      end
+      UpdateAllMetadataJob.perform_later(start_position + parent_objects.count) unless last_job
+    end
+  end
+end

--- a/app/jobs/update_all_metadata_job.rb
+++ b/app/jobs/update_all_metadata_job.rb
@@ -10,7 +10,7 @@ class UpdateAllMetadataJob < ApplicationJob
   def perform(start_position = 0)
     parent_objects = ParentObject.order(:oid).offset(start_position).limit(UpdateAllMetadataJob.job_limit)
     last_job = parent_objects.count < UpdateAllMetadataJob.job_limit
-    return unless parent_objects.count.positive?  # stop if nothing is found
+    return unless parent_objects.count.positive? # stop if nothing is found
     parent_objects.each do |po|
       po.metadata_update = true
       po.setup_metadata_job

--- a/spec/jobs/update_all_metadata_job_spec.rb
+++ b/spec/jobs/update_all_metadata_job_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UpdateAllMetadataJob, type: :job, prep_metadata_sources: true, solr: true do
+  let(:parent_object) { FactoryBot.build(:parent_object, oid: '16797069') }
+
+  context 'with tests active job queue' do
+    def queue_adapter_for_test
+      ActiveJob::QueueAdapters::DelayedJobAdapter.new
+    end
+
+    it 'increments the job queue by one' do
+      parent_object
+      ActiveJob::Base.queue_adapter = :delayed_job
+      expect do
+        UpdateAllMetadataJob.perform_later
+      end.to change { Delayed::Job.count }.by(1)
+    end
+  end
+
+  context 'with more than limit parent objects' do
+    before do
+      limit = UpdateAllMetadataJob.job_limit
+      total_records = 8000 #  some number > UpdateAllMetadataJob.job_limit < UpdateAllMetadataJob.job_limit * 2
+
+      # create mocks for everything the job uses
+      parent = double
+      expect(parent).to receive(:metadata_update=).exactly(total_records).times
+      expect(parent).to receive(:setup_metadata_job).exactly(total_records).times
+
+      parent_object_order = double
+      parent_object_order_offset1 = double
+      parent_object_order_offset2 = double
+      expect(ParentObject).to receive(:order).and_return(parent_object_order).exactly((total_records.to_f / limit).ceil).times
+      expect(parent_object_order).to receive(:offset).with(0).and_return parent_object_order_offset1
+      expect(parent_object_order).to receive(:offset).with(limit).and_return parent_object_order_offset2
+      expect(parent_object_order_offset1).to receive(:limit).with(limit).and_return [*1..limit].map { |_ix| parent }
+      expect(parent_object_order_offset2).to receive(:limit).with(limit).and_return [*1..(total_records - limit)].map { |_ix| parent }
+    end
+
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
+
+    it 'goes through all parents in batches' do
+      UpdateAllMetadataJob.perform_later
+    end
+  end
+end

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -449,14 +449,18 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       end
 
       it "does not update metadata without confirmation" do
-        expect(ParentObject).not_to receive(:find_each)
+        expect(ParentObject).not_to receive(:order)
         click_on("Update Metadata")
         expect(page.driver.browser.switch_to.alert.text).to eq("Are you sure you want to proceed?  This action will update metadata for the entire contents of the system.")
       end
 
       it "does update metadata with confirmation" do
-        expect(ParentObject).to receive(:find_each).and_return([]).once
         click_on("Update Metadata")
+        order = double
+        offset = double
+        allow(offset).to receive(:limit).and_return([])
+        allow(order).to receive(:offset).and_return(offset)
+        expect(ParentObject).to receive(:order).and_return(order)
         expect(page.driver.browser.switch_to.alert.text).to eq("Are you sure you want to proceed?  This action will update metadata for the entire contents of the system.")
         page.driver.browser.switch_to.alert.accept
       end


### PR DESCRIPTION
Queue each parent's metadata job in a new job: UpdateAllMetadataJob
Setup UpdateAllMetadataJob to queue the individual jobs in batches to avoid timeouts.