### PR TITLE
Changed fulltext to allow partial text status

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -89,10 +89,10 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     object.authoritative_metadata_source = MetadataSource.find_by(metadata_cloud_name: (metadata_source.presence || 'ladybird')) if object.class == ParentObject
     object.current_batch_process = self
     object.current_batch_connection = batch_connections.build(connectable: object)
-    if object.class == ChildObject
-      object.full_text = object.remote_ocr
-      object.current_batch_connection.save!
-    end
+    return unless object.class == ChildObject
+
+    object.full_text = object.remote_ocr
+    object.current_batch_connection.save!
   end
 
   def editable_admin_set(admin_set_key, oid, index)

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -89,7 +89,10 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     object.authoritative_metadata_source = MetadataSource.find_by(metadata_cloud_name: (metadata_source.presence || 'ladybird')) if object.class == ParentObject
     object.current_batch_process = self
     object.current_batch_connection = batch_connections.build(connectable: object)
-    object.current_batch_connection.save! if object.class == ChildObject
+    if object.class == ChildObject
+      object.full_text = object.remote_ocr
+      object.current_batch_connection.save!
+    end
   end
 
   def editable_admin_set(admin_set_key, oid, index)

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChildObject < ApplicationRecord
+class ChildObject < ApplicationRecord # rubocop:disable  Metrics/ClassLength
   has_paper_trail
   include Statable
   include Delayable
@@ -154,4 +154,4 @@ class ChildObject < ApplicationRecord
   def batch_connections_for(batch_process)
     batch_connections.where(batch_process: batch_process)
   end
-end
+end # rubocop:enable  Metrics/ClassLength

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -105,6 +105,12 @@ class ChildObject < ApplicationRecord
     @remote_ocr_path = File.join('fulltext', pairtree_path, "#{oid}.txt")
   end
 
+  def self.remote_ocr_path(oid)
+    pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
+    remote_ocr_path = File.join('fulltext', pairtree_path, "#{oid}.txt")
+    S3Service.full_text_exists?(remote_ocr_path)
+  end
+
   def pyramidal_tiff
     @pyramidal_tiff ||= PyramidalTiff.new(self)
   end

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -35,7 +35,6 @@ module Reassociatable
     co.label = row["label"] unless row["label"].nil?
     co.caption = row["caption"] unless row["caption"].nil?
     co.parent_object = po
-    co.full_text = co.remote_ocr
     processing_event_for_child(co)
     co.save!
   end

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -35,6 +35,7 @@ module Reassociatable
     co.label = row["label"] unless row["label"].nil?
     co.caption = row["caption"] unless row["caption"].nil?
     co.parent_object = po
+    co.full_text = co.remote_ocr
     processing_event_for_child(co)
     co.save!
   end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -164,7 +164,7 @@ module SolrIndexable
   def to_solr_full_text(json_to_index = nil)
     solr_document = to_solr(json_to_index)
     child_solr_documents = child_object_solr_documents
-    solr_document[:fulltext_tesim] = child_solr_documents.map { |child_solr_document| child_solr_document[:child_fulltext_tesim] } unless solr_document.nil? || child_solr_documents.nil?
+    solr_document[:fulltext_tesim] = child_solr_documents.map { |child_solr_document| child_solr_document.try(:[], :child_fulltext_tesim) } unless solr_document.nil? || child_solr_documents.nil?
     solr_document = append_full_text_status(solr_document)
 
     [solr_document, child_solr_documents]

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -212,9 +212,7 @@ module SolrIndexable
 
   def append_full_text_status(solr_document)
     return unless solr_document
-    present = solr_document.try(:[], "fulltext_tesim".to_sym).try("present?") ? "Yes" : "No"
-    solr_document[:has_fulltext_ssi] = present
-    solr_document[:is_partial_fulltext_ssi] = partial_fulltext? ? "Yes" : "No"
+    solr_document[:has_fulltext_ssi] = extent_of_full_text
 
     solr_document
   end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -174,8 +174,8 @@ module SolrIndexable
     if full_text?
       full_text_array = child_objects.map do |child_object|
         child_object_full_text = S3Service.download_full_text(child_object.remote_ocr_path)
