### PR TITLE
Reassociate child column values

### DIFF
--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -29,7 +29,7 @@ module Reassociatable
     end
     parents_needing_update
   end
-  # You can set the field to an empty string "" but the implementation skips any value that is nil. For the label, caption, and viewing hint it should be possible to set the value to nil.
+
   def reassociate_child(co, po, row)
     co.order = row["order"] unless row["order"].nil?
     co.label = row["label"]

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module Reassociatable
   extend ActiveSupport::Concern
-  include Updatable
 
   def reassociate_child_oids
     return unless batch_action == "reassociate child oids"
@@ -18,32 +18,65 @@ module Reassociatable
       po = load_parent(index, row["parent_oid"].to_i)
       next unless co.present? && po.present?
 
-      # byebug
-
-      # headers - check if headers present before update
       attach_item(po)
       attach_item(co)
+
       next unless user_update_child_permission(co, po)
 
       parents_needing_update << co.parent_object.oid
       parents_needing_update << row["parent_oid"].to_i
-      if row["order"].present?
-        order = extract_order(index, row)
-        next if order == :invalid_order
-      end
-      reassociate_child(co, po, row)
+
+      reassociate_child(co, po)
+
+      values_to_update = check_headers(headers, row)
+      update_child_parent_values(values_to_update, co, row, index)
     end
     parents_needing_update
   end
 
-  def reassociate_child(co, po, row)
-    # byebug
+  def check_headers(headers, row)
+    possible_headers = headers
+    values_to_update = []
+    possible_headers.each do |h|
+      values_to_update << h if row.headers.include?(h)
+    end
+    values_to_update
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength
+  def update_child_parent_values(values_to_update, co, row, index)
+    values_to_update.each do |h|
+      if h == 'viewing_hint'
+        co.viewing_hint = valid_view(row[h], co.oid)
+      elsif h == 'call_number'
+        co.parent_object.call_number = row[h]
+      elsif h == 'parent_title'
+        co.parent_object.authoritative_json["title"] = row[h]
+      elsif values_to_update.include? h
+        if h == 'label'
+          co.label = row[h]
+        elsif h == 'caption'
+          co.caption = row[h]
+        elsif h == 'order'
+          co.order = extract_order(index, row)
+        elsif h == 'child_oid' || h == 'parent_oid'
+          next
+        end
+      else
+        next
+      end
+      co.save
+      co.parent_object.save
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/MethodLength
+
+  def reassociate_child(co, po)
     co.parent_object = po
-    co.label = row["label"].present? ? row["label"] : co.label
-    co.caption = row["caption"].present? ? row["caption"] : co.caption
-    co.viewing_hint = row["viewing_hint"].present? ? valid_view(row["viewing_hint"], co.oid) : co.viewing_hint
-    co.parent_object.authoritative_json["title"] = row["parent_title"].present? ? row["parent_title"] : co.parent_object.authoritative_json["title"]
-    co.parent_object.call_number = row["call_number"].present? ? row["call_number"] : co.parent_object.call_number
     processing_event_for_child(co)
     co.save!
   end
@@ -75,14 +108,16 @@ module Reassociatable
     po
   end
 
+  # rubocop:disable Metrics/LineLength
   def valid_view(viewing_hint, oid)
     if ChildObject.viewing_hints.include? viewing_hint
       viewing_hint
     else
-      batch_processing_event("Child #{oid} did not update value for Viewing Hint. Value: #{viewing_hint} is invalid. For field Display Layout / Viewing Hint please use: non-paged, facing-pages, or leave column empty", 'Invalid Vocabulary')
+      batch_processing_event("Child #{oid} did not update value for Viewing Hint. Value: #{viewing_hint} is invalid. For field Viewing Hint please use: non-paged, facing-pages, or leave column empty", 'Invalid Vocabulary')
       nil
     end
   end
+  # rubocop:enable Metrics/LineLength
 
   def update_related_parent_objects(parents_needing_update)
     return unless batch_action == "reassociate child oids"
@@ -100,3 +135,4 @@ module Reassociatable
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -23,8 +23,10 @@ module Reassociatable
 
       parents_needing_update << co.parent_object.oid
       parents_needing_update << row["parent_oid"].to_i
-      order = extract_order(index, row)
-      next if order == :invalid_order
+      if row["order"].present?
+        order = extract_order(index, row)
+        next if order == :invalid_order
+      end
       reassociate_child(co, po, row)
     end
     parents_needing_update

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -29,11 +29,11 @@ module Reassociatable
     end
     parents_needing_update
   end