-        raise "Missing full text for child object: #{child_object.oid}, for parent object: #{oid}" if child_object_full_text.nil?
-        child_object_to_solr(child_object, child_object_full_text)
+
+        child_object_to_solr(child_object, child_object_full_text) unless child_object_full_text.nil?
       end
       return full_text_array
     end
@@ -214,6 +214,7 @@ module SolrIndexable
     return unless solr_document
     present = solr_document.try(:[], "fulltext_tesim".to_sym).try("present?") ? "Yes" : "No"
     solr_document[:has_fulltext_ssi] = present
+    solr_document[:is_partial_fulltext_ssi] = partial_fulltext? ? "Yes" : "No"
 
     solr_document
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -113,6 +113,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def upsert_preservica_ingest_child_objects(preservica_ingest_hash)
+    child_objects_hash.map! do |co|
+      co[:full_text] = ChildObject.remote_ocr_path(co[:oid])
+    end
     PreservicaIngest.insert_all(preservica_ingest_hash)
   end
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -114,10 +114,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def upsert_preservica_ingest_child_objects(preservica_ingest_hash)
-    preservica_ingest_hash.map! do |co|
-      co[:full_text] = ChildObject.remote_ocr_path(co[:oid])
-      co
-    end
     PreservicaIngest.insert_all(preservica_ingest_hash)
   end
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -114,7 +114,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def upsert_preservica_ingest_child_objects(preservica_ingest_hash)
-    child_objects_hash.map! do |co|
+    preservica_ingest_hash.map! do |co|
       co[:full_text] = ChildObject.remote_ocr_path(co[:oid])
       co
     end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -97,12 +97,18 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       return self.child_object_count = 0 if ladybird_json["children"].empty?
       upsert_child_objects(array_of_child_hashes)
     end
+    self.child_objects.each do |co|
+      co.fulltext = co.remote_ocr
+      co.save!
+    end
     self.child_object_count = child_objects.size
   end
 
   def upsert_child_objects(child_objects_hash)
     raise "One or more of the child objects exists, Unable to create children" if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
-
+    child_objects_hash.map! do |co|
+      co[:full_text]=  ChildObject.remote_ocr_path(co[:oid])
+    end
     ChildObject.insert_all(child_objects_hash)
   end
 
@@ -368,7 +374,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     children_without_ft = false
 
     child_objects.each do |object|
-      if object.remote_ocr
+      if object.fulltext
         children_with_ft = true
       else
         children_without_ft = true

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -359,16 +359,28 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def full_text?
-    # Iterate over the child objects and check the bucket to see if the first children have a .txt file
     return false unless child_objects.any?
-    child_objects.first.remote_ocr
 
     # This will iterate over all child objects to check if they have a .txt file in the ocr bucket
     # If any do not have a .txt file, the loop will exit and return false
+    #
+    children_with_ft = false
+    children_without_ft = false
 
-    # child_objects.each do |object|
-    #   return false unless object.remote_ocr
-    # end
-    # true
+    child_objects.each do |object|
+      if object.remote_ocr
+        children_with_ft = true
+      else
+        children_without_ft = true
+      end
+    end
+    @partial_fulltext = children_with_ft && children_without_ft
+
+    children_with_ft
+  end
+
+  def partial_fulltext?
+    @partial_fulltext ||= false
+    @partial_fulltext
   end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -98,7 +98,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       upsert_child_objects(array_of_child_hashes)
     end
     child_objects.each do |co|
-      co.fulltext = co.remote_ocr
+      co.full_text = co.remote_ocr
       co.save!
     end
     self.child_object_count = child_objects.size
@@ -108,6 +108,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     raise "One or more of the child objects exists, Unable to create children" if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
     child_objects_hash.map! do |co|
       co[:full_text] = ChildObject.remote_ocr_path(co[:oid])
+      co
     end
     ChildObject.insert_all(child_objects_hash)
   end
@@ -115,6 +116,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def upsert_preservica_ingest_child_objects(preservica_ingest_hash)
     child_objects_hash.map! do |co|
       co[:full_text] = ChildObject.remote_ocr_path(co[:oid])