-
+  # You can set the field to an empty string "" but the implementation skips any value that is nil. For the label, caption, and viewing hint it should be possible to set the value to nil.
   def reassociate_child(co, po, row)
-    co.order = row["order"] unless row["order"].nil?
-    co.label = row["label"] unless row["label"].nil?
-    co.caption = row["caption"] unless row["caption"].nil?
+    co.order = row["order"]
+    co.label = row["label"]
+    co.caption = row["caption"]
     co.parent_object = po
     processing_event_for_child(co)
     co.save!

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -29,12 +29,12 @@ module Reassociatable
     end
     parents_needing_update
   end
-
   # You can set the field to an empty string "" but the implementation skips any value that is nil. For the label, caption, and viewing hint it should be possible to set the value to nil.
   def reassociate_child(co, po, row)
-    co.order = row["order"]
+    co.order = row["order"] unless row["order"].nil?
     co.label = row["label"]
     co.caption = row["caption"]
+    co.viewing_hint = row["viewing_hint"]
     co.parent_object = po
     processing_event_for_child(co)
     co.save!

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -29,6 +29,7 @@ module Reassociatable
     end
     parents_needing_update
   end
+
   # You can set the field to an empty string "" but the implementation skips any value that is nil. For the label, caption, and viewing hint it should be possible to set the value to nil.
   def reassociate_child(co, po, row)
     co.order = row["order"]

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -24,7 +24,6 @@ module Reassociatable
 
       parents_needing_update << co.parent_object.oid
       parents_needing_update << row["parent_oid"].to_i
-      # check_columns(index, row, co)
       order = extract_order(index, row)
       next if order == :invalid_order
       reassociate_child(co, po, row)
@@ -33,12 +32,13 @@ module Reassociatable
   end
 
   def reassociate_child(co, po, row)
+    # byebug
     co.parent_object = po
     co.order = row["order"].present? ? row["order"] : co.order
     co.label = row["label"].present? ? row["label"] : co.label
     co.caption = row["caption"].present? ? row["caption"] : co.caption
     co.viewing_hint = row["viewing_hint"].present? ? row["viewing_hint"] : co.viewing_hint
-    co.parent_object.authoritative_json["title"] = row["parent_title"].present? ? row["parent_title"] : co.parent_object.authoritative_json["title"]  
+    co.parent_object.authoritative_json["title"] = row["parent_title"].present? ? row["parent_title"] : co.parent_object.authoritative_json["title"]
     co.parent_object.call_number = row["call_number"].present? ? row["call_number"] : co.parent_object.call_number
     processing_event_for_child(co)
     co.save!

--- a/spec/fixtures/reassociation_example_child_object_all_columns.csv
+++ b/spec/fixtures/reassociation_example_child_object_all_columns.csv
@@ -1,0 +1,2 @@
+child_oid,parent_oid,order,parent_title,call_number,label,caption,viewing_hint
+1030368,2005512,1,[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion],GEN MSS 257,,,

--- a/spec/fixtures/reassociation_example_child_object_invalid_view.csv
+++ b/spec/fixtures/reassociation_example_child_object_invalid_view.csv
@@ -1,0 +1,2 @@
+child_oid,parent_oid,viewing_hint
+1030368,2005512,note

--- a/spec/fixtures/reassociation_example_child_object_missing_columns.csv
+++ b/spec/fixtures/reassociation_example_child_object_missing_columns.csv
@@ -1,0 +1,2 @@
+child_oid,parent_oid,label,viewing_hint
+1021925,2004548,labelll,facing-pages

--- a/spec/fixtures/reassociation_example_child_object_missing_columns.csv
+++ b/spec/fixtures/reassociation_example_child_object_missing_columns.csv
@@ -1,2 +1,2 @@
-child_oid,parent_oid,viewing_hint
-1030368,2005512,facing-pages
+child_oid,parent_oid,label
+1030368,2005512,note

--- a/spec/fixtures/reassociation_example_child_object_missing_columns.csv
+++ b/spec/fixtures/reassociation_example_child_object_missing_columns.csv
@@ -1,2 +1,2 @@
 child_oid,parent_oid,viewing_hint
-1021925,2004548,facing-pages
+1030368,2005512,facing-pages

--- a/spec/fixtures/reassociation_example_child_object_missing_columns.csv
+++ b/spec/fixtures/reassociation_example_child_object_missing_columns.csv
@@ -1,2 +1,2 @@
-child_oid,parent_oid,label,viewing_hint
-1021925,2004548,labelll,facing-pages
+child_oid,parent_oid,viewing_hint
+1021925,2004548,facing-pages

--- a/spec/models/batch_process_reassociation_spec.rb
+++ b/spec/models/batch_process_reassociation_spec.rb
@@ -52,31 +52,32 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
     end
   end
 
-  describe "child object reassociation with missing column will not delete existing value" do
+  describe "child object reassociation with missing columns" do
     before do
       user.add_role(:editor, admin_set)
       batch_process.user_id = user.id
     end
 
     with_versioning do
-      it "does not delete already existing values if column is missing" do
+      it "does not update already existing values if column is missing" do
         co = ChildObject.find(1_021_925)
-        co.label = "TEST LABEL STAY SAME"
-        co.caption = "TEST LABEL STAY SAME2"
+        co.label = "Sample Label"
+        co.caption = "Example Caption"
         co.order = 3_445_234
         co.viewing_hint = nil
-        co.parent_object.authoritative_json["title"] = "po_title"
-        co.parent_object.call_number = "call_number"
+        co.parent_object.authoritative_json["title"] = "['Title from Parent Object']"
+        co.parent_object.call_number = "Call Number from Parent Object"
         co.save
+        # csv has only child oid, parent oid, and viewing_hint
         batch_process.file = child_object_with_missing_columns
         batch_process.save
         co = ChildObject.find(1_021_925)
-        expect(co.label).to eq "TEST LABEL STAY SAME"
-        expect(co.caption).to eq "TEST LABEL STAY SAME2"
+        expect(co.label).to eq "Sample Label"
+        expect(co.caption).to eq "Example Caption"
         expect(co.order).to eq 3_445_234
         expect(co.viewing_hint).to eq "facing-pages"
-        expect(co.parent_object.authoritative_json["title"]).to eq "po_title"
-        expect(co.parent_object.call_number).to eq "call_number"
+        expect(co.parent_object.authoritative_json["title"]).to eq "['Title from Parent Object']"
+        expect(co.parent_object.call_number).to eq "Call Number from Parent Object"
       end
     end
   end

--- a/spec/models/batch_process_reassociation_spec.rb
+++ b/spec/models/batch_process_reassociation_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   let(:role) { FactoryBot.create(:role, name: editor) }
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "reassociation_example_small.csv")) }
   let(:child_object_nil_values) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "reassociation_example_child_object_counts.csv")) }
-  let(:child_object_with_missing_columns) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "reassociation_example_child_object_missing_columns.csv")) }
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
   let(:parent_object_old_one) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
   let(:parent_object_old_two) { FactoryBot.create(:parent_object, oid: "2004549", admin_set_id: admin_set.id) }

--- a/spec/models/batch_process_reassociation_spec.rb
+++ b/spec/models/batch_process_reassociation_spec.rb
@@ -52,36 +52,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
     end
   end
 
-  describe "child object reassociation with missing columns" do
-    before do
-      user.add_role(:editor, admin_set)
-      batch_process.user_id = user.id
-    end
-
-    with_versioning do
-      it "does not update already existing values if column is missing" do
-        co = ChildObject.find(1_021_925)
-        co.label = "Sample Label"
-        co.caption = "Example Caption"
-        co.order = 3_445_234
-        co.viewing_hint = nil
-        co.parent_object.authoritative_json["title"] = "['Title from Parent Object']"
-        co.parent_object.call_number = "Call Number from Parent Object"
-        co.save
-        # csv has only child oid, parent oid, and viewing_hint
-        batch_process.file = child_object_with_missing_columns
-        batch_process.save
-        co = ChildObject.find(1_021_925)
-        expect(co.label).to eq "Sample Label"
-        expect(co.caption).to eq "Example Caption"
-        expect(co.order).to eq 3_445_234
-        expect(co.viewing_hint).to eq "facing-pages"
-        expect(co.parent_object.authoritative_json["title"]).to eq "['Title from Parent Object']"
-        expect(co.parent_object.call_number).to eq "Call Number from Parent Object"
-      end
-    end
-  end
-
   describe "reassociation as a user with an editor role" do
     # Original oids [2002826, 2004548, 2004548, 2004549, 2004549]
     before do

--- a/spec/system/batch_process_reassociation_spec.rb
+++ b/spec/system/batch_process_reassociation_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
   let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl', label: 'brbl') }
   # parent object has two child objects
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
-  # let(:child_object) { FactoryBot.create(:child_object, oid: "1030368" parent_object: parent_object) }
 
   before do
     parent_object