+      co
     end
     PreservicaIngest.insert_all(preservica_ingest_hash)
   end
@@ -377,7 +379,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     children_without_ft = false
 
     child_objects.each do |object|
-      if object.fulltext
+      if object.full_text
         children_with_ft = true
       else
         children_without_ft = true

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -97,7 +97,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       return self.child_object_count = 0 if ladybird_json["children"].empty?
       upsert_child_objects(array_of_child_hashes)
     end
-    self.child_objects.each do |co|
+    child_objects.each do |co|
       co.fulltext = co.remote_ocr
       co.save!
     end
@@ -107,7 +107,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def upsert_child_objects(child_objects_hash)
     raise "One or more of the child objects exists, Unable to create children" if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
     child_objects_hash.map! do |co|
-      co[:full_text]=  ChildObject.remote_ocr_path(co[:oid])
+      co[:full_text] = ChildObject.remote_ocr_path(co[:oid])
     end
     ChildObject.insert_all(child_objects_hash)
   end

--- a/db/migrate/20210907140414_add_fulltext_to_child_objects.rb
+++ b/db/migrate/20210907140414_add_fulltext_to_child_objects.rb
@@ -1,4 +1,4 @@
-class AddFullTextToChildObjects < ActiveRecord::Migration[6.0]
+class AddFulltextToChildObjects < ActiveRecord::Migration[6.0]
   def change
     add_column :child_objects, :full_text, :boolean, default:false
   end

--- a/db/migrate/20210907140414_add_fulltext_to_child_objects.rb
+++ b/db/migrate/20210907140414_add_fulltext_to_child_objects.rb
@@ -1,0 +1,5 @@
+class AddFullTextToChildObjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :child_objects, :full_text, :boolean, default:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_152826) do
+ActiveRecord::Schema.define(version: 2021_09_07_140414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,7 +73,11 @@ ActiveRecord::Schema.define(version: 2021_06_30_152826) do
     t.string "viewing_hint"
     t.datetime "ptiff_conversion_at"
     t.string "mets_access_master_path"
+    t.boolean "fulltext", default: false
+    t.index ["caption"], name: "index_child_objects_on_caption"
+    t.index ["label"], name: "index_child_objects_on_label"
     t.index ["oid"], name: "index_child_objects_on_oid", unique: true
+    t.index ["order"], name: "index_child_objects_on_order"
     t.index ["parent_object_oid"], name: "index_child_objects_on_parent_object_oid"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,10 +74,7 @@ ActiveRecord::Schema.define(version: 2021_09_07_140414) do
     t.datetime "ptiff_conversion_at"
     t.string "mets_access_master_path"
     t.boolean "full_text", default: false
-    t.index ["caption"], name: "index_child_objects_on_caption"
-    t.index ["label"], name: "index_child_objects_on_label"
     t.index ["oid"], name: "index_child_objects_on_oid", unique: true
-    t.index ["order"], name: "index_child_objects_on_order"
     t.index ["parent_object_oid"], name: "index_child_objects_on_parent_object_oid"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 2021_09_07_140414) do
     t.string "viewing_hint"
     t.datetime "ptiff_conversion_at"
     t.string "mets_access_master_path"
-    t.boolean "fulltext", default: false
+    t.boolean "full_text", default: false
     t.index ["caption"], name: "index_child_objects_on_caption"
     t.index ["label"], name: "index_child_objects_on_label"
     t.index ["oid"], name: "index_child_objects_on_oid", unique: true

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_admin_sets: true, undelayed: true do
   subject(:batch_process) { described_class.new }
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "short_fixture_ids.csv")) }
@@ -498,7 +498,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
         end
       end
 
-      describe "uploading a csv of oids to create parent objects" do
+      describe "uploading a csv of oids to create parent objects", undelayed: true do
         let(:admin_set) { AdminSet.first }
 
         before do

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -170,10 +170,9 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
 
     describe "full text availability" do
       before do
-        stub_metadata_cloud("2004628")
+        stub_metadata_cloud("2004628", "ladybird")
         stub_request(:head, "https://yul-dc-ocr-test.s3.amazonaws.com/fulltext/89/45/67/89/456789.txt")
         .to_return(status: 200, headers: { 'Content-Type' => 'text/plain' })
-        recreate_children(parent_object)
       end
 
       it "can return a the remote ocr path" do
@@ -181,6 +180,9 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       end
 
       it "can determine if a child object has a txt file" do
+        recreate_children(parent_object)
+        child_object = parent_object.child_objects.first
+
         expect(child_object.remote_ocr).to eq(true)
         expect(child_object.full_text).to eq(true)
       end

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -181,6 +181,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
 
       it "can determine if a child object has a txt file" do
         expect(child_object.remote_ocr).to eq(true)
+        expect(child_object.full_text).to eq(true)
       end
     end
 

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
         stub_metadata_cloud("2004628")
         stub_request(:head, "https://yul-dc-ocr-test.s3.amazonaws.com/fulltext/89/45/67/89/456789.txt")
         .to_return(status: 200, headers: { 'Content-Type' => 'text/plain' })
+        recreate_children(parent_object)
       end
 
       it "can return a the remote ocr path" do

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -34,10 +34,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
     end
 
     it "does not have empty strings in to_solr hash" do
-            parent_object.bib = ""
+      parent_object.bib = ""
       parent_object.save!
       solr_document = parent_object.reload.to_solr
-      byebug
       expect(solr_document.values).not_to include("")
     end
 

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -34,9 +34,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
     end
 
     it "does not have empty strings in to_solr hash" do
-      parent_object.bib = ""
+            parent_object.bib = ""
       parent_object.save!
       solr_document = parent_object.reload.to_solr
+      byebug
       expect(solr_document.values).not_to include("")
     end
 
@@ -71,7 +72,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
   end
 
   context "indexing to Solr from the database with Ladybird ParentObjects", solr: true do
-    it "can index the 5 parent objects in the database to Solr and can remove those items" do
+    it "can index the 5 parent objects in the database to Solr and can remove those items", undelayed: true do
       response = solr.get 'select', params: { q: 'type_ssi:parent' }
       existing_solr_count = response["response"]["numFound"].to_i
 
@@ -87,7 +88,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
           FactoryBot.create(:parent_object, oid: oid)
         end
       end.to change { ParentObject.count }.by(5)
-
       response = solr.get 'select', params: { q: 'type_ssi:parent' }
       expect(response["response"]["numFound"]).to eq(5 + existing_solr_count)
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -88,9 +88,11 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         before do
           stub_full_text_not_found("16057782")
         end
-        it "raises exception" do
-          allow(Rails.logger).to receive(:error) { :logger_mock }
-          expect { parent_of_four.to_solr_full_text }.to raise_error("Missing full text for child object: 16057782, for parent object: 16057779")
+        it "becomes a partial fulltext" do
+          solr_document = parent_of_four.to_solr_full_text.first
+          expect(solr_document).not_to be_nil
+          expect(solr_document[:has_fulltext_ssi].to_s).to eq "Yes"
+          expect(solr_document[:is_partial_fulltext_ssi].to_s).to eq "Yes"
         end
       end
 
@@ -106,6 +108,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           expect(solr_document).not_to be_nil
           expect(solr_document[:fulltext_tesim].to_s).to include("много трудившейся")
           expect(solr_document[:has_fulltext_ssi].to_s).to eq "Yes"
+          expect(solr_document[:is_partial_fulltext_ssi].to_s).to eq "No"
         end
       end
     end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           allow(parent_of_four).to receive(:full_text?).and_call_original
           stub_full_text_not_found("16057782")
           parent_of_four.default_fetch
+          recreate_children parent_of_four
         end
         it "becomes a partial fulltext" do
           solr_document = parent_of_four.to_solr_full_text.first

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -94,8 +94,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         it "becomes a partial fulltext" do
           solr_document = parent_of_four.to_solr_full_text.first
           expect(solr_document).not_to be_nil
-          expect(solr_document[:has_fulltext_ssi].to_s).to eq "Yes"
-          expect(solr_document[:is_partial_fulltext_ssi].to_s).to eq "Yes"
+          expect(solr_document[:has_fulltext_ssi].to_s).to eq "Partial"
         end
       end
 