@@ -37,7 +36,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
     it "does not update already existing values if column is missing" do
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.find_by(oid: 1_030_368)
+      co = ChildObject.first
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil
@@ -50,7 +49,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_missing_columns.csv")
       click_button("Submit")
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.find_by(oid: 1_030_368)
+      co = ChildObject.first
       expect(co.order).to eq 1
       expect(co.label).to eq "note"
       expect(co.caption).to be_nil
@@ -73,7 +72,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
     it "updates value to nil when nil value present in csv" do
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.find_by(oid: 1_030_368)
+      co = ChildObject.first
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil

--- a/spec/system/batch_process_reassociation_spec.rb
+++ b/spec/system/batch_process_reassociation_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
 
   before do
-    parent_object
-    stub_ptiffs_and_manifests
     stub_metadata_cloud("2005512")
+    stub_ptiffs_and_manifests
+    parent_object
   end
 
   around do |example|
@@ -35,8 +35,9 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     end
 
     it "does not update already existing values if column is missing" do
+      # byebug
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.first
+      co = parent_object.child_objects.first
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil
@@ -49,7 +50,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_missing_columns.csv")
       click_button("Submit")
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.first
+      co = parent_object.child_objects.first
       expect(co.order).to eq 1
       expect(co.label).to eq "note"
       expect(co.caption).to be_nil
@@ -72,7 +73,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
     it "updates value to nil when nil value present in csv" do
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.first
+      co = parent_object.child_objects.first
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil

--- a/spec/system/batch_process_reassociation_spec.rb
+++ b/spec/system/batch_process_reassociation_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
+  let(:batch_process) { described_class.new(batch_action: "reassociate child oids") }
+  let(:user) { FactoryBot.create(:user) }
+  let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl', label: 'brbl') }
+  # parent object has four child objects
+  let!(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
+
+  before do
+    stub_ptiffs_and_manifests
+    stub_metadata_cloud("2005512")
+  end
+
+  around do |example|
+    perform_enqueued_jobs do
+      original_path_ocr = ENV['OCR_DOWNLOAD_BUCKET']
+      ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
+      example.run
+      ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
+    end
+  end
+
+  describe "child object reassociation with missing columns" do
+    before do
+      login_as user
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+    end
+
+    it "does not update already existing values if column is missing" do
+      visit batch_processes_path
+      select("Reassociate Child Oids")
+      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_all_columns.csv")
+      click_button("Submit")
+      expect(page).to have_content "Your job is queued for processing in the background"
+      co = ChildObject.find(1_030_368)
+      expect(co.order).to eq 1
+      expect(co.label).to be_nil
+      expect(co.caption).to be_nil
+      expect(co.viewing_hint).to be_nil
+      expect(co.parent_object.authoritative_json["title"]).to eq ["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1"]
+      expect(co.parent_object.call_number).to eq "GEN MSS 257"
+      # csv has only child oid, parent oid, and viewing_hint
+      visit batch_processes_path
+      select("Reassociate Child Oids")
+      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_missing_columns.csv")
+      click_button("Submit")
+      expect(page).to have_content "Your job is queued for processing in the background"
+      co = ChildObject.find(1_030_368)
+      expect(co.order).to eq 1
+      expect(co.label).to be_nil
+      expect(co.caption).to be_nil
+      expect(co.viewing_hint).to eq "facing-pages"
+      expect(co.parent_object.authoritative_json["title"]).to eq ["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1"]
+      expect(co.parent_object.call_number).to eq "GEN MSS 257"
+    end
+  end
+end

--- a/spec/system/batch_process_reassociation_spec.rb
+++ b/spec/system/batch_process_reassociation_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
   let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl', label: 'brbl') }
   # parent object has two child objects
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
+  # let(:child_object) { FactoryBot.create(:child_object, oid: "1030368" parent_object: parent_object) }
 
   before do
     parent_object
@@ -36,7 +37,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
     it "does not update already existing values if column is missing" do
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.find(1_030_368)
+      co = ChildObject.find_by(oid: 1_030_368)
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil
@@ -49,7 +50,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_missing_columns.csv")
       click_button("Submit")
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.find(1_030_368)
+      co = ChildObject.find_by(oid: 1_030_368)
       expect(co.order).to eq 1
       expect(co.label).to eq "note"
       expect(co.caption).to be_nil
@@ -72,7 +73,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
     it "updates value to nil when nil value present in csv" do
       expect(page).to have_content "Your job is queued for processing in the background"
-      co = ChildObject.find(1_030_368)
+      co = ChildObject.find_by(oid: 1_030_368)
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil

--- a/spec/system/batch_process_reassociation_spec.rb
+++ b/spec/system/batch_process_reassociation_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
   let(:batch_process) { described_class.new(batch_action: "reassociate child oids") }
   let(:user) { FactoryBot.create(:user) }
   let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl', label: 'brbl') }
-  # parent object has four child objects
-  let!(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
+  # parent object has two child objects
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
 
   before do
+    parent_object
     stub_ptiffs_and_manifests
     stub_metadata_cloud("2005512")
   end
@@ -27,22 +28,22 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       login_as user
       user.add_role(:editor, admin_set)
       batch_process.user_id = user.id
-    end
-
-    it "does not update already existing values if column is missing" do
       visit batch_processes_path
       select("Reassociate Child Oids")
       page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_all_columns.csv")
       click_button("Submit")
+    end
+
+    it "does not update already existing values if column is missing" do
       expect(page).to have_content "Your job is queued for processing in the background"
       co = ChildObject.find(1_030_368)
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil
       expect(co.viewing_hint).to be_nil
-      expect(co.parent_object.authoritative_json["title"]).to eq ["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1"]
+      expect(co.parent_object.authoritative_json["title"]).to eq "[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion]"
       expect(co.parent_object.call_number).to eq "GEN MSS 257"
-      # csv has only child oid, parent oid, and viewing_hint
+      # csv has only child oid, parent oid, and label
       visit batch_processes_path
       select("Reassociate Child Oids")
       page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_missing_columns.csv")
@@ -50,11 +51,53 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       expect(page).to have_content "Your job is queued for processing in the background"
       co = ChildObject.find(1_030_368)
       expect(co.order).to eq 1
+      expect(co.label).to eq "note"
+      expect(co.caption).to be_nil
+      expect(co.viewing_hint).to be_nil
+      expect(co.parent_object.authoritative_json["title"]).to eq "[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion]"
+      expect(co.parent_object.call_number).to eq "GEN MSS 257"
+    end
+  end
+
+  describe "child object reassociation with all columns present" do
+    before do
+      login_as user
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      visit batch_processes_path
+      select("Reassociate Child Oids")
+      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_all_columns.csv")
+      click_button("Submit")
+    end
+
+    it "updates value to nil when nil value present in csv" do
+      expect(page).to have_content "Your job is queued for processing in the background"
+      co = ChildObject.find(1_030_368)
+      expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil
-      expect(co.viewing_hint).to eq "facing-pages"
-      expect(co.parent_object.authoritative_json["title"]).to eq ["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1"]
+      expect(co.viewing_hint).to be_nil
+      expect(co.parent_object.authoritative_json["title"]).to eq "[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion]"
       expect(co.parent_object.call_number).to eq "GEN MSS 257"
+    end
+  end
+
+  describe "child object reassociation with an invalid viewing hint" do
+    before do
+      login_as user
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      visit batch_processes_path
+      select("Reassociate Child Oids")
+      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/reassociation_example_child_object_invalid_view.csv")
+      click_button("Submit")
+    end
+
+    it "returns error message when invalid controlled vocabularly is present in csv" do
+      expect(page).to have_content "Your job is queued for processing in the background"
+      visit "/batch_processes/#{BatchProcess.last.id}"
+      expect(page).to have_content "Child 1030368 did not update value for Viewing Hint. Value: note is invalid. For field Viewing Hint please use: non-paged, facing-pages, or leave column empty"
+      expect(page).to have_content "Invalid Vocabulary"
     end
   end
 end


### PR DESCRIPTION
# Summary
Re-associating Child OIDS batch process now allows 
- partial columns in csvs
- ability to set nil values for label, caption, and viewing_hint

# Related Ticket
[#1546](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1546)

# Screenshots
Before Reassociate Child OIDs:  
![Image 2021-08-23 at 2 54 18 PM](https://user-images.githubusercontent.com/24666568/130524830-dca783a1-5c0e-44ae-a95b-57e2a7df0a65.jpg)  
  
After Reassociate Child OIDs:  
![Image 2021-08-23 at 2 55 50 PM](https://user-images.githubusercontent.com/24666568/130524855-23bb44b3-15f7-41f7-ad2f-bbd5d19720fd.jpg)  
  
Before and After in Rails Console
![Image 2021-08-23 at 2 56 10 PM](https://user-images.githubusercontent.com/24666568/130525028-d431e6e2-1c50-49ac-a058-c442e78dea0d.jpg)

Error message provided when using invalid controlled vocabulary for viewing hint
![image](https://user-images.githubusercontent.com/36549923/131020992-9da9f38f-8266-4876-a307-58f4e0e18767.png)