@@ -111,7 +110,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           expect(solr_document).not_to be_nil
           expect(solr_document[:fulltext_tesim].to_s).to include("много трудившейся")
           expect(solr_document[:has_fulltext_ssi].to_s).to eq "Yes"
-          expect(solr_document[:is_partial_fulltext_ssi].to_s).to eq "No"
         end
       end
     end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -86,7 +86,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
 
       context "with full text not found in s3" do
         before do
+          allow(parent_of_four).to receive(:full_text?).and_call_original
           stub_full_text_not_found("16057782")
+          parent_of_four.default_fetch
         end
         it "becomes a partial fulltext" do
           solr_document = parent_of_four.to_solr_full_text.first

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
   config.include(StubRequestHelper)
   config.include(Devise::Test::IntegrationHelpers)
   config.include Warden::Test::Helpers
+  config.include(ParentChildObjectHelper)
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,7 @@ end
 RSpec.configure do |config|
   config.include(ActiveJob::TestHelper)
   config.include(MetdataSourcesHelper)
+  config.include(DelayedJobsHelper)
   config.include(AdminSetsHelper)
   config.include(SolrHelper)
   config.include(StubRequestHelper)

--- a/spec/support/delayed_jobs_helper.rb
+++ b/spec/support/delayed_jobs_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DelayedJobsHelper
+  # Setup rspec
+  RSpec.configure do |config|
+    config.around(undelayed: true) do |example|
+      Delayed::Worker.delay_jobs = false
+      example.run
+      Delayed::Worker.delay_jobs = true
+    end
+  end
+end

--- a/spec/support/parent_child_object_helper.rb
+++ b/spec/support/parent_child_object_helper.rb
@@ -2,7 +2,19 @@
 
 module ParentChildObjectHelper
   def recreate_children(parent_object)
+    parent_object.child_object_count ||= 0
+    ladybird_json = {}
+    ladybird_json["children"] = []
+
+    ChildObject.where(parent_object_oid: parent_object.oid).each do |child|
+      parent_object.child_objects.push(child) unless parent_object.child_objects.include?(child)
+      ladybird_json["children"] << child
+      parent_object.child_object_count += 1
+    end
+    parent_object.ladybird_json = ladybird_json if parent_object.ladybird_json.blank?
+
     ChildObject.delete_by(parent_object_oid: parent_object.oid)
     parent_object.create_child_records
+    parent_object # return new parent if the parent and child aren't actually linked due to test shenanigans
   end
 end

--- a/spec/support/parent_child_object_helper.rb
+++ b/spec/support/parent_child_object_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ParentChildObjectHelper
   def recreate_children(parent_object)
     ChildObject.delete_by(parent_object_oid: parent_object.oid)

--- a/spec/support/parent_child_object_helper.rb
+++ b/spec/support/parent_child_object_helper.rb
@@ -1,0 +1,6 @@
+module ParentChildObjectHelper
+  def recreate_children(parent_object)
+    ChildObject.delete_by(parent_object_oid: parent_object.oid)
+    parent_object.create_child_records
+  end
+end


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.edu>

**This should be done in a new branch, not `fulltext`**
**The new branch name is next_phase_fulltext_feature**

**Story**

Objects may be partially transcribed, or reassociations may result in the combination of a transcribed object with one that has no transcription.  This should be indicated in the Full Text search facet.   

The current approach of checking the first page for transcription and then assuming that the entire object is transcribed will no longer work.  To avoid performing repeated scans of AWS S3, we will record the full-text status at the child level on ingest. 

**Acceptance**
- [x] Add a `full_text` field to the Child Object model with type Boolean, defaulting to false
- [x] The Parent Object will need to be refactored to be able to indicate that it has partial full text (i.e. some of its children have `full_text` true and others false).  Currently there's a method to return a boolean (`full_text?`).   All values should be based on the values set in the Child Objects, not a real-time scan of S3.
- [x] If an object has partial full text, in `solr_indexable.rb` index the value "Partial" (currently the value is "Yes" or "No"). 
- [x] the logic ought to account for when the object has partial text  
