### PR TITLE
Allow nil itemPermission from ladybird

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -45,7 +45,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     [nil, "Completely digitized", "Partially digitized"]
   end
 
-  validates :visibility, inclusion: { in: visibilities,
+  validates :visibility, inclusion: { in: visibilities, allow_nil: true,
                                       message: "%{value} is not a valid value" }
 
   def initialize(attributes = nil)
@@ -230,7 +230,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.bib = lb_record["orbisBibId"]
     self.barcode = lb_record["orbisBarcode"]
     self.aspace_uri = lb_record["archiveSpaceUri"]
-    self.visibility = lb_record["itemPermission"]
+    self.visibility = lb_record["itemPermission"].nil? ? "Private" : lb_record["itemPermission"]
     self.rights_statement = lb_record["rights"]&.first
     self.extent_of_digitization = normalize_extent_of_digitization
     self.use_ladybird = false

--- a/spec/fixtures/ladybird/16688180.json
+++ b/spec/fixtures/ladybird/16688180.json
@@ -1,0 +1,27287 @@
+{
+  "jsonModelType": "LadybirdSolrRecord",
+  "source": "ladybird",
+  "recordType": "oid",
+  "uri": "/ladybird/oid/16688180",
+  "callNumber": "U55 2009",
+  "title": [
+    "The United States Holocaust Memorial Museum encyclopedia of camps and ghettos, 1933-1945 [electronic resource] / volume editor, Geoffrey P. Megargee."
+  ],
+  "alternativeTitle": [
+    "Project MUSE - UPCC 2012 Archival Complete Foundation Collection",
+    "Project MUSE - UPCC 2012 Books Archival Subscription Plan",
+    "Project MUSE - UPCC 2012 History Foundation Collection",
+    "UPCC book collections on Project MUSE."
+  ],
+  "creationPlace": [
+    "Bloomington : [Washington, D.C.] :"
+  ],
+  "publisher": [
+    "In association with the United States Holocaust Memorial Museum,",
+    "Indiana University Press ;"
+  ],
+  "date": [
+    "c2009-"
+  ],
+  "extent": [
+    "1 online resource (v. &lt;1; in 2) :) ill., maps ;"
+  ],
+  "language": [
+    "English"
+  ],
+  "description": [
+    "Access is available to the Yale community.",
+    "Includes bibliographical references and indexes.",
+    "vol. 1. Early camps, youth camps, and concentration camps and subcamps under the SS-Business Administration Main Office (WVHA)"
+  ],
+  "subjectName": [
+    "Megargee, Geoffrey P., 1959-",
+    "Project Muse.",
+    "United States Holocaust Memorial Museum."
+  ],
+  "subjectTopic": [
+    "Concentration camps--Europe--Encyclopedias.",
+    "Jewish ghettos--Europe, Eastern--Encyclopedias.",
+    "World War, 1939-1945--Concentration camps--Europe--Encyclopedias.",
+    "World War, 1939-1945--Jews--Europe--Encyclopedias."
+  ],
+  "subjectGeographicCode": "e------",
+  "format": [
+    "text"
+  ],
+  "partOf": "Yale University Library",
+  "rights": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement"
+  ],
+  "orbisBibId": "10628989",
+  "relatedUrl": [
+    "http://hdl.handle.net/10079/bibid/10628989"
+  ],
+  "illustrativeMatter": "080826m20099999inu     o  d        eng d",
+  "subjectEra": "World War, 1939-1945--Jews--Europe--Encyclopedias.",
+  "contributor": [
+    "Megargee, Geoffrey P., 1959-",
+    "Project Muse.",
+    "United States Holocaust Memorial Museum."
+  ],
+  "repository": "Yale University Library",
+  "subjectTitle": "World War, 1939-1945--Jews--Europe--Encyclopedias.",
+  "subjectTitleDisplay": [
+    "Concentration camps--Europe--Encyclopedias.",
+    "Jewish ghettos--Europe, Eastern--Encyclopedias.",
+    "World War, 1939-1945--Concentration camps--Europe--Encyclopedias.",
+    "World War, 1939-1945--Jews--Europe--Encyclopedias."
+  ],
+  "contributorDisplay": [
+    "Megargee, Geoffrey P., 1959-",
+    "Project Muse.",
+    "United States Holocaust Memorial Museum."
+  ],
+  "dependentUris": [
+    "/ladybird/oid/16688180"
+  ],
+  "oid": 16688180,
+  "collectionId": 6,
+  "children": [
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688182",
+      "title": [
+        "Page 1"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688182"
+      ],
+      "oid": 16688182,
+      "width": 1188,
+      "height": 1536,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688183",
+      "title": [
+        "Page 2"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688183"
+      ],
+      "oid": 16688183,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688184",
+      "title": [
+        "Page 3"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688184"
+      ],
+      "oid": 16688184,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688185",
+      "title": [
+        "Page 4"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688185"
+      ],
+      "oid": 16688185,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688186",
+      "title": [
+        "Page 5"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688186"
+      ],
+      "oid": 16688186,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688187",
+      "title": [
+        "Page 6"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688187"
+      ],
+      "oid": 16688187,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688188",
+      "title": [
+        "Page 7"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688188"
+      ],
+      "oid": 16688188,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688189",
+      "title": [
+        "Page 8"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688189"
+      ],
+      "oid": 16688189,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688190",
+      "title": [
+        "Page 9"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688190"
+      ],
+      "oid": 16688190,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688191",
+      "title": [
+        "Page 10"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688191"
+      ],
+      "oid": 16688191,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688192",
+      "title": [
+        "Page 11"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688192"
+      ],
+      "oid": 16688192,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688193",
+      "title": [
+        "Page 12"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688193"
+      ],
+      "oid": 16688193,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688194",
+      "title": [
+        "Page 13"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688194"
+      ],
+      "oid": 16688194,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688195",
+      "title": [
+        "Page 14"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688195"
+      ],
+      "oid": 16688195,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688196",
+      "title": [
+        "Page 15"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688196"
+      ],
+      "oid": 16688196,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688197",
+      "title": [
+        "Page 16"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688197"
+      ],
+      "oid": 16688197,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688198",
+      "title": [
+        "Page 17"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688198"
+      ],
+      "oid": 16688198,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688199",
+      "title": [
+        "Page 18"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688199"
+      ],
+      "oid": 16688199,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688200",
+      "title": [
+        "Page 19"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688200"
+      ],
+      "oid": 16688200,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688201",
+      "title": [
+        "Page 20"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688201"
+      ],
+      "oid": 16688201,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688202",
+      "title": [
+        "Page 21"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688202"
+      ],
+      "oid": 16688202,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688203",
+      "title": [
+        "Page 22"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688203"
+      ],
+      "oid": 16688203,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688204",
+      "title": [
+        "Page 23"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688204"
+      ],
+      "oid": 16688204,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688205",
+      "title": [
+        "Page 24"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688205"
+      ],
+      "oid": 16688205,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688206",
+      "title": [
+        "Page 25"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688206"
+      ],
+      "oid": 16688206,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688207",
+      "title": [
+        "Page 26"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688207"
+      ],
+      "oid": 16688207,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688208",
+      "title": [
+        "Page 27"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688208"
+      ],
+      "oid": 16688208,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688209",
+      "title": [
+        "Page 28"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688209"
+      ],
+      "oid": 16688209,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688210",
+      "title": [
+        "Page 29"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688210"
+      ],
+      "oid": 16688210,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688211",
+      "title": [
+        "Page 30"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688211"
+      ],
+      "oid": 16688211,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688212",
+      "title": [
+        "Page 31"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688212"
+      ],
+      "oid": 16688212,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688213",
+      "title": [
+        "Page 32"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688213"
+      ],
+      "oid": 16688213,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688214",
+      "title": [
+        "Page 33"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688214"
+      ],
+      "oid": 16688214,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688215",
+      "title": [
+        "Page 34"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688215"
+      ],
+      "oid": 16688215,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688216",
+      "title": [
+        "Page 35"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688216"
+      ],
+      "oid": 16688216,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688217",
+      "title": [
+        "Page 36"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688217"
+      ],
+      "oid": 16688217,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688218",
+      "title": [
+        "Page 37"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688218"
+      ],
+      "oid": 16688218,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688219",
+      "title": [
+        "Page 38"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688219"
+      ],
+      "oid": 16688219,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688220",
+      "title": [
+        "Page 39"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688220"
+      ],
+      "oid": 16688220,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688221",
+      "title": [
+        "Page 40"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688221"
+      ],
+      "oid": 16688221,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688222",
+      "title": [
+        "Page 41"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688222"
+      ],
+      "oid": 16688222,
+      "width": 2221,
+      "height": 1591,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688223",
+      "title": [
+        "Page 42"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688223"
+      ],
+      "oid": 16688223,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688224",
+      "title": [
+        "Page 43"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688224"
+      ],
+      "oid": 16688224,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688225",
+      "title": [
+        "Page 44"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688225"
+      ],
+      "oid": 16688225,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688226",
+      "title": [
+        "Page 45"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688226"
+      ],
+      "oid": 16688226,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688227",
+      "title": [
+        "Page 46"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688227"
+      ],
+      "oid": 16688227,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688228",
+      "title": [
+        "Page 47"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688228"
+      ],
+      "oid": 16688228,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688229",
+      "title": [
+        "Page 48"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688229"
+      ],
+      "oid": 16688229,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688230",
+      "title": [
+        "Page 49"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688230"
+      ],
+      "oid": 16688230,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688231",
+      "title": [
+        "Page 50"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688231"
+      ],
+      "oid": 16688231,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688232",
+      "title": [
+        "Page 51"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688232"
+      ],
+      "oid": 16688232,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688233",
+      "title": [
+        "Page 52"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688233"
+      ],
+      "oid": 16688233,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688234",
+      "title": [
+        "Page 53"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688234"
+      ],
+      "oid": 16688234,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688235",
+      "title": [
+        "Page 54"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688235"
+      ],
+      "oid": 16688235,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688236",
+      "title": [
+        "Page 55"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688236"
+      ],
+      "oid": 16688236,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688237",
+      "title": [
+        "Page 56"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688237"
+      ],
+      "oid": 16688237,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688238",
+      "title": [
+        "Page 57"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688238"
+      ],
+      "oid": 16688238,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688239",
+      "title": [
+        "Page 58"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688239"
+      ],
+      "oid": 16688239,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688240",
+      "title": [
+        "Page 59"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688240"
+      ],
+      "oid": 16688240,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688241",
+      "title": [
+        "Page 60"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688241"
+      ],
+      "oid": 16688241,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688242",
+      "title": [
+        "Page 61"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688242"
+      ],
+      "oid": 16688242,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688243",
+      "title": [
+        "Page 62"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688243"
+      ],
+      "oid": 16688243,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688244",
+      "title": [
+        "Page 63"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688244"
+      ],
+      "oid": 16688244,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688245",
+      "title": [
+        "Page 64"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688245"
+      ],
+      "oid": 16688245,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688246",
+      "title": [
+        "Page 65"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688246"
+      ],
+      "oid": 16688246,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688247",
+      "title": [
+        "Page 66"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688247"
+      ],
+      "oid": 16688247,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688248",
+      "title": [
+        "Page 67"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688248"
+      ],
+      "oid": 16688248,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688249",
+      "title": [
+        "Page 68"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688249"
+      ],
+      "oid": 16688249,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688250",
+      "title": [
+        "Page 69"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688250"
+      ],
+      "oid": 16688250,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688251",
+      "title": [
+        "Page 70"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688251"
+      ],
+      "oid": 16688251,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688252",
+      "title": [
+        "Page 71"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688252"
+      ],
+      "oid": 16688252,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688253",
+      "title": [
+        "Page 72"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688253"
+      ],
+      "oid": 16688253,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688254",
+      "title": [
+        "Page 73"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688254"
+      ],
+      "oid": 16688254,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688255",
+      "title": [
+        "Page 74"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688255"
+      ],
+      "oid": 16688255,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688256",
+      "title": [
+        "Page 75"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688256"
+      ],
+      "oid": 16688256,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688257",
+      "title": [
+        "Page 76"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688257"
+      ],
+      "oid": 16688257,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688258",
+      "title": [
+        "Page 77"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688258"
+      ],
+      "oid": 16688258,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688259",
+      "title": [
+        "Page 78"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688259"
+      ],
+      "oid": 16688259,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688260",
+      "title": [
+        "Page 79"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688260"
+      ],
+      "oid": 16688260,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688261",
+      "title": [
+        "Page 80"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688261"
+      ],
+      "oid": 16688261,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688262",
+      "title": [
+        "Page 81"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688262"
+      ],
+      "oid": 16688262,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688263",
+      "title": [
+        "Page 82"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688263"
+      ],
+      "oid": 16688263,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688264",
+      "title": [
+        "Page 83"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688264"
+      ],
+      "oid": 16688264,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688265",
+      "title": [
+        "Page 84"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688265"
+      ],
+      "oid": 16688265,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688266",
+      "title": [
+        "Page 85"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688266"
+      ],
+      "oid": 16688266,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688267",
+      "title": [
+        "Page 86"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688267"
+      ],
+      "oid": 16688267,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688268",
+      "title": [
+        "Page 87"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688268"
+      ],
+      "oid": 16688268,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688269",
+      "title": [
+        "Page 88"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688269"
+      ],
+      "oid": 16688269,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688270",
+      "title": [
+        "Page 89"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688270"
+      ],
+      "oid": 16688270,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688271",
+      "title": [
+        "Page 90"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688271"
+      ],
+      "oid": 16688271,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688272",
+      "title": [
+        "Page 91"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688272"
+      ],
+      "oid": 16688272,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688273",
+      "title": [
+        "Page 92"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688273"
+      ],
+      "oid": 16688273,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688274",
+      "title": [
+        "Page 93"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688274"
+      ],
+      "oid": 16688274,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688275",
+      "title": [
+        "Page 94"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688275"
+      ],
+      "oid": 16688275,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688276",
+      "title": [
+        "Page 95"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688276"
+      ],
+      "oid": 16688276,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688277",
+      "title": [
+        "Page 96"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688277"
+      ],
+      "oid": 16688277,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688278",
+      "title": [
+        "Page 97"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688278"
+      ],
+      "oid": 16688278,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688279",
+      "title": [
+        "Page 98"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688279"
+      ],
+      "oid": 16688279,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688280",
+      "title": [
+        "Page 99"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688280"
+      ],
+      "oid": 16688280,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688281",
+      "title": [
+        "Page 100"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688281"
+      ],
+      "oid": 16688281,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688282",
+      "title": [
+        "Page 101"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688282"
+      ],
+      "oid": 16688282,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688283",
+      "title": [
+        "Page 102"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688283"
+      ],
+      "oid": 16688283,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688284",
+      "title": [
+        "Page 103"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688284"
+      ],
+      "oid": 16688284,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688285",
+      "title": [
+        "Page 104"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688285"
+      ],
+      "oid": 16688285,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688286",
+      "title": [
+        "Page 105"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688286"
+      ],
+      "oid": 16688286,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688287",
+      "title": [
+        "Page 106"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688287"
+      ],
+      "oid": 16688287,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688288",
+      "title": [
+        "Page 107"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688288"
+      ],
+      "oid": 16688288,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688289",
+      "title": [
+        "Page 108"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688289"
+      ],
+      "oid": 16688289,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688290",
+      "title": [
+        "Page 109"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688290"
+      ],
+      "oid": 16688290,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688291",
+      "title": [
+        "Page 110"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688291"
+      ],
+      "oid": 16688291,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688292",
+      "title": [
+        "Page 111"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688292"
+      ],
+      "oid": 16688292,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688293",
+      "title": [
+        "Page 112"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688293"
+      ],
+      "oid": 16688293,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688294",
+      "title": [
+        "Page 113"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688294"
+      ],
+      "oid": 16688294,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688295",
+      "title": [
+        "Page 114"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688295"
+      ],
+      "oid": 16688295,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688296",
+      "title": [
+        "Page 115"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688296"
+      ],
+      "oid": 16688296,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688297",
+      "title": [
+        "Page 116"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688297"
+      ],
+      "oid": 16688297,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688298",
+      "title": [
+        "Page 117"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688298"
+      ],
+      "oid": 16688298,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688299",
+      "title": [
+        "Page 118"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688299"
+      ],
+      "oid": 16688299,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688300",
+      "title": [
+        "Page 119"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688300"
+      ],
+      "oid": 16688300,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688301",
+      "title": [
+        "Page 120"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688301"
+      ],
+      "oid": 16688301,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688302",
+      "title": [
+        "Page 121"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688302"
+      ],
+      "oid": 16688302,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688303",
+      "title": [
+        "Page 122"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688303"
+      ],
+      "oid": 16688303,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688304",
+      "title": [
+        "Page 123"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688304"
+      ],
+      "oid": 16688304,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688305",
+      "title": [
+        "Page 124"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688305"
+      ],
+      "oid": 16688305,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688306",
+      "title": [
+        "Page 125"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688306"
+      ],
+      "oid": 16688306,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688307",
+      "title": [
+        "Page 126"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688307"
+      ],
+      "oid": 16688307,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688308",
+      "title": [
+        "Page 127"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688308"
+      ],
+      "oid": 16688308,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688309",
+      "title": [
+        "Page 128"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688309"
+      ],
+      "oid": 16688309,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688310",
+      "title": [
+        "Page 129"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688310"
+      ],
+      "oid": 16688310,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688311",
+      "title": [
+        "Page 130"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688311"
+      ],
+      "oid": 16688311,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688312",
+      "title": [
+        "Page 131"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688312"
+      ],
+      "oid": 16688312,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688313",
+      "title": [
+        "Page 132"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688313"
+      ],
+      "oid": 16688313,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688314",
+      "title": [
+        "Page 133"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688314"
+      ],
+      "oid": 16688314,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688315",
+      "title": [
+        "Page 134"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688315"
+      ],
+      "oid": 16688315,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688316",
+      "title": [
+        "Page 135"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688316"
+      ],
+      "oid": 16688316,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688317",
+      "title": [
+        "Page 136"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688317"
+      ],
+      "oid": 16688317,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688318",
+      "title": [
+        "Page 137"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688318"
+      ],
+      "oid": 16688318,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688319",
+      "title": [
+        "Page 138"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688319"
+      ],
+      "oid": 16688319,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688320",
+      "title": [
+        "Page 139"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688320"
+      ],
+      "oid": 16688320,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688321",
+      "title": [
+        "Page 140"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688321"
+      ],
+      "oid": 16688321,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688322",
+      "title": [
+        "Page 141"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688322"
+      ],
+      "oid": 16688322,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688323",
+      "title": [
+        "Page 142"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688323"
+      ],
+      "oid": 16688323,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688324",
+      "title": [
+        "Page 143"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688324"
+      ],
+      "oid": 16688324,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688325",
+      "title": [
+        "Page 144"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688325"
+      ],
+      "oid": 16688325,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688326",
+      "title": [
+        "Page 145"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688326"
+      ],
+      "oid": 16688326,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688327",
+      "title": [
+        "Page 146"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688327"
+      ],
+      "oid": 16688327,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688328",
+      "title": [
+        "Page 147"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688328"
+      ],
+      "oid": 16688328,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688329",
+      "title": [
+        "Page 148"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688329"
+      ],
+      "oid": 16688329,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688330",
+      "title": [
+        "Page 149"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688330"
+      ],
+      "oid": 16688330,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688331",
+      "title": [
+        "Page 150"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688331"
+      ],
+      "oid": 16688331,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688332",
+      "title": [
+        "Page 151"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688332"
+      ],
+      "oid": 16688332,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688333",
+      "title": [
+        "Page 152"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688333"
+      ],
+      "oid": 16688333,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688334",
+      "title": [
+        "Page 153"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688334"
+      ],
+      "oid": 16688334,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688335",
+      "title": [
+        "Page 154"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688335"
+      ],
+      "oid": 16688335,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688336",
+      "title": [
+        "Page 155"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688336"
+      ],
+      "oid": 16688336,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688337",
+      "title": [
+        "Page 156"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688337"
+      ],
+      "oid": 16688337,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688338",
+      "title": [
+        "Page 157"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688338"
+      ],
+      "oid": 16688338,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688339",
+      "title": [
+        "Page 158"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688339"
+      ],
+      "oid": 16688339,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688340",
+      "title": [
+        "Page 159"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688340"
+      ],
+      "oid": 16688340,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688341",
+      "title": [
+        "Page 160"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688341"
+      ],
+      "oid": 16688341,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688342",
+      "title": [
+        "Page 161"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688342"
+      ],
+      "oid": 16688342,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688343",
+      "title": [
+        "Page 162"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688343"
+      ],
+      "oid": 16688343,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688344",
+      "title": [
+        "Page 163"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688344"
+      ],
+      "oid": 16688344,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688345",
+      "title": [
+        "Page 164"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688345"
+      ],
+      "oid": 16688345,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688346",
+      "title": [
+        "Page 165"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688346"
+      ],
+      "oid": 16688346,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688347",
+      "title": [
+        "Page 166"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688347"
+      ],
+      "oid": 16688347,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688348",
+      "title": [
+        "Page 167"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688348"
+      ],
+      "oid": 16688348,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688349",
+      "title": [
+        "Page 168"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688349"
+      ],
+      "oid": 16688349,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688350",
+      "title": [
+        "Page 169"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688350"
+      ],
+      "oid": 16688350,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688351",
+      "title": [
+        "Page 170"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688351"
+      ],
+      "oid": 16688351,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688352",
+      "title": [
+        "Page 171"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688352"
+      ],
+      "oid": 16688352,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688353",
+      "title": [
+        "Page 172"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688353"
+      ],
+      "oid": 16688353,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688354",
+      "title": [
+        "Page 173"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688354"
+      ],
+      "oid": 16688354,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688355",
+      "title": [
+        "Page 174"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688355"
+      ],
+      "oid": 16688355,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688356",
+      "title": [
+        "Page 175"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688356"
+      ],
+      "oid": 16688356,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688357",
+      "title": [
+        "Page 176"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688357"
+      ],
+      "oid": 16688357,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688358",
+      "title": [
+        "Page 177"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688358"
+      ],
+      "oid": 16688358,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688359",
+      "title": [
+        "Page 178"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688359"
+      ],
+      "oid": 16688359,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688360",
+      "title": [
+        "Page 179"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688360"
+      ],
+      "oid": 16688360,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688361",
+      "title": [
+        "Page 180"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688361"
+      ],
+      "oid": 16688361,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688362",
+      "title": [
+        "Page 181"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688362"
+      ],
+      "oid": 16688362,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688363",
+      "title": [
+        "Page 182"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688363"
+      ],
+      "oid": 16688363,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688364",
+      "title": [
+        "Page 183"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688364"
+      ],
+      "oid": 16688364,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688365",
+      "title": [
+        "Page 184"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688365"
+      ],
+      "oid": 16688365,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688366",
+      "title": [
+        "Page 185"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688366"
+      ],
+      "oid": 16688366,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688367",
+      "title": [
+        "Page 186"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688367"
+      ],
+      "oid": 16688367,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688368",
+      "title": [
+        "Page 187"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688368"
+      ],
+      "oid": 16688368,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688369",
+      "title": [
+        "Page 188"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688369"
+      ],
+      "oid": 16688369,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688370",
+      "title": [
+        "Page 189"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688370"
+      ],
+      "oid": 16688370,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688371",
+      "title": [
+        "Page 190"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688371"
+      ],
+      "oid": 16688371,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688372",
+      "title": [
+        "Page 191"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688372"
+      ],
+      "oid": 16688372,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688373",
+      "title": [
+        "Page 192"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688373"
+      ],
+      "oid": 16688373,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688374",
+      "title": [
+        "Page 193"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688374"
+      ],
+      "oid": 16688374,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688375",
+      "title": [
+        "Page 194"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688375"
+      ],
+      "oid": 16688375,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688376",
+      "title": [
+        "Page 195"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688376"
+      ],
+      "oid": 16688376,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688377",
+      "title": [
+        "Page 196"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688377"
+      ],
+      "oid": 16688377,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688378",
+      "title": [
+        "Page 197"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688378"
+      ],
+      "oid": 16688378,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688379",
+      "title": [
+        "Page 198"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688379"
+      ],
+      "oid": 16688379,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688380",
+      "title": [
+        "Page 199"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688380"
+      ],
+      "oid": 16688380,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688381",
+      "title": [
+        "Page 200"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688381"
+      ],
+      "oid": 16688381,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688382",
+      "title": [
+        "Page 201"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688382"
+      ],
+      "oid": 16688382,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688383",
+      "title": [
+        "Page 202"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688383"
+      ],
+      "oid": 16688383,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688384",
+      "title": [
+        "Page 203"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688384"
+      ],
+      "oid": 16688384,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688385",
+      "title": [
+        "Page 204"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688385"
+      ],
+      "oid": 16688385,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688386",
+      "title": [
+        "Page 205"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688386"
+      ],
+      "oid": 16688386,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688387",
+      "title": [
+        "Page 206"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688387"
+      ],
+      "oid": 16688387,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688388",
+      "title": [
+        "Page 207"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688388"
+      ],
+      "oid": 16688388,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688389",
+      "title": [
+        "Page 208"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688389"
+      ],
+      "oid": 16688389,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688390",
+      "title": [
+        "Page 209"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688390"
+      ],
+      "oid": 16688390,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688391",
+      "title": [
+        "Page 210"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688391"
+      ],
+      "oid": 16688391,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688392",
+      "title": [
+        "Page 211"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688392"
+      ],
+      "oid": 16688392,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688393",
+      "title": [
+        "Page 212"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688393"
+      ],
+      "oid": 16688393,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688394",
+      "title": [
+        "Page 213"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688394"
+      ],
+      "oid": 16688394,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688395",
+      "title": [
+        "Page 214"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688395"
+      ],
+      "oid": 16688395,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688396",
+      "title": [
+        "Page 215"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688396"
+      ],
+      "oid": 16688396,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688397",
+      "title": [
+        "Page 216"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688397"
+      ],
+      "oid": 16688397,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688398",
+      "title": [
+        "Page 217"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688398"
+      ],
+      "oid": 16688398,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688399",
+      "title": [
+        "Page 218"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688399"
+      ],
+      "oid": 16688399,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688400",
+      "title": [
+        "Page 219"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688400"
+      ],
+      "oid": 16688400,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688401",
+      "title": [
+        "Page 220"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688401"
+      ],
+      "oid": 16688401,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688402",
+      "title": [
+        "Page 221"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688402"
+      ],
+      "oid": 16688402,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688403",
+      "title": [
+        "Page 222"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688403"
+      ],
+      "oid": 16688403,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688404",
+      "title": [
+        "Page 223"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688404"
+      ],
+      "oid": 16688404,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688405",
+      "title": [
+        "Page 224"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688405"
+      ],
+      "oid": 16688405,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688406",
+      "title": [
+        "Page 225"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688406"
+      ],
+      "oid": 16688406,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688407",
+      "title": [
+        "Page 226"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688407"
+      ],
+      "oid": 16688407,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688408",
+      "title": [
+        "Page 227"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688408"
+      ],
+      "oid": 16688408,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688409",
+      "title": [
+        "Page 228"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688409"
+      ],
+      "oid": 16688409,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688410",
+      "title": [
+        "Page 229"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688410"
+      ],
+      "oid": 16688410,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688411",
+      "title": [
+        "Page 230"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688411"
+      ],
+      "oid": 16688411,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688412",
+      "title": [
+        "Page 231"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688412"
+      ],
+      "oid": 16688412,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688413",
+      "title": [
+        "Page 232"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688413"
+      ],
+      "oid": 16688413,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688414",
+      "title": [
+        "Page 233"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688414"
+      ],
+      "oid": 16688414,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688415",
+      "title": [
+        "Page 234"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688415"
+      ],
+      "oid": 16688415,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688416",
+      "title": [
+        "Page 235"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688416"
+      ],
+      "oid": 16688416,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688417",
+      "title": [
+        "Page 236"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688417"
+      ],
+      "oid": 16688417,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688418",
+      "title": [
+        "Page 237"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688418"
+      ],
+      "oid": 16688418,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688419",
+      "title": [
+        "Page 238"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688419"
+      ],
+      "oid": 16688419,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688420",
+      "title": [
+        "Page 239"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688420"
+      ],
+      "oid": 16688420,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688421",
+      "title": [
+        "Page 240"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688421"
+      ],
+      "oid": 16688421,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688422",
+      "title": [
+        "Page 241"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688422"
+      ],
+      "oid": 16688422,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688423",
+      "title": [
+        "Page 242"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688423"
+      ],
+      "oid": 16688423,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688424",
+      "title": [
+        "Page 243"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688424"
+      ],
+      "oid": 16688424,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688425",
+      "title": [
+        "Page 244"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688425"
+      ],
+      "oid": 16688425,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688426",
+      "title": [
+        "Page 245"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688426"
+      ],
+      "oid": 16688426,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688427",
+      "title": [
+        "Page 246"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688427"
+      ],
+      "oid": 16688427,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688428",
+      "title": [
+        "Page 247"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688428"
+      ],
+      "oid": 16688428,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688429",
+      "title": [
+        "Page 248"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688429"
+      ],
+      "oid": 16688429,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688430",
+      "title": [
+        "Page 249"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688430"
+      ],
+      "oid": 16688430,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688431",
+      "title": [
+        "Page 250"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688431"
+      ],
+      "oid": 16688431,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688432",
+      "title": [
+        "Page 251"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688432"
+      ],
+      "oid": 16688432,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688433",
+      "title": [
+        "Page 252"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688433"
+      ],
+      "oid": 16688433,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688434",
+      "title": [
+        "Page 253"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688434"
+      ],
+      "oid": 16688434,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688435",
+      "title": [
+        "Page 254"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688435"
+      ],
+      "oid": 16688435,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688436",
+      "title": [
+        "Page 255"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688436"
+      ],
+      "oid": 16688436,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688437",
+      "title": [
+        "Page 256"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688437"
+      ],
+      "oid": 16688437,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688438",
+      "title": [
+        "Page 257"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688438"
+      ],
+      "oid": 16688438,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688439",
+      "title": [
+        "Page 258"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688439"
+      ],
+      "oid": 16688439,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688440",
+      "title": [
+        "Page 259"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688440"
+      ],
+      "oid": 16688440,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688441",
+      "title": [
+        "Page 260"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688441"
+      ],
+      "oid": 16688441,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688442",
+      "title": [
+        "Page 261"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688442"
+      ],
+      "oid": 16688442,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688443",
+      "title": [
+        "Page 262"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688443"
+      ],
+      "oid": 16688443,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688444",
+      "title": [
+        "Page 263"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688444"
+      ],
+      "oid": 16688444,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688445",
+      "title": [
+        "Page 264"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688445"
+      ],
+      "oid": 16688445,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688446",
+      "title": [
+        "Page 265"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688446"
+      ],
+      "oid": 16688446,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688447",
+      "title": [
+        "Page 266"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688447"
+      ],
+      "oid": 16688447,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688448",
+      "title": [
+        "Page 267"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688448"
+      ],
+      "oid": 16688448,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688449",
+      "title": [
+        "Page 268"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688449"
+      ],
+      "oid": 16688449,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688450",
+      "title": [
+        "Page 269"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688450"
+      ],
+      "oid": 16688450,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688451",
+      "title": [
+        "Page 270"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688451"
+      ],
+      "oid": 16688451,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688452",
+      "title": [
+        "Page 271"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688452"
+      ],
+      "oid": 16688452,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688453",
+      "title": [
+        "Page 272"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688453"
+      ],
+      "oid": 16688453,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688454",
+      "title": [
+        "Page 273"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688454"
+      ],
+      "oid": 16688454,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688455",
+      "title": [
+        "Page 274"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688455"
+      ],
+      "oid": 16688455,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688456",
+      "title": [
+        "Page 275"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688456"
+      ],
+      "oid": 16688456,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688457",
+      "title": [
+        "Page 276"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688457"
+      ],
+      "oid": 16688457,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688458",
+      "title": [
+        "Page 277"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688458"
+      ],
+      "oid": 16688458,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688459",
+      "title": [
+        "Page 278"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688459"
+      ],
+      "oid": 16688459,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688460",
+      "title": [
+        "Page 279"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688460"
+      ],
+      "oid": 16688460,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688461",
+      "title": [
+        "Page 280"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688461"
+      ],
+      "oid": 16688461,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688462",
+      "title": [
+        "Page 281"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688462"
+      ],
+      "oid": 16688462,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688463",
+      "title": [
+        "Page 282"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688463"
+      ],
+      "oid": 16688463,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688464",
+      "title": [
+        "Page 283"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688464"
+      ],
+      "oid": 16688464,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688465",
+      "title": [
+        "Page 284"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688465"
+      ],
+      "oid": 16688465,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688466",
+      "title": [
+        "Page 285"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688466"
+      ],
+      "oid": 16688466,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688467",
+      "title": [
+        "Page 286"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688467"
+      ],
+      "oid": 16688467,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688468",
+      "title": [
+        "Page 287"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688468"
+      ],
+      "oid": 16688468,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688469",
+      "title": [
+        "Page 288"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688469"
+      ],
+      "oid": 16688469,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688470",
+      "title": [
+        "Page 289"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688470"
+      ],
+      "oid": 16688470,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688471",
+      "title": [
+        "Page 290"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688471"
+      ],
+      "oid": 16688471,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688472",
+      "title": [
+        "Page 291"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688472"
+      ],
+      "oid": 16688472,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688473",
+      "title": [
+        "Page 292"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688473"
+      ],
+      "oid": 16688473,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688474",
+      "title": [
+        "Page 293"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688474"
+      ],
+      "oid": 16688474,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688475",
+      "title": [
+        "Page 294"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688475"
+      ],
+      "oid": 16688475,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688476",
+      "title": [
+        "Page 295"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688476"
+      ],
+      "oid": 16688476,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688477",
+      "title": [
+        "Page 296"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688477"
+      ],
+      "oid": 16688477,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688478",
+      "title": [
+        "Page 297"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688478"
+      ],
+      "oid": 16688478,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688479",
+      "title": [
+        "Page 298"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688479"
+      ],
+      "oid": 16688479,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688480",
+      "title": [
+        "Page 299"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688480"
+      ],
+      "oid": 16688480,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688481",
+      "title": [
+        "Page 300"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688481"
+      ],
+      "oid": 16688481,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688482",
+      "title": [
+        "Page 301"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688482"
+      ],
+      "oid": 16688482,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688483",
+      "title": [
+        "Page 302"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688483"
+      ],
+      "oid": 16688483,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688484",
+      "title": [
+        "Page 303"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688484"
+      ],
+      "oid": 16688484,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688485",
+      "title": [
+        "Page 304"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688485"
+      ],
+      "oid": 16688485,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688486",
+      "title": [
+        "Page 305"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688486"
+      ],
+      "oid": 16688486,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688487",
+      "title": [
+        "Page 306"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688487"
+      ],
+      "oid": 16688487,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688488",
+      "title": [
+        "Page 307"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688488"
+      ],
+      "oid": 16688488,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688489",
+      "title": [
+        "Page 308"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688489"
+      ],
+      "oid": 16688489,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688490",
+      "title": [
+        "Page 309"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688490"
+      ],
+      "oid": 16688490,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688491",
+      "title": [
+        "Page 310"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688491"
+      ],
+      "oid": 16688491,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688492",
+      "title": [
+        "Page 311"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688492"
+      ],
+      "oid": 16688492,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688493",
+      "title": [
+        "Page 312"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688493"
+      ],
+      "oid": 16688493,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688494",
+      "title": [
+        "Page 313"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688494"
+      ],
+      "oid": 16688494,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688495",
+      "title": [
+        "Page 314"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688495"
+      ],
+      "oid": 16688495,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688496",
+      "title": [
+        "Page 315"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688496"
+      ],
+      "oid": 16688496,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688497",
+      "title": [
+        "Page 316"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688497"
+      ],
+      "oid": 16688497,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688498",
+      "title": [
+        "Page 317"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688498"
+      ],
+      "oid": 16688498,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688499",
+      "title": [
+        "Page 318"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688499"
+      ],
+      "oid": 16688499,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688500",
+      "title": [
+        "Page 319"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688500"
+      ],
+      "oid": 16688500,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688501",
+      "title": [
+        "Page 320"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688501"
+      ],
+      "oid": 16688501,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688502",
+      "title": [
+        "Page 321"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688502"
+      ],
+      "oid": 16688502,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688503",
+      "title": [
+        "Page 322"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688503"
+      ],
+      "oid": 16688503,
+      "width": 1193,
+      "height": 1677,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688504",
+      "title": [
+        "Page 323"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688504"
+      ],
+      "oid": 16688504,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688505",
+      "title": [
+        "Page 324"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688505"
+      ],
+      "oid": 16688505,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688506",
+      "title": [
+        "Page 325"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688506"
+      ],
+      "oid": 16688506,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688507",
+      "title": [
+        "Page 326"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688507"
+      ],
+      "oid": 16688507,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688508",
+      "title": [
+        "Page 327"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688508"
+      ],
+      "oid": 16688508,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688509",
+      "title": [
+        "Page 328"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688509"
+      ],
+      "oid": 16688509,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688510",
+      "title": [
+        "Page 329"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688510"
+      ],
+      "oid": 16688510,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688511",
+      "title": [
+        "Page 330"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688511"
+      ],
+      "oid": 16688511,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688512",
+      "title": [
+        "Page 331"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688512"
+      ],
+      "oid": 16688512,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688513",
+      "title": [
+        "Page 332"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688513"
+      ],
+      "oid": 16688513,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688514",
+      "title": [
+        "Page 333"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688514"
+      ],
+      "oid": 16688514,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688515",
+      "title": [
+        "Page 334"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688515"
+      ],
+      "oid": 16688515,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688516",
+      "title": [
+        "Page 335"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688516"
+      ],
+      "oid": 16688516,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688517",
+      "title": [
+        "Page 336"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688517"
+      ],
+      "oid": 16688517,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688518",
+      "title": [
+        "Page 337"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688518"
+      ],
+      "oid": 16688518,
+      "width": 3331,
+      "height": 2394,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688519",
+      "title": [
+        "Page 338"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688519"
+      ],
+      "oid": 16688519,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688520",
+      "title": [
+        "Page 339"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688520"
+      ],
+      "oid": 16688520,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688521",
+      "title": [
+        "Page 340"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688521"
+      ],
+      "oid": 16688521,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688522",
+      "title": [
+        "Page 341"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688522"
+      ],
+      "oid": 16688522,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688523",
+      "title": [
+        "Page 342"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688523"
+      ],
+      "oid": 16688523,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688524",
+      "title": [
+        "Page 343"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688524"
+      ],
+      "oid": 16688524,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688525",
+      "title": [
+        "Page 344"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688525"
+      ],
+      "oid": 16688525,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688526",
+      "title": [
+        "Page 345"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688526"
+      ],
+      "oid": 16688526,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688527",
+      "title": [
+        "Page 346"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688527"
+      ],
+      "oid": 16688527,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688528",
+      "title": [
+        "Page 347"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688528"
+      ],
+      "oid": 16688528,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688529",
+      "title": [
+        "Page 348"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688529"
+      ],
+      "oid": 16688529,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688530",
+      "title": [
+        "Page 349"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688530"
+      ],
+      "oid": 16688530,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688531",
+      "title": [
+        "Page 350"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688531"
+      ],
+      "oid": 16688531,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688532",
+      "title": [
+        "Page 351"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688532"
+      ],
+      "oid": 16688532,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688533",
+      "title": [
+        "Page 352"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688533"
+      ],
+      "oid": 16688533,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688534",
+      "title": [
+        "Page 353"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688534"
+      ],
+      "oid": 16688534,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688535",
+      "title": [
+        "Page 354"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688535"
+      ],
+      "oid": 16688535,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688536",
+      "title": [
+        "Page 355"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688536"
+      ],
+      "oid": 16688536,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688537",
+      "title": [
+        "Page 356"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688537"
+      ],
+      "oid": 16688537,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688538",
+      "title": [
+        "Page 357"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688538"
+      ],
+      "oid": 16688538,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688539",
+      "title": [
+        "Page 358"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688539"
+      ],
+      "oid": 16688539,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688540",
+      "title": [
+        "Page 359"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688540"
+      ],
+      "oid": 16688540,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688541",
+      "title": [
+        "Page 360"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688541"
+      ],
+      "oid": 16688541,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688542",
+      "title": [
+        "Page 361"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688542"
+      ],
+      "oid": 16688542,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688543",
+      "title": [
+        "Page 362"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688543"
+      ],
+      "oid": 16688543,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688544",
+      "title": [
+        "Page 363"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688544"
+      ],
+      "oid": 16688544,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688545",
+      "title": [
+        "Page 364"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688545"
+      ],
+      "oid": 16688545,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688546",
+      "title": [
+        "Page 365"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688546"
+      ],
+      "oid": 16688546,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688547",
+      "title": [
+        "Page 366"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688547"
+      ],
+      "oid": 16688547,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688548",
+      "title": [
+        "Page 367"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688548"
+      ],
+      "oid": 16688548,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688549",
+      "title": [
+        "Page 368"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688549"
+      ],
+      "oid": 16688549,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688550",
+      "title": [
+        "Page 369"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688550"
+      ],
+      "oid": 16688550,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688551",
+      "title": [
+        "Page 370"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688551"
+      ],
+      "oid": 16688551,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688552",
+      "title": [
+        "Page 371"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688552"
+      ],
+      "oid": 16688552,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688553",
+      "title": [
+        "Page 372"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688553"
+      ],
+      "oid": 16688553,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688554",
+      "title": [
+        "Page 373"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688554"
+      ],
+      "oid": 16688554,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688555",
+      "title": [
+        "Page 374"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688555"
+      ],
+      "oid": 16688555,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688556",
+      "title": [
+        "Page 375"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688556"
+      ],
+      "oid": 16688556,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688557",
+      "title": [
+        "Page 376"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688557"
+      ],
+      "oid": 16688557,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688558",
+      "title": [
+        "Page 377"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688558"
+      ],
+      "oid": 16688558,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688559",
+      "title": [
+        "Page 378"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688559"
+      ],
+      "oid": 16688559,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688560",
+      "title": [
+        "Page 379"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688560"
+      ],
+      "oid": 16688560,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688561",
+      "title": [
+        "Page 380"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688561"
+      ],
+      "oid": 16688561,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688562",
+      "title": [
+        "Page 381"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688562"
+      ],
+      "oid": 16688562,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688563",
+      "title": [
+        "Page 382"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688563"
+      ],
+      "oid": 16688563,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688564",
+      "title": [
+        "Page 383"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688564"
+      ],
+      "oid": 16688564,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688565",
+      "title": [
+        "Page 384"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688565"
+      ],
+      "oid": 16688565,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688566",
+      "title": [
+        "Page 385"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688566"
+      ],
+      "oid": 16688566,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688567",
+      "title": [
+        "Page 386"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688567"
+      ],
+      "oid": 16688567,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688568",
+      "title": [
+        "Page 387"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688568"
+      ],
+      "oid": 16688568,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688569",
+      "title": [
+        "Page 388"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688569"
+      ],
+      "oid": 16688569,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688570",
+      "title": [
+        "Page 389"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688570"
+      ],
+      "oid": 16688570,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688571",
+      "title": [
+        "Page 390"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688571"
+      ],
+      "oid": 16688571,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688572",
+      "title": [
+        "Page 391"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688572"
+      ],
+      "oid": 16688572,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688573",
+      "title": [
+        "Page 392"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688573"
+      ],
+      "oid": 16688573,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688574",
+      "title": [
+        "Page 393"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688574"
+      ],
+      "oid": 16688574,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688575",
+      "title": [
+        "Page 394"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688575"
+      ],
+      "oid": 16688575,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688576",
+      "title": [
+        "Page 395"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688576"
+      ],
+      "oid": 16688576,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688577",
+      "title": [
+        "Page 396"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688577"
+      ],
+      "oid": 16688577,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688578",
+      "title": [
+        "Page 397"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688578"
+      ],
+      "oid": 16688578,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688579",
+      "title": [
+        "Page 398"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688579"
+      ],
+      "oid": 16688579,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688580",
+      "title": [
+        "Page 399"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688580"
+      ],
+      "oid": 16688580,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688581",
+      "title": [
+        "Page 400"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688581"
+      ],
+      "oid": 16688581,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688582",
+      "title": [
+        "Page 401"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688582"
+      ],
+      "oid": 16688582,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688583",
+      "title": [
+        "Page 402"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688583"
+      ],
+      "oid": 16688583,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688584",
+      "title": [
+        "Page 403"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688584"
+      ],
+      "oid": 16688584,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688585",
+      "title": [
+        "Page 404"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688585"
+      ],
+      "oid": 16688585,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688586",
+      "title": [
+        "Page 405"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688586"
+      ],
+      "oid": 16688586,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688587",
+      "title": [
+        "Page 406"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688587"
+      ],
+      "oid": 16688587,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688588",
+      "title": [
+        "Page 407"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688588"
+      ],
+      "oid": 16688588,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688589",
+      "title": [
+        "Page 408"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688589"
+      ],
+      "oid": 16688589,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688590",
+      "title": [
+        "Page 409"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688590"
+      ],
+      "oid": 16688590,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688591",
+      "title": [
+        "Page 410"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688591"
+      ],
+      "oid": 16688591,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688592",
+      "title": [
+        "Page 411"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688592"
+      ],
+      "oid": 16688592,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688593",
+      "title": [
+        "Page 412"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688593"
+      ],
+      "oid": 16688593,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688594",
+      "title": [
+        "Page 413"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688594"
+      ],
+      "oid": 16688594,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688595",
+      "title": [
+        "Page 414"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688595"
+      ],
+      "oid": 16688595,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688596",
+      "title": [
+        "Page 415"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688596"
+      ],
+      "oid": 16688596,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688597",
+      "title": [
+        "Page 416"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688597"
+      ],
+      "oid": 16688597,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688598",
+      "title": [
+        "Page 417"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688598"
+      ],
+      "oid": 16688598,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688599",
+      "title": [
+        "Page 418"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688599"
+      ],
+      "oid": 16688599,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688600",
+      "title": [
+        "Page 419"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688600"
+      ],
+      "oid": 16688600,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688601",
+      "title": [
+        "Page 420"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688601"
+      ],
+      "oid": 16688601,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688602",
+      "title": [
+        "Page 421"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688602"
+      ],
+      "oid": 16688602,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688603",
+      "title": [
+        "Page 422"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688603"
+      ],
+      "oid": 16688603,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688604",
+      "title": [
+        "Page 423"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688604"
+      ],
+      "oid": 16688604,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688605",
+      "title": [
+        "Page 424"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688605"
+      ],
+      "oid": 16688605,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688606",
+      "title": [
+        "Page 425"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688606"
+      ],
+      "oid": 16688606,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688607",
+      "title": [
+        "Page 426"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688607"
+      ],
+      "oid": 16688607,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688608",
+      "title": [
+        "Page 427"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688608"
+      ],
+      "oid": 16688608,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688609",
+      "title": [
+        "Page 428"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688609"
+      ],
+      "oid": 16688609,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688610",
+      "title": [
+        "Page 429"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688610"
+      ],
+      "oid": 16688610,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688611",
+      "title": [
+        "Page 430"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688611"
+      ],
+      "oid": 16688611,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688612",
+      "title": [
+        "Page 431"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688612"
+      ],
+      "oid": 16688612,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688613",
+      "title": [
+        "Page 432"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688613"
+      ],
+      "oid": 16688613,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688614",
+      "title": [
+        "Page 433"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688614"
+      ],
+      "oid": 16688614,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688615",
+      "title": [
+        "Page 434"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688615"
+      ],
+      "oid": 16688615,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688616",
+      "title": [
+        "Page 435"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688616"
+      ],
+      "oid": 16688616,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688617",
+      "title": [
+        "Page 436"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688617"
+      ],
+      "oid": 16688617,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688618",
+      "title": [
+        "Page 437"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688618"
+      ],
+      "oid": 16688618,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688619",
+      "title": [
+        "Page 438"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688619"
+      ],
+      "oid": 16688619,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688620",
+      "title": [
+        "Page 439"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688620"
+      ],
+      "oid": 16688620,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688621",
+      "title": [
+        "Page 440"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688621"
+      ],
+      "oid": 16688621,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688622",
+      "title": [
+        "Page 441"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688622"
+      ],
+      "oid": 16688622,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688623",
+      "title": [
+        "Page 442"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688623"
+      ],
+      "oid": 16688623,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688624",
+      "title": [
+        "Page 443"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688624"
+      ],
+      "oid": 16688624,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688625",
+      "title": [
+        "Page 444"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688625"
+      ],
+      "oid": 16688625,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688626",
+      "title": [
+        "Page 445"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688626"
+      ],
+      "oid": 16688626,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688627",
+      "title": [
+        "Page 446"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688627"
+      ],
+      "oid": 16688627,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688628",
+      "title": [
+        "Page 447"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688628"
+      ],
+      "oid": 16688628,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688629",
+      "title": [
+        "Page 448"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688629"
+      ],
+      "oid": 16688629,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688630",
+      "title": [
+        "Page 449"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688630"
+      ],
+      "oid": 16688630,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688631",
+      "title": [
+        "Page 450"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688631"
+      ],
+      "oid": 16688631,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688632",
+      "title": [
+        "Page 451"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688632"
+      ],
+      "oid": 16688632,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688633",
+      "title": [
+        "Page 452"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688633"
+      ],
+      "oid": 16688633,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688634",
+      "title": [
+        "Page 453"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688634"
+      ],
+      "oid": 16688634,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688635",
+      "title": [
+        "Page 454"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688635"
+      ],
+      "oid": 16688635,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688636",
+      "title": [
+        "Page 455"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688636"
+      ],
+      "oid": 16688636,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688637",
+      "title": [
+        "Page 456"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688637"
+      ],
+      "oid": 16688637,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688638",
+      "title": [
+        "Page 457"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688638"
+      ],
+      "oid": 16688638,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688639",
+      "title": [
+        "Page 458"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688639"
+      ],
+      "oid": 16688639,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688640",
+      "title": [
+        "Page 459"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688640"
+      ],
+      "oid": 16688640,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688641",
+      "title": [
+        "Page 460"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688641"
+      ],
+      "oid": 16688641,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688642",
+      "title": [
+        "Page 461"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688642"
+      ],
+      "oid": 16688642,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688643",
+      "title": [
+        "Page 462"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688643"
+      ],
+      "oid": 16688643,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688644",
+      "title": [
+        "Page 463"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688644"
+      ],
+      "oid": 16688644,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688645",
+      "title": [
+        "Page 464"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688645"
+      ],
+      "oid": 16688645,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688646",
+      "title": [
+        "Page 465"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688646"
+      ],
+      "oid": 16688646,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688647",
+      "title": [
+        "Page 466"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688647"
+      ],
+      "oid": 16688647,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688648",
+      "title": [
+        "Page 467"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688648"
+      ],
+      "oid": 16688648,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688649",
+      "title": [
+        "Page 468"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688649"
+      ],
+      "oid": 16688649,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688650",
+      "title": [
+        "Page 469"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688650"
+      ],
+      "oid": 16688650,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688651",
+      "title": [
+        "Page 470"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688651"
+      ],
+      "oid": 16688651,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688652",
+      "title": [
+        "Page 471"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688652"
+      ],
+      "oid": 16688652,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688653",
+      "title": [
+        "Page 472"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688653"
+      ],
+      "oid": 16688653,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688654",
+      "title": [
+        "Page 473"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688654"
+      ],
+      "oid": 16688654,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688655",
+      "title": [
+        "Page 474"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688655"
+      ],
+      "oid": 16688655,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688656",
+      "title": [
+        "Page 475"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688656"
+      ],
+      "oid": 16688656,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688657",
+      "title": [
+        "Page 476"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688657"
+      ],
+      "oid": 16688657,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688658",
+      "title": [
+        "Page 477"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688658"
+      ],
+      "oid": 16688658,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688659",
+      "title": [
+        "Page 478"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688659"
+      ],
+      "oid": 16688659,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688660",
+      "title": [
+        "Page 479"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688660"
+      ],
+      "oid": 16688660,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688661",
+      "title": [
+        "Page 480"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688661"
+      ],
+      "oid": 16688661,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688662",
+      "title": [
+        "Page 481"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688662"
+      ],
+      "oid": 16688662,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688663",
+      "title": [
+        "Page 482"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688663"
+      ],
+      "oid": 16688663,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688664",
+      "title": [
+        "Page 483"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688664"
+      ],
+      "oid": 16688664,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688665",
+      "title": [
+        "Page 484"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688665"
+      ],
+      "oid": 16688665,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688666",
+      "title": [
+        "Page 485"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688666"
+      ],
+      "oid": 16688666,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688667",
+      "title": [
+        "Page 486"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688667"
+      ],
+      "oid": 16688667,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688668",
+      "title": [
+        "Page 487"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688668"
+      ],
+      "oid": 16688668,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688669",
+      "title": [
+        "Page 488"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688669"
+      ],
+      "oid": 16688669,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688670",
+      "title": [
+        "Page 489"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688670"
+      ],
+      "oid": 16688670,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688671",
+      "title": [
+        "Page 490"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688671"
+      ],
+      "oid": 16688671,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688672",
+      "title": [
+        "Page 491"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688672"
+      ],
+      "oid": 16688672,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688673",
+      "title": [
+        "Page 492"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688673"
+      ],
+      "oid": 16688673,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688674",
+      "title": [
+        "Page 493"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688674"
+      ],
+      "oid": 16688674,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688675",
+      "title": [
+        "Page 494"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688675"
+      ],
+      "oid": 16688675,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688676",
+      "title": [
+        "Page 495"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688676"
+      ],
+      "oid": 16688676,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688677",
+      "title": [
+        "Page 496"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688677"
+      ],
+      "oid": 16688677,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688678",
+      "title": [
+        "Page 497"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688678"
+      ],
+      "oid": 16688678,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688679",
+      "title": [
+        "Page 498"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688679"
+      ],
+      "oid": 16688679,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688680",
+      "title": [
+        "Page 499"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688680"
+      ],
+      "oid": 16688680,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688681",
+      "title": [
+        "Page 500"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688681"
+      ],
+      "oid": 16688681,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688682",
+      "title": [
+        "Page 501"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688682"
+      ],
+      "oid": 16688682,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688683",
+      "title": [
+        "Page 502"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688683"
+      ],
+      "oid": 16688683,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688684",
+      "title": [
+        "Page 503"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688684"
+      ],
+      "oid": 16688684,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688685",
+      "title": [
+        "Page 504"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688685"
+      ],
+      "oid": 16688685,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688686",
+      "title": [
+        "Page 505"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688686"
+      ],
+      "oid": 16688686,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688687",
+      "title": [
+        "Page 506"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688687"
+      ],
+      "oid": 16688687,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688688",
+      "title": [
+        "Page 507"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688688"
+      ],
+      "oid": 16688688,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688689",
+      "title": [
+        "Page 508"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688689"
+      ],
+      "oid": 16688689,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688690",
+      "title": [
+        "Page 509"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688690"
+      ],
+      "oid": 16688690,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688691",
+      "title": [
+        "Page 510"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688691"
+      ],
+      "oid": 16688691,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688692",
+      "title": [
+        "Page 511"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688692"
+      ],
+      "oid": 16688692,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688693",
+      "title": [
+        "Page 512"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688693"
+      ],
+      "oid": 16688693,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688694",
+      "title": [
+        "Page 513"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688694"
+      ],
+      "oid": 16688694,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688695",
+      "title": [
+        "Page 514"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688695"
+      ],
+      "oid": 16688695,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688696",
+      "title": [
+        "Page 515"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688696"
+      ],
+      "oid": 16688696,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688697",
+      "title": [
+        "Page 516"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688697"
+      ],
+      "oid": 16688697,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688698",
+      "title": [
+        "Page 517"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688698"
+      ],
+      "oid": 16688698,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688699",
+      "title": [
+        "Page 518"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688699"
+      ],
+      "oid": 16688699,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688700",
+      "title": [
+        "Page 519"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688700"
+      ],
+      "oid": 16688700,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688701",
+      "title": [
+        "Page 520"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688701"
+      ],
+      "oid": 16688701,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688702",
+      "title": [
+        "Page 521"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688702"
+      ],
+      "oid": 16688702,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688703",
+      "title": [
+        "Page 522"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688703"
+      ],
+      "oid": 16688703,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688704",
+      "title": [
+        "Page 523"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688704"
+      ],
+      "oid": 16688704,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688705",
+      "title": [
+        "Page 524"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688705"
+      ],
+      "oid": 16688705,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688706",
+      "title": [
+        "Page 525"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688706"
+      ],
+      "oid": 16688706,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688707",
+      "title": [
+        "Page 526"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688707"
+      ],
+      "oid": 16688707,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688708",
+      "title": [
+        "Page 527"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688708"
+      ],
+      "oid": 16688708,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688709",
+      "title": [
+        "Page 528"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688709"
+      ],
+      "oid": 16688709,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688710",
+      "title": [
+        "Page 529"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688710"
+      ],
+      "oid": 16688710,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688711",
+      "title": [
+        "Page 530"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688711"
+      ],
+      "oid": 16688711,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688712",
+      "title": [
+        "Page 531"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688712"
+      ],
+      "oid": 16688712,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688713",
+      "title": [
+        "Page 532"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688713"
+      ],
+      "oid": 16688713,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688714",
+      "title": [
+        "Page 533"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688714"
+      ],
+      "oid": 16688714,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688715",
+      "title": [
+        "Page 534"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688715"
+      ],
+      "oid": 16688715,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688716",
+      "title": [
+        "Page 535"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688716"
+      ],
+      "oid": 16688716,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688717",
+      "title": [
+        "Page 536"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688717"
+      ],
+      "oid": 16688717,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688718",
+      "title": [
+        "Page 537"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688718"
+      ],
+      "oid": 16688718,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688719",
+      "title": [
+        "Page 538"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688719"
+      ],
+      "oid": 16688719,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688720",
+      "title": [
+        "Page 539"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688720"
+      ],
+      "oid": 16688720,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688721",
+      "title": [
+        "Page 540"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688721"
+      ],
+      "oid": 16688721,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688722",
+      "title": [
+        "Page 541"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688722"
+      ],
+      "oid": 16688722,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688723",
+      "title": [
+        "Page 542"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688723"
+      ],
+      "oid": 16688723,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688724",
+      "title": [
+        "Page 543"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688724"
+      ],
+      "oid": 16688724,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688725",
+      "title": [
+        "Page 544"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688725"
+      ],
+      "oid": 16688725,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688726",
+      "title": [
+        "Page 545"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688726"
+      ],
+      "oid": 16688726,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688727",
+      "title": [
+        "Page 546"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688727"
+      ],
+      "oid": 16688727,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688728",
+      "title": [
+        "Page 547"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688728"
+      ],
+      "oid": 16688728,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688729",
+      "title": [
+        "Page 548"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688729"
+      ],
+      "oid": 16688729,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688730",
+      "title": [
+        "Page 549"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688730"
+      ],
+      "oid": 16688730,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688731",
+      "title": [
+        "Page 550"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688731"
+      ],
+      "oid": 16688731,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688732",
+      "title": [
+        "Page 551"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688732"
+      ],
+      "oid": 16688732,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688733",
+      "title": [
+        "Page 552"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688733"
+      ],
+      "oid": 16688733,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688734",
+      "title": [
+        "Page 553"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688734"
+      ],
+      "oid": 16688734,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688735",
+      "title": [
+        "Page 554"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688735"
+      ],
+      "oid": 16688735,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688736",
+      "title": [
+        "Page 555"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688736"
+      ],
+      "oid": 16688736,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688737",
+      "title": [
+        "Page 556"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688737"
+      ],
+      "oid": 16688737,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688738",
+      "title": [
+        "Page 557"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688738"
+      ],
+      "oid": 16688738,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688739",
+      "title": [
+        "Page 558"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688739"
+      ],
+      "oid": 16688739,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688740",
+      "title": [
+        "Page 559"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688740"
+      ],
+      "oid": 16688740,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688741",
+      "title": [
+        "Page 560"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688741"
+      ],
+      "oid": 16688741,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688742",
+      "title": [
+        "Page 561"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688742"
+      ],
+      "oid": 16688742,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688743",
+      "title": [
+        "Page 562"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688743"
+      ],
+      "oid": 16688743,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688744",
+      "title": [
+        "Page 563"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688744"
+      ],
+      "oid": 16688744,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688745",
+      "title": [
+        "Page 564"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688745"
+      ],
+      "oid": 16688745,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688746",
+      "title": [
+        "Page 565"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688746"
+      ],
+      "oid": 16688746,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688747",
+      "title": [
+        "Page 566"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688747"
+      ],
+      "oid": 16688747,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688748",
+      "title": [
+        "Page 567"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688748"
+      ],
+      "oid": 16688748,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688749",
+      "title": [
+        "Page 568"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688749"
+      ],
+      "oid": 16688749,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688750",
+      "title": [
+        "Page 569"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688750"
+      ],
+      "oid": 16688750,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688751",
+      "title": [
+        "Page 570"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688751"
+      ],
+      "oid": 16688751,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688752",
+      "title": [
+        "Page 571"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688752"
+      ],
+      "oid": 16688752,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688753",
+      "title": [
+        "Page 572"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688753"
+      ],
+      "oid": 16688753,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688754",
+      "title": [
+        "Page 573"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688754"
+      ],
+      "oid": 16688754,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688755",
+      "title": [
+        "Page 574"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688755"
+      ],
+      "oid": 16688755,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688756",
+      "title": [
+        "Page 575"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688756"
+      ],
+      "oid": 16688756,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688757",
+      "title": [
+        "Page 576"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688757"
+      ],
+      "oid": 16688757,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688758",
+      "title": [
+        "Page 577"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688758"
+      ],
+      "oid": 16688758,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688759",
+      "title": [
+        "Page 578"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688759"
+      ],
+      "oid": 16688759,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688760",
+      "title": [
+        "Page 579"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688760"
+      ],
+      "oid": 16688760,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688761",
+      "title": [
+        "Page 580"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688761"
+      ],
+      "oid": 16688761,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688762",
+      "title": [
+        "Page 581"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688762"
+      ],
+      "oid": 16688762,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688763",
+      "title": [
+        "Page 582"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688763"
+      ],
+      "oid": 16688763,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688764",
+      "title": [
+        "Page 583"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688764"
+      ],
+      "oid": 16688764,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688765",
+      "title": [
+        "Page 584"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688765"
+      ],
+      "oid": 16688765,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688766",
+      "title": [
+        "Page 585"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688766"
+      ],
+      "oid": 16688766,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688767",
+      "title": [
+        "Page 586"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688767"
+      ],
+      "oid": 16688767,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688768",
+      "title": [
+        "Page 587"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688768"
+      ],
+      "oid": 16688768,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688769",
+      "title": [
+        "Page 588"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688769"
+      ],
+      "oid": 16688769,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688770",
+      "title": [
+        "Page 589"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688770"
+      ],
+      "oid": 16688770,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688771",
+      "title": [
+        "Page 590"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688771"
+      ],
+      "oid": 16688771,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688772",
+      "title": [
+        "Page 591"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688772"
+      ],
+      "oid": 16688772,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688773",
+      "title": [
+        "Page 592"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688773"
+      ],
+      "oid": 16688773,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688774",
+      "title": [
+        "Page 593"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688774"
+      ],
+      "oid": 16688774,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688775",
+      "title": [
+        "Page 594"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688775"
+      ],
+      "oid": 16688775,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688776",
+      "title": [
+        "Page 595"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688776"
+      ],
+      "oid": 16688776,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688777",
+      "title": [
+        "Page 596"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688777"
+      ],
+      "oid": 16688777,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688778",
+      "title": [
+        "Page 597"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688778"
+      ],
+      "oid": 16688778,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688779",
+      "title": [
+        "Page 598"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688779"
+      ],
+      "oid": 16688779,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688780",
+      "title": [
+        "Page 599"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688780"
+      ],
+      "oid": 16688780,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688781",
+      "title": [
+        "Page 600"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688781"
+      ],
+      "oid": 16688781,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688782",
+      "title": [
+        "Page 601"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688782"
+      ],
+      "oid": 16688782,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688783",
+      "title": [
+        "Page 602"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688783"
+      ],
+      "oid": 16688783,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688784",
+      "title": [
+        "Page 603"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688784"
+      ],
+      "oid": 16688784,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688785",
+      "title": [
+        "Page 604"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688785"
+      ],
+      "oid": 16688785,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688786",
+      "title": [
+        "Page 605"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688786"
+      ],
+      "oid": 16688786,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688787",
+      "title": [
+        "Page 606"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688787"
+      ],
+      "oid": 16688787,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688788",
+      "title": [
+        "Page 607"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688788"
+      ],
+      "oid": 16688788,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688789",
+      "title": [
+        "Page 608"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688789"
+      ],
+      "oid": 16688789,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688790",
+      "title": [
+        "Page 609"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688790"
+      ],
+      "oid": 16688790,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688791",
+      "title": [
+        "Page 610"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688791"
+      ],
+      "oid": 16688791,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688792",
+      "title": [
+        "Page 611"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688792"
+      ],
+      "oid": 16688792,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688793",
+      "title": [
+        "Page 612"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688793"
+      ],
+      "oid": 16688793,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688794",
+      "title": [
+        "Page 613"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688794"
+      ],
+      "oid": 16688794,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688795",
+      "title": [
+        "Page 614"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688795"
+      ],
+      "oid": 16688795,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688796",
+      "title": [
+        "Page 615"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688796"
+      ],
+      "oid": 16688796,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688797",
+      "title": [
+        "Page 616"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688797"
+      ],
+      "oid": 16688797,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688798",
+      "title": [
+        "Page 617"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688798"
+      ],
+      "oid": 16688798,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688799",
+      "title": [
+        "Page 618"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688799"
+      ],
+      "oid": 16688799,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688800",
+      "title": [
+        "Page 619"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688800"
+      ],
+      "oid": 16688800,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688801",
+      "title": [
+        "Page 620"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688801"
+      ],
+      "oid": 16688801,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688802",
+      "title": [
+        "Page 621"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688802"
+      ],
+      "oid": 16688802,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688803",
+      "title": [
+        "Page 622"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688803"
+      ],
+      "oid": 16688803,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688804",
+      "title": [
+        "Page 623"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688804"
+      ],
+      "oid": 16688804,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688805",
+      "title": [
+        "Page 624"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688805"
+      ],
+      "oid": 16688805,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688806",
+      "title": [
+        "Page 625"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688806"
+      ],
+      "oid": 16688806,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688807",
+      "title": [
+        "Page 626"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688807"
+      ],
+      "oid": 16688807,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688808",
+      "title": [
+        "Page 627"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688808"
+      ],
+      "oid": 16688808,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688809",
+      "title": [
+        "Page 628"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688809"
+      ],
+      "oid": 16688809,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688810",
+      "title": [
+        "Page 629"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688810"
+      ],
+      "oid": 16688810,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688811",
+      "title": [
+        "Page 630"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688811"
+      ],
+      "oid": 16688811,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688812",
+      "title": [
+        "Page 631"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688812"
+      ],
+      "oid": 16688812,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688813",
+      "title": [
+        "Page 632"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688813"
+      ],
+      "oid": 16688813,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688814",
+      "title": [
+        "Page 633"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688814"
+      ],
+      "oid": 16688814,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688815",
+      "title": [
+        "Page 634"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688815"
+      ],
+      "oid": 16688815,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688816",
+      "title": [
+        "Page 635"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688816"
+      ],
+      "oid": 16688816,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688817",
+      "title": [
+        "Page 636"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688817"
+      ],
+      "oid": 16688817,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688818",
+      "title": [
+        "Page 637"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688818"
+      ],
+      "oid": 16688818,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688819",
+      "title": [
+        "Page 638"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688819"
+      ],
+      "oid": 16688819,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688820",
+      "title": [
+        "Page 639"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688820"
+      ],
+      "oid": 16688820,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688821",
+      "title": [
+        "Page 640"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688821"
+      ],
+      "oid": 16688821,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688822",
+      "title": [
+        "Page 641"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688822"
+      ],
+      "oid": 16688822,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688823",
+      "title": [
+        "Page 642"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688823"
+      ],
+      "oid": 16688823,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688824",
+      "title": [
+        "Page 643"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688824"
+      ],
+      "oid": 16688824,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688825",
+      "title": [
+        "Page 644"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688825"
+      ],
+      "oid": 16688825,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688826",
+      "title": [
+        "Page 645"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688826"
+      ],
+      "oid": 16688826,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688827",
+      "title": [
+        "Page 646"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688827"
+      ],
+      "oid": 16688827,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688828",
+      "title": [
+        "Page 647"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688828"
+      ],
+      "oid": 16688828,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688829",
+      "title": [
+        "Page 648"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688829"
+      ],
+      "oid": 16688829,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688830",
+      "title": [
+        "Page 649"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688830"
+      ],
+      "oid": 16688830,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688831",
+      "title": [
+        "Page 650"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688831"
+      ],
+      "oid": 16688831,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688832",
+      "title": [
+        "Page 651"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688832"
+      ],
+      "oid": 16688832,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688833",
+      "title": [
+        "Page 652"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688833"
+      ],
+      "oid": 16688833,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688834",
+      "title": [
+        "Page 653"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688834"
+      ],
+      "oid": 16688834,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688835",
+      "title": [
+        "Page 654"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688835"
+      ],
+      "oid": 16688835,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688836",
+      "title": [
+        "Page 655"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688836"
+      ],
+      "oid": 16688836,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688837",
+      "title": [
+        "Page 656"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688837"
+      ],
+      "oid": 16688837,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688838",
+      "title": [
+        "Page 657"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688838"
+      ],
+      "oid": 16688838,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688839",
+      "title": [
+        "Page 658"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688839"
+      ],
+      "oid": 16688839,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688840",
+      "title": [
+        "Page 659"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688840"
+      ],
+      "oid": 16688840,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688841",
+      "title": [
+        "Page 660"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688841"
+      ],
+      "oid": 16688841,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688842",
+      "title": [
+        "Page 661"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688842"
+      ],
+      "oid": 16688842,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688843",
+      "title": [
+        "Page 662"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688843"
+      ],
+      "oid": 16688843,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688844",
+      "title": [
+        "Page 663"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688844"
+      ],
+      "oid": 16688844,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688845",
+      "title": [
+        "Page 664"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688845"
+      ],
+      "oid": 16688845,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688846",
+      "title": [
+        "Page 665"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688846"
+      ],
+      "oid": 16688846,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688847",
+      "title": [
+        "Page 666"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688847"
+      ],
+      "oid": 16688847,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688848",
+      "title": [
+        "Page 667"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688848"
+      ],
+      "oid": 16688848,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688849",
+      "title": [
+        "Page 668"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688849"
+      ],
+      "oid": 16688849,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688850",
+      "title": [
+        "Page 669"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688850"
+      ],
+      "oid": 16688850,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688851",
+      "title": [
+        "Page 670"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688851"
+      ],
+      "oid": 16688851,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688852",
+      "title": [
+        "Page 671"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688852"
+      ],
+      "oid": 16688852,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688853",
+      "title": [
+        "Page 672"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688853"
+      ],
+      "oid": 16688853,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688854",
+      "title": [
+        "Page 673"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688854"
+      ],
+      "oid": 16688854,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688855",
+      "title": [
+        "Page 674"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688855"
+      ],
+      "oid": 16688855,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688856",
+      "title": [
+        "Page 675"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688856"
+      ],
+      "oid": 16688856,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688857",
+      "title": [
+        "Page 676"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688857"
+      ],
+      "oid": 16688857,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688858",
+      "title": [
+        "Page 677"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688858"
+      ],
+      "oid": 16688858,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688859",
+      "title": [
+        "Page 678"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688859"
+      ],
+      "oid": 16688859,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688860",
+      "title": [
+        "Page 679"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688860"
+      ],
+      "oid": 16688860,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688861",
+      "title": [
+        "Page 680"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688861"
+      ],
+      "oid": 16688861,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688862",
+      "title": [
+        "Page 681"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688862"
+      ],
+      "oid": 16688862,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688863",
+      "title": [
+        "Page 682"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688863"
+      ],
+      "oid": 16688863,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688864",
+      "title": [
+        "Page 683"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688864"
+      ],
+      "oid": 16688864,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688865",
+      "title": [
+        "Page 684"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688865"
+      ],
+      "oid": 16688865,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688866",
+      "title": [
+        "Page 685"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688866"
+      ],
+      "oid": 16688866,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688867",
+      "title": [
+        "Page 686"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688867"
+      ],
+      "oid": 16688867,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688868",
+      "title": [
+        "Page 687"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688868"
+      ],
+      "oid": 16688868,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688869",
+      "title": [
+        "Page 688"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688869"
+      ],
+      "oid": 16688869,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688870",
+      "title": [
+        "Page 689"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688870"
+      ],
+      "oid": 16688870,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688871",
+      "title": [
+        "Page 690"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688871"
+      ],
+      "oid": 16688871,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688872",
+      "title": [
+        "Page 691"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688872"
+      ],
+      "oid": 16688872,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688873",
+      "title": [
+        "Page 692"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688873"
+      ],
+      "oid": 16688873,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688874",
+      "title": [
+        "Page 693"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688874"
+      ],
+      "oid": 16688874,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688875",
+      "title": [
+        "Page 694"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688875"
+      ],
+      "oid": 16688875,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688876",
+      "title": [
+        "Page 695"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688876"
+      ],
+      "oid": 16688876,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688877",
+      "title": [
+        "Page 696"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688877"
+      ],
+      "oid": 16688877,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688878",
+      "title": [
+        "Page 697"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688878"
+      ],
+      "oid": 16688878,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688879",
+      "title": [
+        "Page 698"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688879"
+      ],
+      "oid": 16688879,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688880",
+      "title": [
+        "Page 699"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688880"
+      ],
+      "oid": 16688880,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688881",
+      "title": [
+        "Page 700"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688881"
+      ],
+      "oid": 16688881,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688882",
+      "title": [
+        "Page 701"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688882"
+      ],
+      "oid": 16688882,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688883",
+      "title": [
+        "Page 702"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688883"
+      ],
+      "oid": 16688883,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688884",
+      "title": [
+        "Page 703"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688884"
+      ],
+      "oid": 16688884,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688885",
+      "title": [
+        "Page 704"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688885"
+      ],
+      "oid": 16688885,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688886",
+      "title": [
+        "Page 705"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688886"
+      ],
+      "oid": 16688886,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688887",
+      "title": [
+        "Page 706"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688887"
+      ],
+      "oid": 16688887,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688888",
+      "title": [
+        "Page 707"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688888"
+      ],
+      "oid": 16688888,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688889",
+      "title": [
+        "Page 708"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688889"
+      ],
+      "oid": 16688889,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688890",
+      "title": [
+        "Page 709"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688890"
+      ],
+      "oid": 16688890,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688891",
+      "title": [
+        "Page 710"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688891"
+      ],
+      "oid": 16688891,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688892",
+      "title": [
+        "Page 711"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688892"
+      ],
+      "oid": 16688892,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688893",
+      "title": [
+        "Page 712"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688893"
+      ],
+      "oid": 16688893,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688894",
+      "title": [
+        "Page 713"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688894"
+      ],
+      "oid": 16688894,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688895",
+      "title": [
+        "Page 714"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688895"
+      ],
+      "oid": 16688895,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688896",
+      "title": [
+        "Page 715"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688896"
+      ],
+      "oid": 16688896,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688897",
+      "title": [
+        "Page 716"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688897"
+      ],
+      "oid": 16688897,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688898",
+      "title": [
+        "Page 717"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688898"
+      ],
+      "oid": 16688898,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688899",
+      "title": [
+        "Page 718"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688899"
+      ],
+      "oid": 16688899,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688900",
+      "title": [
+        "Page 719"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688900"
+      ],
+      "oid": 16688900,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688901",
+      "title": [
+        "Page 720"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688901"
+      ],
+      "oid": 16688901,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688902",
+      "title": [
+        "Page 721"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688902"
+      ],
+      "oid": 16688902,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688903",
+      "title": [
+        "Page 722"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688903"
+      ],
+      "oid": 16688903,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688904",
+      "title": [
+        "Page 723"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688904"
+      ],
+      "oid": 16688904,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688905",
+      "title": [
+        "Page 724"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688905"
+      ],
+      "oid": 16688905,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688906",
+      "title": [
+        "Page 725"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688906"
+      ],
+      "oid": 16688906,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688907",
+      "title": [
+        "Page 726"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688907"
+      ],
+      "oid": 16688907,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688908",
+      "title": [
+        "Page 727"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688908"
+      ],
+      "oid": 16688908,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688909",
+      "title": [
+        "Page 728"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688909"
+      ],
+      "oid": 16688909,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688910",
+      "title": [
+        "Page 729"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688910"
+      ],
+      "oid": 16688910,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688911",
+      "title": [
+        "Page 730"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688911"
+      ],
+      "oid": 16688911,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688912",
+      "title": [
+        "Page 731"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688912"
+      ],
+      "oid": 16688912,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688913",
+      "title": [
+        "Page 732"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688913"
+      ],
+      "oid": 16688913,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688914",
+      "title": [
+        "Page 733"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688914"
+      ],
+      "oid": 16688914,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688915",
+      "title": [
+        "Page 734"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688915"
+      ],
+      "oid": 16688915,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688916",
+      "title": [
+        "Page 735"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688916"
+      ],
+      "oid": 16688916,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688917",
+      "title": [
+        "Page 736"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688917"
+      ],
+      "oid": 16688917,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688918",
+      "title": [
+        "Page 737"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688918"
+      ],
+      "oid": 16688918,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688919",
+      "title": [
+        "Page 738"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688919"
+      ],
+      "oid": 16688919,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688920",
+      "title": [
+        "Page 739"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688920"
+      ],
+      "oid": 16688920,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688921",
+      "title": [
+        "Page 740"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688921"
+      ],
+      "oid": 16688921,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688922",
+      "title": [
+        "Page 741"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688922"
+      ],
+      "oid": 16688922,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688923",
+      "title": [
+        "Page 742"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688923"
+      ],
+      "oid": 16688923,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688924",
+      "title": [
+        "Page 743"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688924"
+      ],
+      "oid": 16688924,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688925",
+      "title": [
+        "Page 744"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688925"
+      ],
+      "oid": 16688925,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688926",
+      "title": [
+        "Page 745"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688926"
+      ],
+      "oid": 16688926,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688927",
+      "title": [
+        "Page 746"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688927"
+      ],
+      "oid": 16688927,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688928",
+      "title": [
+        "Page 747"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688928"
+      ],
+      "oid": 16688928,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688929",
+      "title": [
+        "Page 748"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688929"
+      ],
+      "oid": 16688929,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688930",
+      "title": [
+        "Page 749"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688930"
+      ],
+      "oid": 16688930,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688931",
+      "title": [
+        "Page 750"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688931"
+      ],
+      "oid": 16688931,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688932",
+      "title": [
+        "Page 751"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688932"
+      ],
+      "oid": 16688932,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688933",
+      "title": [
+        "Page 752"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688933"
+      ],
+      "oid": 16688933,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688934",
+      "title": [
+        "Page 753"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688934"
+      ],
+      "oid": 16688934,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688935",
+      "title": [
+        "Page 754"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688935"
+      ],
+      "oid": 16688935,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688936",
+      "title": [
+        "Page 755"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688936"
+      ],
+      "oid": 16688936,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688937",
+      "title": [
+        "Page 756"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688937"
+      ],
+      "oid": 16688937,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688938",
+      "title": [
+        "Page 757"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688938"
+      ],
+      "oid": 16688938,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688939",
+      "title": [
+        "Page 758"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688939"
+      ],
+      "oid": 16688939,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688940",
+      "title": [
+        "Page 759"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688940"
+      ],
+      "oid": 16688940,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688941",
+      "title": [
+        "Page 760"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688941"
+      ],
+      "oid": 16688941,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688942",
+      "title": [
+        "Page 761"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688942"
+      ],
+      "oid": 16688942,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688943",
+      "title": [
+        "Page 762"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688943"
+      ],
+      "oid": 16688943,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688944",
+      "title": [
+        "Page 763"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688944"
+      ],
+      "oid": 16688944,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688945",
+      "title": [
+        "Page 764"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688945"
+      ],
+      "oid": 16688945,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688946",
+      "title": [
+        "Page 765"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688946"
+      ],
+      "oid": 16688946,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688947",
+      "title": [
+        "Page 766"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688947"
+      ],
+      "oid": 16688947,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688948",
+      "title": [
+        "Page 767"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688948"
+      ],
+      "oid": 16688948,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688949",
+      "title": [
+        "Page 768"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688949"
+      ],
+      "oid": 16688949,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688950",
+      "title": [
+        "Page 769"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688950"
+      ],
+      "oid": 16688950,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688951",
+      "title": [
+        "Page 770"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688951"
+      ],
+      "oid": 16688951,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688952",
+      "title": [
+        "Page 771"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688952"
+      ],
+      "oid": 16688952,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688953",
+      "title": [
+        "Page 772"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688953"
+      ],
+      "oid": 16688953,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688954",
+      "title": [
+        "Page 773"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688954"
+      ],
+      "oid": 16688954,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688955",
+      "title": [
+        "Page 774"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688955"
+      ],
+      "oid": 16688955,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688956",
+      "title": [
+        "Page 775"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688956"
+      ],
+      "oid": 16688956,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688957",
+      "title": [
+        "Page 776"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688957"
+      ],
+      "oid": 16688957,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688958",
+      "title": [
+        "Page 777"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688958"
+      ],
+      "oid": 16688958,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688959",
+      "title": [
+        "Page 778"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688959"
+      ],
+      "oid": 16688959,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688960",
+      "title": [
+        "Page 779"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688960"
+      ],
+      "oid": 16688960,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688961",
+      "title": [
+        "Page 780"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688961"
+      ],
+      "oid": 16688961,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688962",
+      "title": [
+        "Page 781"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688962"
+      ],
+      "oid": 16688962,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688963",
+      "title": [
+        "Page 782"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688963"
+      ],
+      "oid": 16688963,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688964",
+      "title": [
+        "Page 783"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688964"
+      ],
+      "oid": 16688964,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688965",
+      "title": [
+        "Page 784"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688965"
+      ],
+      "oid": 16688965,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688966",
+      "title": [
+        "Page 785"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688966"
+      ],
+      "oid": 16688966,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688967",
+      "title": [
+        "Page 786"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688967"
+      ],
+      "oid": 16688967,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688968",
+      "title": [
+        "Page 787"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688968"
+      ],
+      "oid": 16688968,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688969",
+      "title": [
+        "Page 788"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688969"
+      ],
+      "oid": 16688969,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688970",
+      "title": [
+        "Page 789"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688970"
+      ],
+      "oid": 16688970,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688971",
+      "title": [
+        "Page 790"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688971"
+      ],
+      "oid": 16688971,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688972",
+      "title": [
+        "Page 791"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688972"
+      ],
+      "oid": 16688972,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688973",
+      "title": [
+        "Page 792"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688973"
+      ],
+      "oid": 16688973,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688974",
+      "title": [
+        "Page 793"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688974"
+      ],
+      "oid": 16688974,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688975",
+      "title": [
+        "Page 794"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688975"
+      ],
+      "oid": 16688975,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688976",
+      "title": [
+        "Page 795"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688976"
+      ],
+      "oid": 16688976,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688977",
+      "title": [
+        "Page 796"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688977"
+      ],
+      "oid": 16688977,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688978",
+      "title": [
+        "Page 797"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688978"
+      ],
+      "oid": 16688978,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688979",
+      "title": [
+        "Page 798"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688979"
+      ],
+      "oid": 16688979,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688980",
+      "title": [
+        "Page 799"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688980"
+      ],
+      "oid": 16688980,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688981",
+      "title": [
+        "Page 800"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688981"
+      ],
+      "oid": 16688981,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688982",
+      "title": [
+        "Page 801"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688982"
+      ],
+      "oid": 16688982,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688983",
+      "title": [
+        "Page 802"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688983"
+      ],
+      "oid": 16688983,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688984",
+      "title": [
+        "Page 803"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688984"
+      ],
+      "oid": 16688984,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688985",
+      "title": [
+        "Page 804"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688985"
+      ],
+      "oid": 16688985,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688986",
+      "title": [
+        "Page 805"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688986"
+      ],
+      "oid": 16688986,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688987",
+      "title": [
+        "Page 806"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688987"
+      ],
+      "oid": 16688987,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688988",
+      "title": [
+        "Page 807"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688988"
+      ],
+      "oid": 16688988,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688989",
+      "title": [
+        "Page 808"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688989"
+      ],
+      "oid": 16688989,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688990",
+      "title": [
+        "Page 809"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688990"
+      ],
+      "oid": 16688990,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688991",
+      "title": [
+        "Page 810"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688991"
+      ],
+      "oid": 16688991,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688992",
+      "title": [
+        "Page 811"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688992"
+      ],
+      "oid": 16688992,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688993",
+      "title": [
+        "Page 812"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688993"
+      ],
+      "oid": 16688993,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688994",
+      "title": [
+        "Page 813"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688994"
+      ],
+      "oid": 16688994,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688995",
+      "title": [
+        "Page 814"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688995"
+      ],
+      "oid": 16688995,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688996",
+      "title": [
+        "Page 815"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688996"
+      ],
+      "oid": 16688996,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688997",
+      "title": [
+        "Page 816"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688997"
+      ],
+      "oid": 16688997,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688998",
+      "title": [
+        "Page 817"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688998"
+      ],
+      "oid": 16688998,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16688999",
+      "title": [
+        "Page 818"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16688999"
+      ],
+      "oid": 16688999,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689000",
+      "title": [
+        "Page 819"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689000"
+      ],
+      "oid": 16689000,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689001",
+      "title": [
+        "Page 820"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689001"
+      ],
+      "oid": 16689001,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689002",
+      "title": [
+        "Page 821"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689002"
+      ],
+      "oid": 16689002,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689003",
+      "title": [
+        "Page 822"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689003"
+      ],
+      "oid": 16689003,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689004",
+      "title": [
+        "Page 823"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689004"
+      ],
+      "oid": 16689004,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689005",
+      "title": [
+        "Page 824"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689005"
+      ],
+      "oid": 16689005,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689006",
+      "title": [
+        "Page 825"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689006"
+      ],
+      "oid": 16689006,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689007",
+      "title": [
+        "Page 826"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689007"
+      ],
+      "oid": 16689007,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689008",
+      "title": [
+        "Page 827"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689008"
+      ],
+      "oid": 16689008,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689009",
+      "title": [
+        "Page 828"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689009"
+      ],
+      "oid": 16689009,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689010",
+      "title": [
+        "Page 829"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689010"
+      ],
+      "oid": 16689010,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689011",
+      "title": [
+        "Page 830"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689011"
+      ],
+      "oid": 16689011,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689012",
+      "title": [
+        "Page 831"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689012"
+      ],
+      "oid": 16689012,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689013",
+      "title": [
+        "Page 832"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689013"
+      ],
+      "oid": 16689013,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689014",
+      "title": [
+        "Page 833"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689014"
+      ],
+      "oid": 16689014,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689015",
+      "title": [
+        "Page 834"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689015"
+      ],
+      "oid": 16689015,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689016",
+      "title": [
+        "Page 835"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689016"
+      ],
+      "oid": 16689016,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689017",
+      "title": [
+        "Page 836"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689017"
+      ],
+      "oid": 16689017,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689018",
+      "title": [
+        "Page 837"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689018"
+      ],
+      "oid": 16689018,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689019",
+      "title": [
+        "Page 838"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689019"
+      ],
+      "oid": 16689019,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689020",
+      "title": [
+        "Page 839"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689020"
+      ],
+      "oid": 16689020,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689021",
+      "title": [
+        "Page 840"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689021"
+      ],
+      "oid": 16689021,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689022",
+      "title": [
+        "Page 841"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689022"
+      ],
+      "oid": 16689022,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689023",
+      "title": [
+        "Page 842"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689023"
+      ],
+      "oid": 16689023,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689024",
+      "title": [
+        "Page 843"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689024"
+      ],
+      "oid": 16689024,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689025",
+      "title": [
+        "Page 844"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689025"
+      ],
+      "oid": 16689025,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689026",
+      "title": [
+        "Page 845"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689026"
+      ],
+      "oid": 16689026,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689027",
+      "title": [
+        "Page 846"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689027"
+      ],
+      "oid": 16689027,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689028",
+      "title": [
+        "Page 847"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689028"
+      ],
+      "oid": 16689028,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689029",
+      "title": [
+        "Page 848"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689029"
+      ],
+      "oid": 16689029,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689030",
+      "title": [
+        "Page 849"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689030"
+      ],
+      "oid": 16689030,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689031",
+      "title": [
+        "Page 850"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689031"
+      ],
+      "oid": 16689031,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689032",
+      "title": [
+        "Page 851"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689032"
+      ],
+      "oid": 16689032,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689033",
+      "title": [
+        "Page 852"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689033"
+      ],
+      "oid": 16689033,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689034",
+      "title": [
+        "Page 853"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689034"
+      ],
+      "oid": 16689034,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689035",
+      "title": [
+        "Page 854"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689035"
+      ],
+      "oid": 16689035,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689036",
+      "title": [
+        "Page 855"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689036"
+      ],
+      "oid": 16689036,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689037",
+      "title": [
+        "Page 856"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689037"
+      ],
+      "oid": 16689037,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689038",
+      "title": [
+        "Page 857"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689038"
+      ],
+      "oid": 16689038,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689039",
+      "title": [
+        "Page 858"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689039"
+      ],
+      "oid": 16689039,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689040",
+      "title": [
+        "Page 859"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689040"
+      ],
+      "oid": 16689040,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689041",
+      "title": [
+        "Page 860"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689041"
+      ],
+      "oid": 16689041,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689042",
+      "title": [
+        "Page 861"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689042"
+      ],
+      "oid": 16689042,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689043",
+      "title": [
+        "Page 862"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689043"
+      ],
+      "oid": 16689043,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689044",
+      "title": [
+        "Page 863"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689044"
+      ],
+      "oid": 16689044,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689045",
+      "title": [
+        "Page 864"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689045"
+      ],
+      "oid": 16689045,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689046",
+      "title": [
+        "Page 865"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689046"
+      ],
+      "oid": 16689046,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689047",
+      "title": [
+        "Page 866"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689047"
+      ],
+      "oid": 16689047,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689048",
+      "title": [
+        "Page 867"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689048"
+      ],
+      "oid": 16689048,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689049",
+      "title": [
+        "Page 868"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689049"
+      ],
+      "oid": 16689049,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689050",
+      "title": [
+        "Page 869"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689050"
+      ],
+      "oid": 16689050,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689051",
+      "title": [
+        "Page 870"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689051"
+      ],
+      "oid": 16689051,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689052",
+      "title": [
+        "Page 871"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689052"
+      ],
+      "oid": 16689052,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689053",
+      "title": [
+        "Page 872"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689053"
+      ],
+      "oid": 16689053,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689054",
+      "title": [
+        "Page 873"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689054"
+      ],
+      "oid": 16689054,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689055",
+      "title": [
+        "Page 874"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689055"
+      ],
+      "oid": 16689055,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689056",
+      "title": [
+        "Page 875"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689056"
+      ],
+      "oid": 16689056,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689057",
+      "title": [
+        "Page 876"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689057"
+      ],
+      "oid": 16689057,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689058",
+      "title": [
+        "Page 877"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689058"
+      ],
+      "oid": 16689058,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689059",
+      "title": [
+        "Page 878"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689059"
+      ],
+      "oid": 16689059,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689060",
+      "title": [
+        "Page 879"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689060"
+      ],
+      "oid": 16689060,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689061",
+      "title": [
+        "Page 880"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689061"
+      ],
+      "oid": 16689061,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689062",
+      "title": [
+        "Page 881"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689062"
+      ],
+      "oid": 16689062,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689063",
+      "title": [
+        "Page 882"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689063"
+      ],
+      "oid": 16689063,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689064",
+      "title": [
+        "Page 883"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689064"
+      ],
+      "oid": 16689064,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689065",
+      "title": [
+        "Page 884"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689065"
+      ],
+      "oid": 16689065,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689066",
+      "title": [
+        "Page 885"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689066"
+      ],
+      "oid": 16689066,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689067",
+      "title": [
+        "Page 886"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689067"
+      ],
+      "oid": 16689067,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689068",
+      "title": [
+        "Page 887"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689068"
+      ],
+      "oid": 16689068,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689069",
+      "title": [
+        "Page 888"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689069"
+      ],
+      "oid": 16689069,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689070",
+      "title": [
+        "Page 889"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689070"
+      ],
+      "oid": 16689070,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689071",
+      "title": [
+        "Page 890"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689071"
+      ],
+      "oid": 16689071,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689072",
+      "title": [
+        "Page 891"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689072"
+      ],
+      "oid": 16689072,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689073",
+      "title": [
+        "Page 892"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689073"
+      ],
+      "oid": 16689073,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689074",
+      "title": [
+        "Page 893"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689074"
+      ],
+      "oid": 16689074,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689075",
+      "title": [
+        "Page 894"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689075"
+      ],
+      "oid": 16689075,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689076",
+      "title": [
+        "Page 895"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689076"
+      ],
+      "oid": 16689076,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689077",
+      "title": [
+        "Page 896"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689077"
+      ],
+      "oid": 16689077,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689078",
+      "title": [
+        "Page 897"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689078"
+      ],
+      "oid": 16689078,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689079",
+      "title": [
+        "Page 898"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689079"
+      ],
+      "oid": 16689079,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689080",
+      "title": [
+        "Page 899"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689080"
+      ],
+      "oid": 16689080,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689081",
+      "title": [
+        "Page 900"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689081"
+      ],
+      "oid": 16689081,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689082",
+      "title": [
+        "Page 901"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689082"
+      ],
+      "oid": 16689082,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689083",
+      "title": [
+        "Page 902"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689083"
+      ],
+      "oid": 16689083,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689084",
+      "title": [
+        "Page 903"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689084"
+      ],
+      "oid": 16689084,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689085",
+      "title": [
+        "Page 904"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689085"
+      ],
+      "oid": 16689085,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689086",
+      "title": [
+        "Page 905"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689086"
+      ],
+      "oid": 16689086,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689087",
+      "title": [
+        "Page 906"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689087"
+      ],
+      "oid": 16689087,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689088",
+      "title": [
+        "Page 907"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689088"
+      ],
+      "oid": 16689088,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689089",
+      "title": [
+        "Page 908"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689089"
+      ],
+      "oid": 16689089,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689090",
+      "title": [
+        "Page 909"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689090"
+      ],
+      "oid": 16689090,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689091",
+      "title": [
+        "Page 910"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689091"
+      ],
+      "oid": 16689091,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689092",
+      "title": [
+        "Page 911"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689092"
+      ],
+      "oid": 16689092,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689093",
+      "title": [
+        "Page 912"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689093"
+      ],
+      "oid": 16689093,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689094",
+      "title": [
+        "Page 913"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689094"
+      ],
+      "oid": 16689094,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689095",
+      "title": [
+        "Page 914"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689095"
+      ],
+      "oid": 16689095,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689096",
+      "title": [
+        "Page 915"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689096"
+      ],
+      "oid": 16689096,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689097",
+      "title": [
+        "Page 916"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689097"
+      ],
+      "oid": 16689097,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689098",
+      "title": [
+        "Page 917"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689098"
+      ],
+      "oid": 16689098,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689099",
+      "title": [
+        "Page 918"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689099"
+      ],
+      "oid": 16689099,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689100",
+      "title": [
+        "Page 919"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689100"
+      ],
+      "oid": 16689100,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689101",
+      "title": [
+        "Page 920"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689101"
+      ],
+      "oid": 16689101,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689102",
+      "title": [
+        "Page 921"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689102"
+      ],
+      "oid": 16689102,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689103",
+      "title": [
+        "Page 922"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689103"
+      ],
+      "oid": 16689103,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689104",
+      "title": [
+        "Page 923"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689104"
+      ],
+      "oid": 16689104,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689105",
+      "title": [
+        "Page 924"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689105"
+      ],
+      "oid": 16689105,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689106",
+      "title": [
+        "Page 925"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689106"
+      ],
+      "oid": 16689106,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689107",
+      "title": [
+        "Page 926"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689107"
+      ],
+      "oid": 16689107,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689108",
+      "title": [
+        "Page 927"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689108"
+      ],
+      "oid": 16689108,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689109",
+      "title": [
+        "Page 928"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689109"
+      ],
+      "oid": 16689109,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689110",
+      "title": [
+        "Page 929"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689110"
+      ],
+      "oid": 16689110,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689111",
+      "title": [
+        "Page 930"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689111"
+      ],
+      "oid": 16689111,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689112",
+      "title": [
+        "Page 931"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689112"
+      ],
+      "oid": 16689112,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689113",
+      "title": [
+        "Page 932"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689113"
+      ],
+      "oid": 16689113,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689114",
+      "title": [
+        "Page 933"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689114"
+      ],
+      "oid": 16689114,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689115",
+      "title": [
+        "Page 934"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689115"
+      ],
+      "oid": 16689115,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689116",
+      "title": [
+        "Page 935"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689116"
+      ],
+      "oid": 16689116,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689117",
+      "title": [
+        "Page 936"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689117"
+      ],
+      "oid": 16689117,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689118",
+      "title": [
+        "Page 937"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689118"
+      ],
+      "oid": 16689118,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689119",
+      "title": [
+        "Page 938"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689119"
+      ],
+      "oid": 16689119,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689120",
+      "title": [
+        "Page 939"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689120"
+      ],
+      "oid": 16689120,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689121",
+      "title": [
+        "Page 940"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689121"
+      ],
+      "oid": 16689121,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689122",
+      "title": [
+        "Page 941"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689122"
+      ],
+      "oid": 16689122,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689123",
+      "title": [
+        "Page 942"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689123"
+      ],
+      "oid": 16689123,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689124",
+      "title": [
+        "Page 943"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689124"
+      ],
+      "oid": 16689124,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689125",
+      "title": [
+        "Page 944"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689125"
+      ],
+      "oid": 16689125,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689126",
+      "title": [
+        "Page 945"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689126"
+      ],
+      "oid": 16689126,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689127",
+      "title": [
+        "Page 946"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689127"
+      ],
+      "oid": 16689127,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689128",
+      "title": [
+        "Page 947"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689128"
+      ],
+      "oid": 16689128,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689129",
+      "title": [
+        "Page 948"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689129"
+      ],
+      "oid": 16689129,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689130",
+      "title": [
+        "Page 949"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689130"
+      ],
+      "oid": 16689130,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689131",
+      "title": [
+        "Page 950"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689131"
+      ],
+      "oid": 16689131,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689132",
+      "title": [
+        "Page 951"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689132"
+      ],
+      "oid": 16689132,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689133",
+      "title": [
+        "Page 952"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689133"
+      ],
+      "oid": 16689133,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689134",
+      "title": [
+        "Page 953"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689134"
+      ],
+      "oid": 16689134,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689135",
+      "title": [
+        "Page 954"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689135"
+      ],
+      "oid": 16689135,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689136",
+      "title": [
+        "Page 955"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689136"
+      ],
+      "oid": 16689136,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689137",
+      "title": [
+        "Page 956"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689137"
+      ],
+      "oid": 16689137,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689138",
+      "title": [
+        "Page 957"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689138"
+      ],
+      "oid": 16689138,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689139",
+      "title": [
+        "Page 958"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689139"
+      ],
+      "oid": 16689139,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689140",
+      "title": [
+        "Page 959"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689140"
+      ],
+      "oid": 16689140,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689141",
+      "title": [
+        "Page 960"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689141"
+      ],
+      "oid": 16689141,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689142",
+      "title": [
+        "Page 961"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689142"
+      ],
+      "oid": 16689142,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689143",
+      "title": [
+        "Page 962"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689143"
+      ],
+      "oid": 16689143,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689144",
+      "title": [
+        "Page 963"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689144"
+      ],
+      "oid": 16689144,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689145",
+      "title": [
+        "Page 964"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689145"
+      ],
+      "oid": 16689145,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689146",
+      "title": [
+        "Page 965"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689146"
+      ],
+      "oid": 16689146,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689147",
+      "title": [
+        "Page 966"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689147"
+      ],
+      "oid": 16689147,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689148",
+      "title": [
+        "Page 967"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689148"
+      ],
+      "oid": 16689148,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689149",
+      "title": [
+        "Page 968"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689149"
+      ],
+      "oid": 16689149,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689150",
+      "title": [
+        "Page 969"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689150"
+      ],
+      "oid": 16689150,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689151",
+      "title": [
+        "Page 970"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689151"
+      ],
+      "oid": 16689151,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689152",
+      "title": [
+        "Page 971"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689152"
+      ],
+      "oid": 16689152,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689153",
+      "title": [
+        "Page 972"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689153"
+      ],
+      "oid": 16689153,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689154",
+      "title": [
+        "Page 973"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689154"
+      ],
+      "oid": 16689154,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689155",
+      "title": [
+        "Page 974"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689155"
+      ],
+      "oid": 16689155,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689156",
+      "title": [
+        "Page 975"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689156"
+      ],
+      "oid": 16689156,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689157",
+      "title": [
+        "Page 976"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689157"
+      ],
+      "oid": 16689157,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689158",
+      "title": [
+        "Page 977"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689158"
+      ],
+      "oid": 16689158,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689159",
+      "title": [
+        "Page 978"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689159"
+      ],
+      "oid": 16689159,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689160",
+      "title": [
+        "Page 979"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689160"
+      ],
+      "oid": 16689160,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689161",
+      "title": [
+        "Page 980"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689161"
+      ],
+      "oid": 16689161,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689162",
+      "title": [
+        "Page 981"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689162"
+      ],
+      "oid": 16689162,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689163",
+      "title": [
+        "Page 982"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689163"
+      ],
+      "oid": 16689163,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689164",
+      "title": [
+        "Page 983"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689164"
+      ],
+      "oid": 16689164,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689165",
+      "title": [
+        "Page 984"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689165"
+      ],
+      "oid": 16689165,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689166",
+      "title": [
+        "Page 985"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689166"
+      ],
+      "oid": 16689166,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689167",
+      "title": [
+        "Page 986"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689167"
+      ],
+      "oid": 16689167,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689168",
+      "title": [
+        "Page 987"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689168"
+      ],
+      "oid": 16689168,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689169",
+      "title": [
+        "Page 988"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689169"
+      ],
+      "oid": 16689169,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689170",
+      "title": [
+        "Page 989"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689170"
+      ],
+      "oid": 16689170,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689171",
+      "title": [
+        "Page 990"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689171"
+      ],
+      "oid": 16689171,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689172",
+      "title": [
+        "Page 991"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689172"
+      ],
+      "oid": 16689172,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689173",
+      "title": [
+        "Page 992"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689173"
+      ],
+      "oid": 16689173,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689174",
+      "title": [
+        "Page 993"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689174"
+      ],
+      "oid": 16689174,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689175",
+      "title": [
+        "Page 994"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689175"
+      ],
+      "oid": 16689175,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689176",
+      "title": [
+        "Page 995"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689176"
+      ],
+      "oid": 16689176,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689177",
+      "title": [
+        "Page 996"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689177"
+      ],
+      "oid": 16689177,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689178",
+      "title": [
+        "Page 997"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689178"
+      ],
+      "oid": 16689178,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689179",
+      "title": [
+        "Page 998"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689179"
+      ],
+      "oid": 16689179,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689180",
+      "title": [
+        "Page 999"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689180"
+      ],
+      "oid": 16689180,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689181",
+      "title": [
+        "Page 1000"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689181"
+      ],
+      "oid": 16689181,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689182",
+      "title": [
+        "Page 1001"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689182"
+      ],
+      "oid": 16689182,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689183",
+      "title": [
+        "Page 1002"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689183"
+      ],
+      "oid": 16689183,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689184",
+      "title": [
+        "Page 1003"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689184"
+      ],
+      "oid": 16689184,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689185",
+      "title": [
+        "Page 1004"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689185"
+      ],
+      "oid": 16689185,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689186",
+      "title": [
+        "Page 1005"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689186"
+      ],
+      "oid": 16689186,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689187",
+      "title": [
+        "Page 1006"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689187"
+      ],
+      "oid": 16689187,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689188",
+      "title": [
+        "Page 1007"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689188"
+      ],
+      "oid": 16689188,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689189",
+      "title": [
+        "Page 1008"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689189"
+      ],
+      "oid": 16689189,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689190",
+      "title": [
+        "Page 1009"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689190"
+      ],
+      "oid": 16689190,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689191",
+      "title": [
+        "Page 1010"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689191"
+      ],
+      "oid": 16689191,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689192",
+      "title": [
+        "Page 1011"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689192"
+      ],
+      "oid": 16689192,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689193",
+      "title": [
+        "Page 1012"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689193"
+      ],
+      "oid": 16689193,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689194",
+      "title": [
+        "Page 1013"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689194"
+      ],
+      "oid": 16689194,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689195",
+      "title": [
+        "Page 1014"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689195"
+      ],
+      "oid": 16689195,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689196",
+      "title": [
+        "Page 1015"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689196"
+      ],
+      "oid": 16689196,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689197",
+      "title": [
+        "Page 1016"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689197"
+      ],
+      "oid": 16689197,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689198",
+      "title": [
+        "Page 1017"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689198"
+      ],
+      "oid": 16689198,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689199",
+      "title": [
+        "Page 1018"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689199"
+      ],
+      "oid": 16689199,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689200",
+      "title": [
+        "Page 1019"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689200"
+      ],
+      "oid": 16689200,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689201",
+      "title": [
+        "Page 1020"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689201"
+      ],
+      "oid": 16689201,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689202",
+      "title": [
+        "Page 1021"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689202"
+      ],
+      "oid": 16689202,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689203",
+      "title": [
+        "Page 1022"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689203"
+      ],
+      "oid": 16689203,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689204",
+      "title": [
+        "Page 1023"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689204"
+      ],
+      "oid": 16689204,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689205",
+      "title": [
+        "Page 1024"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689205"
+      ],
+      "oid": 16689205,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689206",
+      "title": [
+        "Page 1025"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689206"
+      ],
+      "oid": 16689206,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689207",
+      "title": [
+        "Page 1026"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689207"
+      ],
+      "oid": 16689207,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689208",
+      "title": [
+        "Page 1027"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689208"
+      ],
+      "oid": 16689208,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689209",
+      "title": [
+        "Page 1028"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689209"
+      ],
+      "oid": 16689209,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689210",
+      "title": [
+        "Page 1029"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689210"
+      ],
+      "oid": 16689210,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689211",
+      "title": [
+        "Page 1030"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689211"
+      ],
+      "oid": 16689211,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689212",
+      "title": [
+        "Page 1031"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689212"
+      ],
+      "oid": 16689212,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689213",
+      "title": [
+        "Page 1032"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689213"
+      ],
+      "oid": 16689213,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689214",
+      "title": [
+        "Page 1033"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689214"
+      ],
+      "oid": 16689214,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689215",
+      "title": [
+        "Page 1034"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689215"
+      ],
+      "oid": 16689215,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689216",
+      "title": [
+        "Page 1035"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689216"
+      ],
+      "oid": 16689216,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689217",
+      "title": [
+        "Page 1036"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689217"
+      ],
+      "oid": 16689217,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689218",
+      "title": [
+        "Page 1037"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689218"
+      ],
+      "oid": 16689218,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689219",
+      "title": [
+        "Page 1038"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689219"
+      ],
+      "oid": 16689219,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689220",
+      "title": [
+        "Page 1039"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689220"
+      ],
+      "oid": 16689220,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689221",
+      "title": [
+        "Page 1040"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689221"
+      ],
+      "oid": 16689221,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689222",
+      "title": [
+        "Page 1041"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689222"
+      ],
+      "oid": 16689222,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689223",
+      "title": [
+        "Page 1042"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689223"
+      ],
+      "oid": 16689223,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689224",
+      "title": [
+        "Page 1043"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689224"
+      ],
+      "oid": 16689224,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689225",
+      "title": [
+        "Page 1044"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689225"
+      ],
+      "oid": 16689225,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689226",
+      "title": [
+        "Page 1045"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689226"
+      ],
+      "oid": 16689226,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689227",
+      "title": [
+        "Page 1046"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689227"
+      ],
+      "oid": 16689227,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689228",
+      "title": [
+        "Page 1047"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689228"
+      ],
+      "oid": 16689228,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689229",
+      "title": [
+        "Page 1048"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689229"
+      ],
+      "oid": 16689229,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689230",
+      "title": [
+        "Page 1049"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689230"
+      ],
+      "oid": 16689230,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689231",
+      "title": [
+        "Page 1050"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689231"
+      ],
+      "oid": 16689231,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689232",
+      "title": [
+        "Page 1051"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689232"
+      ],
+      "oid": 16689232,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689233",
+      "title": [
+        "Page 1052"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689233"
+      ],
+      "oid": 16689233,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689234",
+      "title": [
+        "Page 1053"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689234"
+      ],
+      "oid": 16689234,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689235",
+      "title": [
+        "Page 1054"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689235"
+      ],
+      "oid": 16689235,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689236",
+      "title": [
+        "Page 1055"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689236"
+      ],
+      "oid": 16689236,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689237",
+      "title": [
+        "Page 1056"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689237"
+      ],
+      "oid": 16689237,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689238",
+      "title": [
+        "Page 1057"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689238"
+      ],
+      "oid": 16689238,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689239",
+      "title": [
+        "Page 1058"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689239"
+      ],
+      "oid": 16689239,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689240",
+      "title": [
+        "Page 1059"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689240"
+      ],
+      "oid": 16689240,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689241",
+      "title": [
+        "Page 1060"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689241"
+      ],
+      "oid": 16689241,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689242",
+      "title": [
+        "Page 1061"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689242"
+      ],
+      "oid": 16689242,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689243",
+      "title": [
+        "Page 1062"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689243"
+      ],
+      "oid": 16689243,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689244",
+      "title": [
+        "Page 1063"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689244"
+      ],
+      "oid": 16689244,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689245",
+      "title": [
+        "Page 1064"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689245"
+      ],
+      "oid": 16689245,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689246",
+      "title": [
+        "Page 1065"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689246"
+      ],
+      "oid": 16689246,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689247",
+      "title": [
+        "Page 1066"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689247"
+      ],
+      "oid": 16689247,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689248",
+      "title": [
+        "Page 1067"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689248"
+      ],
+      "oid": 16689248,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689249",
+      "title": [
+        "Page 1068"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689249"
+      ],
+      "oid": 16689249,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689250",
+      "title": [
+        "Page 1069"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689250"
+      ],
+      "oid": 16689250,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689251",
+      "title": [
+        "Page 1070"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689251"
+      ],
+      "oid": 16689251,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689252",
+      "title": [
+        "Page 1071"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689252"
+      ],
+      "oid": 16689252,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689253",
+      "title": [
+        "Page 1072"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689253"
+      ],
+      "oid": 16689253,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689254",
+      "title": [
+        "Page 1073"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689254"
+      ],
+      "oid": 16689254,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689255",
+      "title": [
+        "Page 1074"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689255"
+      ],
+      "oid": 16689255,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689256",
+      "title": [
+        "Page 1075"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689256"
+      ],
+      "oid": 16689256,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689257",
+      "title": [
+        "Page 1076"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689257"
+      ],
+      "oid": 16689257,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689258",
+      "title": [
+        "Page 1077"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689258"
+      ],
+      "oid": 16689258,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689259",
+      "title": [
+        "Page 1078"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689259"
+      ],
+      "oid": 16689259,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689260",
+      "title": [
+        "Page 1079"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689260"
+      ],
+      "oid": 16689260,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689261",
+      "title": [
+        "Page 1080"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689261"
+      ],
+      "oid": 16689261,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689262",
+      "title": [
+        "Page 1081"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689262"
+      ],
+      "oid": 16689262,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689263",
+      "title": [
+        "Page 1082"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689263"
+      ],
+      "oid": 16689263,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689264",
+      "title": [
+        "Page 1083"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689264"
+      ],
+      "oid": 16689264,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689265",
+      "title": [
+        "Page 1084"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689265"
+      ],
+      "oid": 16689265,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689266",
+      "title": [
+        "Page 1085"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689266"
+      ],
+      "oid": 16689266,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689267",
+      "title": [
+        "Page 1086"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689267"
+      ],
+      "oid": 16689267,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689268",
+      "title": [
+        "Page 1087"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689268"
+      ],
+      "oid": 16689268,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689269",
+      "title": [
+        "Page 1088"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689269"
+      ],
+      "oid": 16689269,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689270",
+      "title": [
+        "Page 1089"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689270"
+      ],
+      "oid": 16689270,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689271",
+      "title": [
+        "Page 1090"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689271"
+      ],
+      "oid": 16689271,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689272",
+      "title": [
+        "Page 1091"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689272"
+      ],
+      "oid": 16689272,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689273",
+      "title": [
+        "Page 1092"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689273"
+      ],
+      "oid": 16689273,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689274",
+      "title": [
+        "Page 1093"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689274"
+      ],
+      "oid": 16689274,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689275",
+      "title": [
+        "Page 1094"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689275"
+      ],
+      "oid": 16689275,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689276",
+      "title": [
+        "Page 1095"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689276"
+      ],
+      "oid": 16689276,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689277",
+      "title": [
+        "Page 1096"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689277"
+      ],
+      "oid": 16689277,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689278",
+      "title": [
+        "Page 1097"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689278"
+      ],
+      "oid": 16689278,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689279",
+      "title": [
+        "Page 1098"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689279"
+      ],
+      "oid": 16689279,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689280",
+      "title": [
+        "Page 1099"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689280"
+      ],
+      "oid": 16689280,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689281",
+      "title": [
+        "Page 1100"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689281"
+      ],
+      "oid": 16689281,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689282",
+      "title": [
+        "Page 1101"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689282"
+      ],
+      "oid": 16689282,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689283",
+      "title": [
+        "Page 1102"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689283"
+      ],
+      "oid": 16689283,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689284",
+      "title": [
+        "Page 1103"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689284"
+      ],
+      "oid": 16689284,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689285",
+      "title": [
+        "Page 1104"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689285"
+      ],
+      "oid": 16689285,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689286",
+      "title": [
+        "Page 1105"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689286"
+      ],
+      "oid": 16689286,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689287",
+      "title": [
+        "Page 1106"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689287"
+      ],
+      "oid": 16689287,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689288",
+      "title": [
+        "Page 1107"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689288"
+      ],
+      "oid": 16689288,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689289",
+      "title": [
+        "Page 1108"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689289"
+      ],
+      "oid": 16689289,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689290",
+      "title": [
+        "Page 1109"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689290"
+      ],
+      "oid": 16689290,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689291",
+      "title": [
+        "Page 1110"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689291"
+      ],
+      "oid": 16689291,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689292",
+      "title": [
+        "Page 1111"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689292"
+      ],
+      "oid": 16689292,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689293",
+      "title": [
+        "Page 1112"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689293"
+      ],
+      "oid": 16689293,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689294",
+      "title": [
+        "Page 1113"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689294"
+      ],
+      "oid": 16689294,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689295",
+      "title": [
+        "Page 1114"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689295"
+      ],
+      "oid": 16689295,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689296",
+      "title": [
+        "Page 1115"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689296"
+      ],
+      "oid": 16689296,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689297",
+      "title": [
+        "Page 1116"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689297"
+      ],
+      "oid": 16689297,
+      "width": 1193,
+      "height": 1677,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689298",
+      "title": [
+        "Page 1117"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689298"
+      ],
+      "oid": 16689298,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689299",
+      "title": [
+        "Page 1118"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689299"
+      ],
+      "oid": 16689299,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689300",
+      "title": [
+        "Page 1119"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689300"
+      ],
+      "oid": 16689300,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689301",
+      "title": [
+        "Page 1120"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689301"
+      ],
+      "oid": 16689301,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689302",
+      "title": [
+        "Page 1121"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689302"
+      ],
+      "oid": 16689302,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689303",
+      "title": [
+        "Page 1122"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689303"
+      ],
+      "oid": 16689303,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689304",
+      "title": [
+        "Page 1123"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689304"
+      ],
+      "oid": 16689304,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689305",
+      "title": [
+        "Page 1124"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689305"
+      ],
+      "oid": 16689305,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689306",
+      "title": [
+        "Page 1125"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689306"
+      ],
+      "oid": 16689306,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689307",
+      "title": [
+        "Page 1126"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689307"
+      ],
+      "oid": 16689307,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689308",
+      "title": [
+        "Page 1127"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689308"
+      ],
+      "oid": 16689308,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689309",
+      "title": [
+        "Page 1128"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689309"
+      ],
+      "oid": 16689309,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689310",
+      "title": [
+        "Page 1129"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689310"
+      ],
+      "oid": 16689310,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689311",
+      "title": [
+        "Page 1130"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689311"
+      ],
+      "oid": 16689311,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689312",
+      "title": [
+        "Page 1131"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689312"
+      ],
+      "oid": 16689312,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689313",
+      "title": [
+        "Page 1132"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689313"
+      ],
+      "oid": 16689313,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689314",
+      "title": [
+        "Page 1133"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689314"
+      ],
+      "oid": 16689314,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689315",
+      "title": [
+        "Page 1134"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689315"
+      ],
+      "oid": 16689315,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689316",
+      "title": [
+        "Page 1135"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689316"
+      ],
+      "oid": 16689316,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689317",
+      "title": [
+        "Page 1136"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689317"
+      ],
+      "oid": 16689317,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689318",
+      "title": [
+        "Page 1137"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689318"
+      ],
+      "oid": 16689318,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689319",
+      "title": [
+        "Page 1138"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689319"
+      ],
+      "oid": 16689319,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689320",
+      "title": [
+        "Page 1139"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689320"
+      ],
+      "oid": 16689320,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689321",
+      "title": [
+        "Page 1140"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689321"
+      ],
+      "oid": 16689321,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689322",
+      "title": [
+        "Page 1141"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689322"
+      ],
+      "oid": 16689322,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689323",
+      "title": [
+        "Page 1142"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689323"
+      ],
+      "oid": 16689323,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689324",
+      "title": [
+        "Page 1143"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689324"
+      ],
+      "oid": 16689324,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689325",
+      "title": [
+        "Page 1144"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689325"
+      ],
+      "oid": 16689325,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689326",
+      "title": [
+        "Page 1145"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689326"
+      ],
+      "oid": 16689326,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689327",
+      "title": [
+        "Page 1146"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689327"
+      ],
+      "oid": 16689327,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689328",
+      "title": [
+        "Page 1147"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689328"
+      ],
+      "oid": 16689328,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689329",
+      "title": [
+        "Page 1148"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689329"
+      ],
+      "oid": 16689329,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689330",
+      "title": [
+        "Page 1149"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689330"
+      ],
+      "oid": 16689330,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689331",
+      "title": [
+        "Page 1150"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689331"
+      ],
+      "oid": 16689331,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689332",
+      "title": [
+        "Page 1151"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689332"
+      ],
+      "oid": 16689332,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689333",
+      "title": [
+        "Page 1152"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689333"
+      ],
+      "oid": 16689333,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689334",
+      "title": [
+        "Page 1153"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689334"
+      ],
+      "oid": 16689334,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689335",
+      "title": [
+        "Page 1154"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689335"
+      ],
+      "oid": 16689335,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689336",
+      "title": [
+        "Page 1155"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689336"
+      ],
+      "oid": 16689336,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689337",
+      "title": [
+        "Page 1156"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689337"
+      ],
+      "oid": 16689337,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689338",
+      "title": [
+        "Page 1157"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689338"
+      ],
+      "oid": 16689338,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689339",
+      "title": [
+        "Page 1158"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689339"
+      ],
+      "oid": 16689339,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689340",
+      "title": [
+        "Page 1159"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689340"
+      ],
+      "oid": 16689340,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689341",
+      "title": [
+        "Page 1160"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689341"
+      ],
+      "oid": 16689341,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689342",
+      "title": [
+        "Page 1161"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689342"
+      ],
+      "oid": 16689342,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689343",
+      "title": [
+        "Page 1162"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689343"
+      ],
+      "oid": 16689343,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689344",
+      "title": [
+        "Page 1163"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689344"
+      ],
+      "oid": 16689344,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689345",
+      "title": [
+        "Page 1164"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689345"
+      ],
+      "oid": 16689345,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689346",
+      "title": [
+        "Page 1165"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689346"
+      ],
+      "oid": 16689346,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689347",
+      "title": [
+        "Page 1166"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689347"
+      ],
+      "oid": 16689347,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689348",
+      "title": [
+        "Page 1167"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689348"
+      ],
+      "oid": 16689348,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689349",
+      "title": [
+        "Page 1168"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689349"
+      ],
+      "oid": 16689349,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689350",
+      "title": [
+        "Page 1169"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689350"
+      ],
+      "oid": 16689350,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689351",
+      "title": [
+        "Page 1170"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689351"
+      ],
+      "oid": 16689351,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689352",
+      "title": [
+        "Page 1171"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689352"
+      ],
+      "oid": 16689352,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689353",
+      "title": [
+        "Page 1172"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689353"
+      ],
+      "oid": 16689353,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689354",
+      "title": [
+        "Page 1173"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689354"
+      ],
+      "oid": 16689354,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689355",
+      "title": [
+        "Page 1174"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689355"
+      ],
+      "oid": 16689355,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689356",
+      "title": [
+        "Page 1175"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689356"
+      ],
+      "oid": 16689356,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689357",
+      "title": [
+        "Page 1176"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689357"
+      ],
+      "oid": 16689357,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689358",
+      "title": [
+        "Page 1177"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689358"
+      ],
+      "oid": 16689358,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689359",
+      "title": [
+        "Page 1178"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689359"
+      ],
+      "oid": 16689359,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689360",
+      "title": [
+        "Page 1179"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689360"
+      ],
+      "oid": 16689360,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689361",
+      "title": [
+        "Page 1180"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689361"
+      ],
+      "oid": 16689361,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689362",
+      "title": [
+        "Page 1181"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689362"
+      ],
+      "oid": 16689362,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689363",
+      "title": [
+        "Page 1182"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689363"
+      ],
+      "oid": 16689363,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689364",
+      "title": [
+        "Page 1183"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689364"
+      ],
+      "oid": 16689364,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689365",
+      "title": [
+        "Page 1184"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689365"
+      ],
+      "oid": 16689365,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689366",
+      "title": [
+        "Page 1185"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689366"
+      ],
+      "oid": 16689366,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689367",
+      "title": [
+        "Page 1186"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689367"
+      ],
+      "oid": 16689367,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689368",
+      "title": [
+        "Page 1187"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689368"
+      ],
+      "oid": 16689368,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689369",
+      "title": [
+        "Page 1188"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689369"
+      ],
+      "oid": 16689369,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689370",
+      "title": [
+        "Page 1189"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689370"
+      ],
+      "oid": 16689370,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689371",
+      "title": [
+        "Page 1190"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689371"
+      ],
+      "oid": 16689371,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689372",
+      "title": [
+        "Page 1191"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689372"
+      ],
+      "oid": 16689372,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689373",
+      "title": [
+        "Page 1192"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689373"
+      ],
+      "oid": 16689373,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689374",
+      "title": [
+        "Page 1193"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689374"
+      ],
+      "oid": 16689374,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689375",
+      "title": [
+        "Page 1194"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689375"
+      ],
+      "oid": 16689375,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689376",
+      "title": [
+        "Page 1195"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689376"
+      ],
+      "oid": 16689376,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689377",
+      "title": [
+        "Page 1196"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689377"
+      ],
+      "oid": 16689377,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689378",
+      "title": [
+        "Page 1197"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689378"
+      ],
+      "oid": 16689378,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689379",
+      "title": [
+        "Page 1198"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689379"
+      ],
+      "oid": 16689379,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689380",
+      "title": [
+        "Page 1199"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689380"
+      ],
+      "oid": 16689380,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689381",
+      "title": [
+        "Page 1200"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689381"
+      ],
+      "oid": 16689381,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689382",
+      "title": [
+        "Page 1201"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689382"
+      ],
+      "oid": 16689382,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689383",
+      "title": [
+        "Page 1202"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689383"
+      ],
+      "oid": 16689383,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689384",
+      "title": [
+        "Page 1203"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689384"
+      ],
+      "oid": 16689384,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689385",
+      "title": [
+        "Page 1204"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689385"
+      ],
+      "oid": 16689385,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689386",
+      "title": [
+        "Page 1205"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689386"
+      ],
+      "oid": 16689386,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689387",
+      "title": [
+        "Page 1206"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689387"
+      ],
+      "oid": 16689387,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689388",
+      "title": [
+        "Page 1207"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689388"
+      ],
+      "oid": 16689388,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689389",
+      "title": [
+        "Page 1208"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689389"
+      ],
+      "oid": 16689389,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689390",
+      "title": [
+        "Page 1209"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689390"
+      ],
+      "oid": 16689390,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689391",
+      "title": [
+        "Page 1210"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689391"
+      ],
+      "oid": 16689391,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689392",
+      "title": [
+        "Page 1211"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689392"
+      ],
+      "oid": 16689392,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689393",
+      "title": [
+        "Page 1212"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689393"
+      ],
+      "oid": 16689393,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689394",
+      "title": [
+        "Page 1213"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689394"
+      ],
+      "oid": 16689394,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689395",
+      "title": [
+        "Page 1214"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689395"
+      ],
+      "oid": 16689395,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689396",
+      "title": [
+        "Page 1215"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689396"
+      ],
+      "oid": 16689396,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689397",
+      "title": [
+        "Page 1216"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689397"
+      ],
+      "oid": 16689397,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689398",
+      "title": [
+        "Page 1217"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689398"
+      ],
+      "oid": 16689398,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689399",
+      "title": [
+        "Page 1218"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689399"
+      ],
+      "oid": 16689399,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689400",
+      "title": [
+        "Page 1219"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689400"
+      ],
+      "oid": 16689400,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689401",
+      "title": [
+        "Page 1220"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689401"
+      ],
+      "oid": 16689401,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689402",
+      "title": [
+        "Page 1221"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689402"
+      ],
+      "oid": 16689402,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689403",
+      "title": [
+        "Page 1222"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689403"
+      ],
+      "oid": 16689403,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689404",
+      "title": [
+        "Page 1223"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689404"
+      ],
+      "oid": 16689404,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689405",
+      "title": [
+        "Page 1224"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689405"
+      ],
+      "oid": 16689405,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689406",
+      "title": [
+        "Page 1225"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689406"
+      ],
+      "oid": 16689406,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689407",
+      "title": [
+        "Page 1226"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689407"
+      ],
+      "oid": 16689407,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689408",
+      "title": [
+        "Page 1227"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689408"
+      ],
+      "oid": 16689408,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689409",
+      "title": [
+        "Page 1228"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689409"
+      ],
+      "oid": 16689409,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689410",
+      "title": [
+        "Page 1229"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689410"
+      ],
+      "oid": 16689410,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689411",
+      "title": [
+        "Page 1230"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689411"
+      ],
+      "oid": 16689411,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689412",
+      "title": [
+        "Page 1231"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689412"
+      ],
+      "oid": 16689412,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689413",
+      "title": [
+        "Page 1232"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689413"
+      ],
+      "oid": 16689413,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689414",
+      "title": [
+        "Page 1233"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689414"
+      ],
+      "oid": 16689414,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689415",
+      "title": [
+        "Page 1234"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689415"
+      ],
+      "oid": 16689415,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689416",
+      "title": [
+        "Page 1235"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689416"
+      ],
+      "oid": 16689416,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689417",
+      "title": [
+        "Page 1236"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689417"
+      ],
+      "oid": 16689417,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689418",
+      "title": [
+        "Page 1237"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689418"
+      ],
+      "oid": 16689418,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689419",
+      "title": [
+        "Page 1238"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689419"
+      ],
+      "oid": 16689419,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689420",
+      "title": [
+        "Page 1239"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689420"
+      ],
+      "oid": 16689420,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689421",
+      "title": [
+        "Page 1240"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689421"
+      ],
+      "oid": 16689421,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689422",
+      "title": [
+        "Page 1241"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689422"
+      ],
+      "oid": 16689422,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689423",
+      "title": [
+        "Page 1242"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689423"
+      ],
+      "oid": 16689423,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689424",
+      "title": [
+        "Page 1243"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689424"
+      ],
+      "oid": 16689424,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689425",
+      "title": [
+        "Page 1244"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689425"
+      ],
+      "oid": 16689425,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689426",
+      "title": [
+        "Page 1245"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689426"
+      ],
+      "oid": 16689426,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689427",
+      "title": [
+        "Page 1246"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689427"
+      ],
+      "oid": 16689427,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689428",
+      "title": [
+        "Page 1247"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689428"
+      ],
+      "oid": 16689428,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689429",
+      "title": [
+        "Page 1248"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689429"
+      ],
+      "oid": 16689429,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689430",
+      "title": [
+        "Page 1249"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689430"
+      ],
+      "oid": 16689430,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689431",
+      "title": [
+        "Page 1250"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689431"
+      ],
+      "oid": 16689431,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689432",
+      "title": [
+        "Page 1251"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689432"
+      ],
+      "oid": 16689432,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689433",
+      "title": [
+        "Page 1252"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689433"
+      ],
+      "oid": 16689433,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689434",
+      "title": [
+        "Page 1253"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689434"
+      ],
+      "oid": 16689434,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689435",
+      "title": [
+        "Page 1254"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689435"
+      ],
+      "oid": 16689435,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689436",
+      "title": [
+        "Page 1255"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689436"
+      ],
+      "oid": 16689436,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689437",
+      "title": [
+        "Page 1256"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689437"
+      ],
+      "oid": 16689437,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689438",
+      "title": [
+        "Page 1257"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689438"
+      ],
+      "oid": 16689438,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689439",
+      "title": [
+        "Page 1258"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689439"
+      ],
+      "oid": 16689439,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689440",
+      "title": [
+        "Page 1259"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689440"
+      ],
+      "oid": 16689440,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689441",
+      "title": [
+        "Page 1260"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689441"
+      ],
+      "oid": 16689441,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689442",
+      "title": [
+        "Page 1261"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689442"
+      ],
+      "oid": 16689442,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689443",
+      "title": [
+        "Page 1262"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689443"
+      ],
+      "oid": 16689443,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689444",
+      "title": [
+        "Page 1263"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689444"
+      ],
+      "oid": 16689444,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689445",
+      "title": [
+        "Page 1264"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689445"
+      ],
+      "oid": 16689445,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689446",
+      "title": [
+        "Page 1265"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689446"
+      ],
+      "oid": 16689446,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689447",
+      "title": [
+        "Page 1266"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689447"
+      ],
+      "oid": 16689447,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689448",
+      "title": [
+        "Page 1267"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689448"
+      ],
+      "oid": 16689448,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689449",
+      "title": [
+        "Page 1268"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689449"
+      ],
+      "oid": 16689449,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689450",
+      "title": [
+        "Page 1269"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689450"
+      ],
+      "oid": 16689450,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689451",
+      "title": [
+        "Page 1270"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689451"
+      ],
+      "oid": 16689451,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689452",
+      "title": [
+        "Page 1271"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689452"
+      ],
+      "oid": 16689452,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689453",
+      "title": [
+        "Page 1272"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689453"
+      ],
+      "oid": 16689453,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689454",
+      "title": [
+        "Page 1273"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689454"
+      ],
+      "oid": 16689454,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689455",
+      "title": [
+        "Page 1274"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689455"
+      ],
+      "oid": 16689455,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689456",
+      "title": [
+        "Page 1275"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689456"
+      ],
+      "oid": 16689456,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689457",
+      "title": [
+        "Page 1276"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689457"
+      ],
+      "oid": 16689457,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689458",
+      "title": [
+        "Page 1277"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689458"
+      ],
+      "oid": 16689458,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689459",
+      "title": [
+        "Page 1278"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689459"
+      ],
+      "oid": 16689459,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689460",
+      "title": [
+        "Page 1279"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689460"
+      ],
+      "oid": 16689460,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689461",
+      "title": [
+        "Page 1280"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689461"
+      ],
+      "oid": 16689461,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689462",
+      "title": [
+        "Page 1281"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689462"
+      ],
+      "oid": 16689462,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689463",
+      "title": [
+        "Page 1282"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689463"
+      ],
+      "oid": 16689463,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689464",
+      "title": [
+        "Page 1283"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689464"
+      ],
+      "oid": 16689464,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689465",
+      "title": [
+        "Page 1284"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689465"
+      ],
+      "oid": 16689465,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689466",
+      "title": [
+        "Page 1285"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689466"
+      ],
+      "oid": 16689466,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689467",
+      "title": [
+        "Page 1286"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689467"
+      ],
+      "oid": 16689467,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689468",
+      "title": [
+        "Page 1287"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689468"
+      ],
+      "oid": 16689468,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689469",
+      "title": [
+        "Page 1288"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689469"
+      ],
+      "oid": 16689469,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689470",
+      "title": [
+        "Page 1289"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689470"
+      ],
+      "oid": 16689470,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689471",
+      "title": [
+        "Page 1290"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689471"
+      ],
+      "oid": 16689471,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689472",
+      "title": [
+        "Page 1291"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689472"
+      ],
+      "oid": 16689472,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689473",
+      "title": [
+        "Page 1292"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689473"
+      ],
+      "oid": 16689473,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689474",
+      "title": [
+        "Page 1293"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689474"
+      ],
+      "oid": 16689474,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689475",
+      "title": [
+        "Page 1294"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689475"
+      ],
+      "oid": 16689475,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689476",
+      "title": [
+        "Page 1295"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689476"
+      ],
+      "oid": 16689476,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689477",
+      "title": [
+        "Page 1296"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689477"
+      ],
+      "oid": 16689477,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689478",
+      "title": [
+        "Page 1297"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689478"
+      ],
+      "oid": 16689478,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689479",
+      "title": [
+        "Page 1298"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689479"
+      ],
+      "oid": 16689479,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689480",
+      "title": [
+        "Page 1299"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689480"
+      ],
+      "oid": 16689480,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689481",
+      "title": [
+        "Page 1300"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689481"
+      ],
+      "oid": 16689481,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689482",
+      "title": [
+        "Page 1301"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689482"
+      ],
+      "oid": 16689482,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689483",
+      "title": [
+        "Page 1302"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689483"
+      ],
+      "oid": 16689483,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689484",
+      "title": [
+        "Page 1303"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689484"
+      ],
+      "oid": 16689484,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689485",
+      "title": [
+        "Page 1304"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689485"
+      ],
+      "oid": 16689485,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689486",
+      "title": [
+        "Page 1305"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689486"
+      ],
+      "oid": 16689486,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689487",
+      "title": [
+        "Page 1306"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689487"
+      ],
+      "oid": 16689487,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689488",
+      "title": [
+        "Page 1307"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689488"
+      ],
+      "oid": 16689488,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689489",
+      "title": [
+        "Page 1308"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689489"
+      ],
+      "oid": 16689489,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689490",
+      "title": [
+        "Page 1309"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689490"
+      ],
+      "oid": 16689490,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689491",
+      "title": [
+        "Page 1310"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689491"
+      ],
+      "oid": 16689491,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689492",
+      "title": [
+        "Page 1311"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689492"
+      ],
+      "oid": 16689492,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689493",
+      "title": [
+        "Page 1312"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689493"
+      ],
+      "oid": 16689493,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689494",
+      "title": [
+        "Page 1313"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689494"
+      ],
+      "oid": 16689494,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689495",
+      "title": [
+        "Page 1314"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689495"
+      ],
+      "oid": 16689495,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689496",
+      "title": [
+        "Page 1315"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689496"
+      ],
+      "oid": 16689496,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689497",
+      "title": [
+        "Page 1316"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689497"
+      ],
+      "oid": 16689497,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689498",
+      "title": [
+        "Page 1317"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689498"
+      ],
+      "oid": 16689498,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689499",
+      "title": [
+        "Page 1318"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689499"
+      ],
+      "oid": 16689499,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689500",
+      "title": [
+        "Page 1319"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689500"
+      ],
+      "oid": 16689500,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689501",
+      "title": [
+        "Page 1320"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689501"
+      ],
+      "oid": 16689501,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689502",
+      "title": [
+        "Page 1321"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689502"
+      ],
+      "oid": 16689502,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689503",
+      "title": [
+        "Page 1322"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689503"
+      ],
+      "oid": 16689503,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689504",
+      "title": [
+        "Page 1323"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689504"
+      ],
+      "oid": 16689504,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689505",
+      "title": [
+        "Page 1324"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689505"
+      ],
+      "oid": 16689505,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689506",
+      "title": [
+        "Page 1325"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689506"
+      ],
+      "oid": 16689506,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689507",
+      "title": [
+        "Page 1326"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689507"
+      ],
+      "oid": 16689507,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689508",
+      "title": [
+        "Page 1327"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689508"
+      ],
+      "oid": 16689508,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689509",
+      "title": [
+        "Page 1328"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689509"
+      ],
+      "oid": 16689509,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689510",
+      "title": [
+        "Page 1329"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689510"
+      ],
+      "oid": 16689510,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689511",
+      "title": [
+        "Page 1330"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689511"
+      ],
+      "oid": 16689511,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689512",
+      "title": [
+        "Page 1331"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689512"
+      ],
+      "oid": 16689512,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689513",
+      "title": [
+        "Page 1332"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689513"
+      ],
+      "oid": 16689513,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689514",
+      "title": [
+        "Page 1333"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689514"
+      ],
+      "oid": 16689514,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689515",
+      "title": [
+        "Page 1334"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689515"
+      ],
+      "oid": 16689515,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689516",
+      "title": [
+        "Page 1335"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689516"
+      ],
+      "oid": 16689516,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689517",
+      "title": [
+        "Page 1336"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689517"
+      ],
+      "oid": 16689517,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689518",
+      "title": [
+        "Page 1337"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689518"
+      ],
+      "oid": 16689518,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689519",
+      "title": [
+        "Page 1338"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689519"
+      ],
+      "oid": 16689519,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689520",
+      "title": [
+        "Page 1339"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689520"
+      ],
+      "oid": 16689520,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689521",
+      "title": [
+        "Page 1340"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689521"
+      ],
+      "oid": 16689521,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689522",
+      "title": [
+        "Page 1341"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689522"
+      ],
+      "oid": 16689522,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689523",
+      "title": [
+        "Page 1342"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689523"
+      ],
+      "oid": 16689523,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689524",
+      "title": [
+        "Page 1343"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689524"
+      ],
+      "oid": 16689524,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689525",
+      "title": [
+        "Page 1344"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689525"
+      ],
+      "oid": 16689525,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689526",
+      "title": [
+        "Page 1345"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689526"
+      ],
+      "oid": 16689526,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689527",
+      "title": [
+        "Page 1346"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689527"
+      ],
+      "oid": 16689527,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689528",
+      "title": [
+        "Page 1347"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689528"
+      ],
+      "oid": 16689528,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689529",
+      "title": [
+        "Page 1348"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689529"
+      ],
+      "oid": 16689529,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689530",
+      "title": [
+        "Page 1349"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689530"
+      ],
+      "oid": 16689530,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689531",
+      "title": [
+        "Page 1350"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689531"
+      ],
+      "oid": 16689531,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689532",
+      "title": [
+        "Page 1351"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689532"
+      ],
+      "oid": 16689532,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689533",
+      "title": [
+        "Page 1352"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689533"
+      ],
+      "oid": 16689533,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689534",
+      "title": [
+        "Page 1353"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689534"
+      ],
+      "oid": 16689534,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689535",
+      "title": [
+        "Page 1354"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689535"
+      ],
+      "oid": 16689535,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689536",
+      "title": [
+        "Page 1355"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689536"
+      ],
+      "oid": 16689536,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689537",
+      "title": [
+        "Page 1356"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689537"
+      ],
+      "oid": 16689537,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689538",
+      "title": [
+        "Page 1357"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689538"
+      ],
+      "oid": 16689538,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689539",
+      "title": [
+        "Page 1358"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689539"
+      ],
+      "oid": 16689539,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689540",
+      "title": [
+        "Page 1359"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689540"
+      ],
+      "oid": 16689540,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689541",
+      "title": [
+        "Page 1360"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689541"
+      ],
+      "oid": 16689541,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689542",
+      "title": [
+        "Page 1361"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689542"
+      ],
+      "oid": 16689542,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689543",
+      "title": [
+        "Page 1362"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689543"
+      ],
+      "oid": 16689543,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689544",
+      "title": [
+        "Page 1363"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689544"
+      ],
+      "oid": 16689544,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689545",
+      "title": [
+        "Page 1364"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689545"
+      ],
+      "oid": 16689545,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689546",
+      "title": [
+        "Page 1365"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689546"
+      ],
+      "oid": 16689546,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689547",
+      "title": [
+        "Page 1366"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689547"
+      ],
+      "oid": 16689547,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689548",
+      "title": [
+        "Page 1367"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689548"
+      ],
+      "oid": 16689548,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689549",
+      "title": [
+        "Page 1368"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689549"
+      ],
+      "oid": 16689549,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689550",
+      "title": [
+        "Page 1369"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689550"
+      ],
+      "oid": 16689550,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689551",
+      "title": [
+        "Page 1370"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689551"
+      ],
+      "oid": 16689551,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689552",
+      "title": [
+        "Page 1371"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689552"
+      ],
+      "oid": 16689552,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689553",
+      "title": [
+        "Page 1372"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689553"
+      ],
+      "oid": 16689553,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689554",
+      "title": [
+        "Page 1373"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689554"
+      ],
+      "oid": 16689554,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689555",
+      "title": [
+        "Page 1374"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689555"
+      ],
+      "oid": 16689555,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689556",
+      "title": [
+        "Page 1375"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689556"
+      ],
+      "oid": 16689556,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689557",
+      "title": [
+        "Page 1376"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689557"
+      ],
+      "oid": 16689557,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689558",
+      "title": [
+        "Page 1377"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689558"
+      ],
+      "oid": 16689558,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689559",
+      "title": [
+        "Page 1378"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689559"
+      ],
+      "oid": 16689559,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689560",
+      "title": [
+        "Page 1379"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689560"
+      ],
+      "oid": 16689560,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689561",
+      "title": [
+        "Page 1380"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689561"
+      ],
+      "oid": 16689561,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689562",
+      "title": [
+        "Page 1381"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689562"
+      ],
+      "oid": 16689562,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689563",
+      "title": [
+        "Page 1382"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689563"
+      ],
+      "oid": 16689563,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689564",
+      "title": [
+        "Page 1383"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689564"
+      ],
+      "oid": 16689564,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689565",
+      "title": [
+        "Page 1384"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689565"
+      ],
+      "oid": 16689565,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689566",
+      "title": [
+        "Page 1385"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689566"
+      ],
+      "oid": 16689566,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689567",
+      "title": [
+        "Page 1386"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689567"
+      ],
+      "oid": 16689567,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689568",
+      "title": [
+        "Page 1387"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689568"
+      ],
+      "oid": 16689568,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689569",
+      "title": [
+        "Page 1388"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689569"
+      ],
+      "oid": 16689569,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689570",
+      "title": [
+        "Page 1389"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689570"
+      ],
+      "oid": 16689570,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689571",
+      "title": [
+        "Page 1390"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689571"
+      ],
+      "oid": 16689571,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689572",
+      "title": [
+        "Page 1391"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689572"
+      ],
+      "oid": 16689572,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689573",
+      "title": [
+        "Page 1392"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689573"
+      ],
+      "oid": 16689573,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689574",
+      "title": [
+        "Page 1393"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689574"
+      ],
+      "oid": 16689574,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689575",
+      "title": [
+        "Page 1394"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689575"
+      ],
+      "oid": 16689575,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689576",
+      "title": [
+        "Page 1395"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689576"
+      ],
+      "oid": 16689576,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689577",
+      "title": [
+        "Page 1396"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689577"
+      ],
+      "oid": 16689577,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689578",
+      "title": [
+        "Page 1397"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689578"
+      ],
+      "oid": 16689578,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689579",
+      "title": [
+        "Page 1398"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689579"
+      ],
+      "oid": 16689579,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689580",
+      "title": [
+        "Page 1399"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689580"
+      ],
+      "oid": 16689580,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689581",
+      "title": [
+        "Page 1400"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689581"
+      ],
+      "oid": 16689581,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689582",
+      "title": [
+        "Page 1401"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689582"
+      ],
+      "oid": 16689582,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689583",
+      "title": [
+        "Page 1402"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689583"
+      ],
+      "oid": 16689583,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689584",
+      "title": [
+        "Page 1403"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689584"
+      ],
+      "oid": 16689584,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689585",
+      "title": [
+        "Page 1404"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689585"
+      ],
+      "oid": 16689585,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689586",
+      "title": [
+        "Page 1405"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689586"
+      ],
+      "oid": 16689586,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689587",
+      "title": [
+        "Page 1406"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689587"
+      ],
+      "oid": 16689587,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689588",
+      "title": [
+        "Page 1407"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689588"
+      ],
+      "oid": 16689588,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689589",
+      "title": [
+        "Page 1408"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689589"
+      ],
+      "oid": 16689589,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689590",
+      "title": [
+        "Page 1409"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689590"
+      ],
+      "oid": 16689590,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689591",
+      "title": [
+        "Page 1410"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689591"
+      ],
+      "oid": 16689591,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689592",
+      "title": [
+        "Page 1411"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689592"
+      ],
+      "oid": 16689592,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689593",
+      "title": [
+        "Page 1412"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689593"
+      ],
+      "oid": 16689593,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689594",
+      "title": [
+        "Page 1413"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689594"
+      ],
+      "oid": 16689594,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689595",
+      "title": [
+        "Page 1414"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689595"
+      ],
+      "oid": 16689595,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689596",
+      "title": [
+        "Page 1415"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689596"
+      ],
+      "oid": 16689596,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689597",
+      "title": [
+        "Page 1416"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689597"
+      ],
+      "oid": 16689597,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689598",
+      "title": [
+        "Page 1417"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689598"
+      ],
+      "oid": 16689598,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689599",
+      "title": [
+        "Page 1418"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689599"
+      ],
+      "oid": 16689599,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689600",
+      "title": [
+        "Page 1419"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689600"
+      ],
+      "oid": 16689600,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689601",
+      "title": [
+        "Page 1420"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689601"
+      ],
+      "oid": 16689601,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689602",
+      "title": [
+        "Page 1421"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689602"
+      ],
+      "oid": 16689602,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689603",
+      "title": [
+        "Page 1422"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689603"
+      ],
+      "oid": 16689603,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689604",
+      "title": [
+        "Page 1423"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689604"
+      ],
+      "oid": 16689604,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689605",
+      "title": [
+        "Page 1424"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689605"
+      ],
+      "oid": 16689605,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689606",
+      "title": [
+        "Page 1425"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689606"
+      ],
+      "oid": 16689606,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689607",
+      "title": [
+        "Page 1426"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689607"
+      ],
+      "oid": 16689607,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689608",
+      "title": [
+        "Page 1427"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689608"
+      ],
+      "oid": 16689608,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689609",
+      "title": [
+        "Page 1428"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689609"
+      ],
+      "oid": 16689609,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689610",
+      "title": [
+        "Page 1429"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689610"
+      ],
+      "oid": 16689610,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689611",
+      "title": [
+        "Page 1430"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689611"
+      ],
+      "oid": 16689611,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689612",
+      "title": [
+        "Page 1431"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689612"
+      ],
+      "oid": 16689612,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689613",
+      "title": [
+        "Page 1432"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689613"
+      ],
+      "oid": 16689613,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689614",
+      "title": [
+        "Page 1433"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689614"
+      ],
+      "oid": 16689614,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689615",
+      "title": [
+        "Page 1434"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689615"
+      ],
+      "oid": 16689615,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689616",
+      "title": [
+        "Page 1435"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689616"
+      ],
+      "oid": 16689616,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689617",
+      "title": [
+        "Page 1436"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689617"
+      ],
+      "oid": 16689617,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689618",
+      "title": [
+        "Page 1437"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689618"
+      ],
+      "oid": 16689618,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689619",
+      "title": [
+        "Page 1438"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689619"
+      ],
+      "oid": 16689619,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689620",
+      "title": [
+        "Page 1439"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689620"
+      ],
+      "oid": 16689620,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689621",
+      "title": [
+        "Page 1440"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689621"
+      ],
+      "oid": 16689621,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689622",
+      "title": [
+        "Page 1441"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689622"
+      ],
+      "oid": 16689622,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689623",
+      "title": [
+        "Page 1442"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689623"
+      ],
+      "oid": 16689623,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689624",
+      "title": [
+        "Page 1443"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689624"
+      ],
+      "oid": 16689624,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689625",
+      "title": [
+        "Page 1444"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689625"
+      ],
+      "oid": 16689625,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689626",
+      "title": [
+        "Page 1445"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689626"
+      ],
+      "oid": 16689626,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689627",
+      "title": [
+        "Page 1446"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689627"
+      ],
+      "oid": 16689627,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689628",
+      "title": [
+        "Page 1447"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689628"
+      ],
+      "oid": 16689628,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689629",
+      "title": [
+        "Page 1448"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689629"
+      ],
+      "oid": 16689629,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689630",
+      "title": [
+        "Page 1449"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689630"
+      ],
+      "oid": 16689630,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689631",
+      "title": [
+        "Page 1450"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689631"
+      ],
+      "oid": 16689631,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689632",
+      "title": [
+        "Page 1451"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689632"
+      ],
+      "oid": 16689632,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689633",
+      "title": [
+        "Page 1452"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689633"
+      ],
+      "oid": 16689633,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689634",
+      "title": [
+        "Page 1453"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689634"
+      ],
+      "oid": 16689634,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689635",
+      "title": [
+        "Page 1454"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689635"
+      ],
+      "oid": 16689635,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689636",
+      "title": [
+        "Page 1455"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689636"
+      ],
+      "oid": 16689636,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689637",
+      "title": [
+        "Page 1456"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689637"
+      ],
+      "oid": 16689637,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689638",
+      "title": [
+        "Page 1457"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689638"
+      ],
+      "oid": 16689638,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689639",
+      "title": [
+        "Page 1458"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689639"
+      ],
+      "oid": 16689639,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689640",
+      "title": [
+        "Page 1459"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689640"
+      ],
+      "oid": 16689640,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689641",
+      "title": [
+        "Page 1460"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689641"
+      ],
+      "oid": 16689641,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689642",
+      "title": [
+        "Page 1461"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689642"
+      ],
+      "oid": 16689642,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689643",
+      "title": [
+        "Page 1462"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689643"
+      ],
+      "oid": 16689643,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689644",
+      "title": [
+        "Page 1463"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689644"
+      ],
+      "oid": 16689644,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689645",
+      "title": [
+        "Page 1464"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689645"
+      ],
+      "oid": 16689645,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689646",
+      "title": [
+        "Page 1465"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689646"
+      ],
+      "oid": 16689646,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689647",
+      "title": [
+        "Page 1466"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689647"
+      ],
+      "oid": 16689647,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689648",
+      "title": [
+        "Page 1467"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689648"
+      ],
+      "oid": 16689648,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689649",
+      "title": [
+        "Page 1468"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689649"
+      ],
+      "oid": 16689649,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689650",
+      "title": [
+        "Page 1469"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689650"
+      ],
+      "oid": 16689650,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689651",
+      "title": [
+        "Page 1470"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689651"
+      ],
+      "oid": 16689651,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689652",
+      "title": [
+        "Page 1471"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689652"
+      ],
+      "oid": 16689652,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689653",
+      "title": [
+        "Page 1472"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689653"
+      ],
+      "oid": 16689653,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689654",
+      "title": [
+        "Page 1473"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689654"
+      ],
+      "oid": 16689654,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689655",
+      "title": [
+        "Page 1474"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689655"
+      ],
+      "oid": 16689655,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689656",
+      "title": [
+        "Page 1475"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689656"
+      ],
+      "oid": 16689656,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689657",
+      "title": [
+        "Page 1476"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689657"
+      ],
+      "oid": 16689657,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689658",
+      "title": [
+        "Page 1477"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689658"
+      ],
+      "oid": 16689658,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689659",
+      "title": [
+        "Page 1478"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689659"
+      ],
+      "oid": 16689659,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689660",
+      "title": [
+        "Page 1479"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689660"
+      ],
+      "oid": 16689660,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689661",
+      "title": [
+        "Page 1480"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689661"
+      ],
+      "oid": 16689661,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689662",
+      "title": [
+        "Page 1481"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689662"
+      ],
+      "oid": 16689662,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689663",
+      "title": [
+        "Page 1482"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689663"
+      ],
+      "oid": 16689663,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689664",
+      "title": [
+        "Page 1483"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689664"
+      ],
+      "oid": 16689664,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689665",
+      "title": [
+        "Page 1484"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689665"
+      ],
+      "oid": 16689665,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689666",
+      "title": [
+        "Page 1485"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689666"
+      ],
+      "oid": 16689666,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689667",
+      "title": [
+        "Page 1486"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689667"
+      ],
+      "oid": 16689667,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689668",
+      "title": [
+        "Page 1487"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689668"
+      ],
+      "oid": 16689668,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689669",
+      "title": [
+        "Page 1488"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689669"
+      ],
+      "oid": 16689669,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689670",
+      "title": [
+        "Page 1489"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689670"
+      ],
+      "oid": 16689670,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689671",
+      "title": [
+        "Page 1490"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689671"
+      ],
+      "oid": 16689671,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689672",
+      "title": [
+        "Page 1491"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689672"
+      ],
+      "oid": 16689672,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689673",
+      "title": [
+        "Page 1492"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689673"
+      ],
+      "oid": 16689673,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689674",
+      "title": [
+        "Page 1493"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689674"
+      ],
+      "oid": 16689674,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689675",
+      "title": [
+        "Page 1494"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689675"
+      ],
+      "oid": 16689675,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689676",
+      "title": [
+        "Page 1495"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689676"
+      ],
+      "oid": 16689676,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689677",
+      "title": [
+        "Page 1496"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689677"
+      ],
+      "oid": 16689677,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689678",
+      "title": [
+        "Page 1497"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689678"
+      ],
+      "oid": 16689678,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689679",
+      "title": [
+        "Page 1498"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689679"
+      ],
+      "oid": 16689679,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689680",
+      "title": [
+        "Page 1499"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689680"
+      ],
+      "oid": 16689680,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689681",
+      "title": [
+        "Page 1500"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689681"
+      ],
+      "oid": 16689681,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689682",
+      "title": [
+        "Page 1501"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689682"
+      ],
+      "oid": 16689682,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689683",
+      "title": [
+        "Page 1502"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689683"
+      ],
+      "oid": 16689683,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689684",
+      "title": [
+        "Page 1503"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689684"
+      ],
+      "oid": 16689684,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689685",
+      "title": [
+        "Page 1504"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689685"
+      ],
+      "oid": 16689685,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689686",
+      "title": [
+        "Page 1505"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689686"
+      ],
+      "oid": 16689686,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689687",
+      "title": [
+        "Page 1506"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689687"
+      ],
+      "oid": 16689687,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689688",
+      "title": [
+        "Page 1507"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689688"
+      ],
+      "oid": 16689688,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689689",
+      "title": [
+        "Page 1508"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689689"
+      ],
+      "oid": 16689689,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689690",
+      "title": [
+        "Page 1509"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689690"
+      ],
+      "oid": 16689690,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689691",
+      "title": [
+        "Page 1510"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689691"
+      ],
+      "oid": 16689691,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689692",
+      "title": [
+        "Page 1511"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689692"
+      ],
+      "oid": 16689692,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689693",
+      "title": [
+        "Page 1512"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689693"
+      ],
+      "oid": 16689693,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689694",
+      "title": [
+        "Page 1513"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689694"
+      ],
+      "oid": 16689694,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689695",
+      "title": [
+        "Page 1514"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689695"
+      ],
+      "oid": 16689695,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689696",
+      "title": [
+        "Page 1515"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689696"
+      ],
+      "oid": 16689696,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689697",
+      "title": [
+        "Page 1516"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689697"
+      ],
+      "oid": 16689697,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689698",
+      "title": [
+        "Page 1517"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689698"
+      ],
+      "oid": 16689698,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689699",
+      "title": [
+        "Page 1518"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689699"
+      ],
+      "oid": 16689699,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689700",
+      "title": [
+        "Page 1519"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689700"
+      ],
+      "oid": 16689700,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689701",
+      "title": [
+        "Page 1520"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689701"
+      ],
+      "oid": 16689701,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689702",
+      "title": [
+        "Page 1521"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689702"
+      ],
+      "oid": 16689702,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689703",
+      "title": [
+        "Page 1522"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689703"
+      ],
+      "oid": 16689703,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689704",
+      "title": [
+        "Page 1523"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689704"
+      ],
+      "oid": 16689704,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689705",
+      "title": [
+        "Page 1524"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689705"
+      ],
+      "oid": 16689705,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689706",
+      "title": [
+        "Page 1525"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689706"
+      ],
+      "oid": 16689706,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689707",
+      "title": [
+        "Page 1526"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689707"
+      ],
+      "oid": 16689707,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689708",
+      "title": [
+        "Page 1527"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689708"
+      ],
+      "oid": 16689708,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689709",
+      "title": [
+        "Page 1528"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689709"
+      ],
+      "oid": 16689709,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689710",
+      "title": [
+        "Page 1529"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689710"
+      ],
+      "oid": 16689710,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689711",
+      "title": [
+        "Page 1530"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689711"
+      ],
+      "oid": 16689711,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689712",
+      "title": [
+        "Page 1531"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689712"
+      ],
+      "oid": 16689712,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689713",
+      "title": [
+        "Page 1532"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689713"
+      ],
+      "oid": 16689713,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689714",
+      "title": [
+        "Page 1533"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689714"
+      ],
+      "oid": 16689714,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689715",
+      "title": [
+        "Page 1534"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689715"
+      ],
+      "oid": 16689715,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689716",
+      "title": [
+        "Page 1535"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689716"
+      ],
+      "oid": 16689716,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689717",
+      "title": [
+        "Page 1536"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689717"
+      ],
+      "oid": 16689717,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689718",
+      "title": [
+        "Page 1537"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689718"
+      ],
+      "oid": 16689718,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689719",
+      "title": [
+        "Page 1538"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689719"
+      ],
+      "oid": 16689719,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689720",
+      "title": [
+        "Page 1539"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689720"
+      ],
+      "oid": 16689720,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689721",
+      "title": [
+        "Page 1540"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689721"
+      ],
+      "oid": 16689721,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689722",
+      "title": [
+        "Page 1541"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689722"
+      ],
+      "oid": 16689722,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689723",
+      "title": [
+        "Page 1542"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689723"
+      ],
+      "oid": 16689723,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689724",
+      "title": [
+        "Page 1543"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689724"
+      ],
+      "oid": 16689724,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689725",
+      "title": [
+        "Page 1544"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689725"
+      ],
+      "oid": 16689725,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689726",
+      "title": [
+        "Page 1545"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689726"
+      ],
+      "oid": 16689726,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689727",
+      "title": [
+        "Page 1546"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689727"
+      ],
+      "oid": 16689727,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689728",
+      "title": [
+        "Page 1547"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689728"
+      ],
+      "oid": 16689728,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689729",
+      "title": [
+        "Page 1548"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689729"
+      ],
+      "oid": 16689729,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689730",
+      "title": [
+        "Page 1549"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689730"
+      ],
+      "oid": 16689730,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689731",
+      "title": [
+        "Page 1550"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689731"
+      ],
+      "oid": 16689731,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689732",
+      "title": [
+        "Page 1551"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689732"
+      ],
+      "oid": 16689732,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689733",
+      "title": [
+        "Page 1552"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689733"
+      ],
+      "oid": 16689733,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689734",
+      "title": [
+        "Page 1553"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689734"
+      ],
+      "oid": 16689734,
+      "width": 1193,
+      "height": 1677,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689735",
+      "title": [
+        "Page 1554"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689735"
+      ],
+      "oid": 16689735,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689736",
+      "title": [
+        "Page 1555"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689736"
+      ],
+      "oid": 16689736,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689737",
+      "title": [
+        "Page 1556"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689737"
+      ],
+      "oid": 16689737,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689738",
+      "title": [
+        "Page 1557"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689738"
+      ],
+      "oid": 16689738,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689739",
+      "title": [
+        "Page 1558"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689739"
+      ],
+      "oid": 16689739,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689740",
+      "title": [
+        "Page 1559"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689740"
+      ],
+      "oid": 16689740,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689741",
+      "title": [
+        "Page 1560"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689741"
+      ],
+      "oid": 16689741,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689742",
+      "title": [
+        "Page 1561"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689742"
+      ],
+      "oid": 16689742,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689743",
+      "title": [
+        "Page 1562"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689743"
+      ],
+      "oid": 16689743,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689744",
+      "title": [
+        "Page 1563"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689744"
+      ],
+      "oid": 16689744,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689745",
+      "title": [
+        "Page 1564"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689745"
+      ],
+      "oid": 16689745,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689746",
+      "title": [
+        "Page 1565"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689746"
+      ],
+      "oid": 16689746,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689747",
+      "title": [
+        "Page 1566"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689747"
+      ],
+      "oid": 16689747,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689748",
+      "title": [
+        "Page 1567"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689748"
+      ],
+      "oid": 16689748,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689749",
+      "title": [
+        "Page 1568"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689749"
+      ],
+      "oid": 16689749,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689750",
+      "title": [
+        "Page 1569"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689750"
+      ],
+      "oid": 16689750,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689751",
+      "title": [
+        "Page 1570"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689751"
+      ],
+      "oid": 16689751,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689752",
+      "title": [
+        "Page 1571"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689752"
+      ],
+      "oid": 16689752,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689753",
+      "title": [
+        "Page 1572"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689753"
+      ],
+      "oid": 16689753,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689754",
+      "title": [
+        "Page 1573"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689754"
+      ],
+      "oid": 16689754,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689755",
+      "title": [
+        "Page 1574"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689755"
+      ],
+      "oid": 16689755,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689756",
+      "title": [
+        "Page 1575"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689756"
+      ],
+      "oid": 16689756,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689757",
+      "title": [
+        "Page 1576"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689757"
+      ],
+      "oid": 16689757,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689758",
+      "title": [
+        "Page 1577"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689758"
+      ],
+      "oid": 16689758,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689759",
+      "title": [
+        "Page 1578"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689759"
+      ],
+      "oid": 16689759,
+      "width": 1193,
+      "height": 1666,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689760",
+      "title": [
+        "Page 1579"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689760"
+      ],
+      "oid": 16689760,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689761",
+      "title": [
+        "Page 1580"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689761"
+      ],
+      "oid": 16689761,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689762",
+      "title": [
+        "Page 1581"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689762"
+      ],
+      "oid": 16689762,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689763",
+      "title": [
+        "Page 1582"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689763"
+      ],
+      "oid": 16689763,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689764",
+      "title": [
+        "Page 1583"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689764"
+      ],
+      "oid": 16689764,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689765",
+      "title": [
+        "Page 1584"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689765"
+      ],
+      "oid": 16689765,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689766",
+      "title": [
+        "Page 1585"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689766"
+      ],
+      "oid": 16689766,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689767",
+      "title": [
+        "Page 1586"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689767"
+      ],
+      "oid": 16689767,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689768",
+      "title": [
+        "Page 1587"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689768"
+      ],
+      "oid": 16689768,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689769",
+      "title": [
+        "Page 1588"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689769"
+      ],
+      "oid": 16689769,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689770",
+      "title": [
+        "Page 1589"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689770"
+      ],
+      "oid": 16689770,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689771",
+      "title": [
+        "Page 1590"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689771"
+      ],
+      "oid": 16689771,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689772",
+      "title": [
+        "Page 1591"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689772"
+      ],
+      "oid": 16689772,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689773",
+      "title": [
+        "Page 1592"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689773"
+      ],
+      "oid": 16689773,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689774",
+      "title": [
+        "Page 1593"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689774"
+      ],
+      "oid": 16689774,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689775",
+      "title": [
+        "Page 1594"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689775"
+      ],
+      "oid": 16689775,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689776",
+      "title": [
+        "Page 1595"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689776"
+      ],
+      "oid": 16689776,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689777",
+      "title": [
+        "Page 1596"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689777"
+      ],
+      "oid": 16689777,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689778",
+      "title": [
+        "Page 1597"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689778"
+      ],
+      "oid": 16689778,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689779",
+      "title": [
+        "Page 1598"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689779"
+      ],
+      "oid": 16689779,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689780",
+      "title": [
+        "Page 1599"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689780"
+      ],
+      "oid": 16689780,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689781",
+      "title": [
+        "Page 1600"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689781"
+      ],
+      "oid": 16689781,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689782",
+      "title": [
+        "Page 1601"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689782"
+      ],
+      "oid": 16689782,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689783",
+      "title": [
+        "Page 1602"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689783"
+      ],
+      "oid": 16689783,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689784",
+      "title": [
+        "Page 1603"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689784"
+      ],
+      "oid": 16689784,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689785",
+      "title": [
+        "Page 1604"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689785"
+      ],
+      "oid": 16689785,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689786",
+      "title": [
+        "Page 1605"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689786"
+      ],
+      "oid": 16689786,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689787",
+      "title": [
+        "Page 1606"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689787"
+      ],
+      "oid": 16689787,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689788",
+      "title": [
+        "Page 1607"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689788"
+      ],
+      "oid": 16689788,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689789",
+      "title": [
+        "Page 1608"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689789"
+      ],
+      "oid": 16689789,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689790",
+      "title": [
+        "Page 1609"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689790"
+      ],
+      "oid": 16689790,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689791",
+      "title": [
+        "Page 1610"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689791"
+      ],
+      "oid": 16689791,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689792",
+      "title": [
+        "Page 1611"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689792"
+      ],
+      "oid": 16689792,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689793",
+      "title": [
+        "Page 1612"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689793"
+      ],
+      "oid": 16689793,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689794",
+      "title": [
+        "Page 1613"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689794"
+      ],
+      "oid": 16689794,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689795",
+      "title": [
+        "Page 1614"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689795"
+      ],
+      "oid": 16689795,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689796",
+      "title": [
+        "Page 1615"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689796"
+      ],
+      "oid": 16689796,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689797",
+      "title": [
+        "Page 1616"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689797"
+      ],
+      "oid": 16689797,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689798",
+      "title": [
+        "Page 1617"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689798"
+      ],
+      "oid": 16689798,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689799",
+      "title": [
+        "Page 1618"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689799"
+      ],
+      "oid": 16689799,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689800",
+      "title": [
+        "Page 1619"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689800"
+      ],
+      "oid": 16689800,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689801",
+      "title": [
+        "Page 1620"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689801"
+      ],
+      "oid": 16689801,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689802",
+      "title": [
+        "Page 1621"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689802"
+      ],
+      "oid": 16689802,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689803",
+      "title": [
+        "Page 1622"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689803"
+      ],
+      "oid": 16689803,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689804",
+      "title": [
+        "Page 1623"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689804"
+      ],
+      "oid": 16689804,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689805",
+      "title": [
+        "Page 1624"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689805"
+      ],
+      "oid": 16689805,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689806",
+      "title": [
+        "Page 1625"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689806"
+      ],
+      "oid": 16689806,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689807",
+      "title": [
+        "Page 1626"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689807"
+      ],
+      "oid": 16689807,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689808",
+      "title": [
+        "Page 1627"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689808"
+      ],
+      "oid": 16689808,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689809",
+      "title": [
+        "Page 1628"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689809"
+      ],
+      "oid": 16689809,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689810",
+      "title": [
+        "Page 1629"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689810"
+      ],
+      "oid": 16689810,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689811",
+      "title": [
+        "Page 1630"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689811"
+      ],
+      "oid": 16689811,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689812",
+      "title": [
+        "Page 1631"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689812"
+      ],
+      "oid": 16689812,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689813",
+      "title": [
+        "Page 1632"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689813"
+      ],
+      "oid": 16689813,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689814",
+      "title": [
+        "Page 1633"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689814"
+      ],
+      "oid": 16689814,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689815",
+      "title": [
+        "Page 1634"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689815"
+      ],
+      "oid": 16689815,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689816",
+      "title": [
+        "Page 1635"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689816"
+      ],
+      "oid": 16689816,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689817",
+      "title": [
+        "Page 1636"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689817"
+      ],
+      "oid": 16689817,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689818",
+      "title": [
+        "Page 1637"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689818"
+      ],
+      "oid": 16689818,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689819",
+      "title": [
+        "Page 1638"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689819"
+      ],
+      "oid": 16689819,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689820",
+      "title": [
+        "Page 1639"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689820"
+      ],
+      "oid": 16689820,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689821",
+      "title": [
+        "Page 1640"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689821"
+      ],
+      "oid": 16689821,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689822",
+      "title": [
+        "Page 1641"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689822"
+      ],
+      "oid": 16689822,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689823",
+      "title": [
+        "Page 1642"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689823"
+      ],
+      "oid": 16689823,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689824",
+      "title": [
+        "Page 1643"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689824"
+      ],
+      "oid": 16689824,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689825",
+      "title": [
+        "Page 1644"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689825"
+      ],
+      "oid": 16689825,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689826",
+      "title": [
+        "Page 1645"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689826"
+      ],
+      "oid": 16689826,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689827",
+      "title": [
+        "Page 1646"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689827"
+      ],
+      "oid": 16689827,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689828",
+      "title": [
+        "Page 1647"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689828"
+      ],
+      "oid": 16689828,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689829",
+      "title": [
+        "Page 1648"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689829"
+      ],
+      "oid": 16689829,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689830",
+      "title": [
+        "Page 1649"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689830"
+      ],
+      "oid": 16689830,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689831",
+      "title": [
+        "Page 1650"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689831"
+      ],
+      "oid": 16689831,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689832",
+      "title": [
+        "Page 1651"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689832"
+      ],
+      "oid": 16689832,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689833",
+      "title": [
+        "Page 1652"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689833"
+      ],
+      "oid": 16689833,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689834",
+      "title": [
+        "Page 1653"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689834"
+      ],
+      "oid": 16689834,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689835",
+      "title": [
+        "Page 1654"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689835"
+      ],
+      "oid": 16689835,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689836",
+      "title": [
+        "Page 1655"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689836"
+      ],
+      "oid": 16689836,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689837",
+      "title": [
+        "Page 1656"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689837"
+      ],
+      "oid": 16689837,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689838",
+      "title": [
+        "Page 1657"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689838"
+      ],
+      "oid": 16689838,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689839",
+      "title": [
+        "Page 1658"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689839"
+      ],
+      "oid": 16689839,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689840",
+      "title": [
+        "Page 1659"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689840"
+      ],
+      "oid": 16689840,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689841",
+      "title": [
+        "Page 1660"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689841"
+      ],
+      "oid": 16689841,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689842",
+      "title": [
+        "Page 1661"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689842"
+      ],
+      "oid": 16689842,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689843",
+      "title": [
+        "Page 1662"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689843"
+      ],
+      "oid": 16689843,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689844",
+      "title": [
+        "Page 1663"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689844"
+      ],
+      "oid": 16689844,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689845",
+      "title": [
+        "Page 1664"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689845"
+      ],
+      "oid": 16689845,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689846",
+      "title": [
+        "Page 1665"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689846"
+      ],
+      "oid": 16689846,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689847",
+      "title": [
+        "Page 1666"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689847"
+      ],
+      "oid": 16689847,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689848",
+      "title": [
+        "Page 1667"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689848"
+      ],
+      "oid": 16689848,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689849",
+      "title": [
+        "Page 1668"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689849"
+      ],
+      "oid": 16689849,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689850",
+      "title": [
+        "Page 1669"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689850"
+      ],
+      "oid": 16689850,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689851",
+      "title": [
+        "Page 1670"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689851"
+      ],
+      "oid": 16689851,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689852",
+      "title": [
+        "Page 1671"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689852"
+      ],
+      "oid": 16689852,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689853",
+      "title": [
+        "Page 1672"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689853"
+      ],
+      "oid": 16689853,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689854",
+      "title": [
+        "Page 1673"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689854"
+      ],
+      "oid": 16689854,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689855",
+      "title": [
+        "Page 1674"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689855"
+      ],
+      "oid": 16689855,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689856",
+      "title": [
+        "Page 1675"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689856"
+      ],
+      "oid": 16689856,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689857",
+      "title": [
+        "Page 1676"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689857"
+      ],
+      "oid": 16689857,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689858",
+      "title": [
+        "Page 1677"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689858"
+      ],
+      "oid": 16689858,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689859",
+      "title": [
+        "Page 1678"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689859"
+      ],
+      "oid": 16689859,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689860",
+      "title": [
+        "Page 1679"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689860"
+      ],
+      "oid": 16689860,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689861",
+      "title": [
+        "Page 1680"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689861"
+      ],
+      "oid": 16689861,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689862",
+      "title": [
+        "Page 1681"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689862"
+      ],
+      "oid": 16689862,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689863",
+      "title": [
+        "Page 1682"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689863"
+      ],
+      "oid": 16689863,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689864",
+      "title": [
+        "Page 1683"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689864"
+      ],
+      "oid": 16689864,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689865",
+      "title": [
+        "Page 1684"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689865"
+      ],
+      "oid": 16689865,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689866",
+      "title": [
+        "Page 1685"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689866"
+      ],
+      "oid": 16689866,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689867",
+      "title": [
+        "Page 1686"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689867"
+      ],
+      "oid": 16689867,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689868",
+      "title": [
+        "Page 1687"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689868"
+      ],
+      "oid": 16689868,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689869",
+      "title": [
+        "Page 1688"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689869"
+      ],
+      "oid": 16689869,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689870",
+      "title": [
+        "Page 1689"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689870"
+      ],
+      "oid": 16689870,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689871",
+      "title": [
+        "Page 1690"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689871"
+      ],
+      "oid": 16689871,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689872",
+      "title": [
+        "Page 1691"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689872"
+      ],
+      "oid": 16689872,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689873",
+      "title": [
+        "Page 1692"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689873"
+      ],
+      "oid": 16689873,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689874",
+      "title": [
+        "Page 1693"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689874"
+      ],
+      "oid": 16689874,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689875",
+      "title": [
+        "Page 1694"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689875"
+      ],
+      "oid": 16689875,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689876",
+      "title": [
+        "Page 1695"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689876"
+      ],
+      "oid": 16689876,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689877",
+      "title": [
+        "Page 1696"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689877"
+      ],
+      "oid": 16689877,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689878",
+      "title": [
+        "Page 1697"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689878"
+      ],
+      "oid": 16689878,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689879",
+      "title": [
+        "Page 1698"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689879"
+      ],
+      "oid": 16689879,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689880",
+      "title": [
+        "Page 1699"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689880"
+      ],
+      "oid": 16689880,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    },
+    {
+      "jsonModelType": "LadybirdSolrRecord",
+      "source": "ladybird",
+      "recordType": "oid",
+      "uri": "/ladybird/oid/16689881",
+      "title": [
+        "Page 1700"
+      ],
+      "dependentUris": [
+        "/ladybird/oid/16689881"
+      ],
+      "oid": 16689881,
+      "width": 1591,
+      "height": 2221,
+      "children": []
+    }
+  ]
+}

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -660,4 +660,15 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       expect(parent_object.batch_connections_for(batch_process)).to eq(batch_connection)
     end
   end
+
+  context "a ladybird Object without itemPermission" do
+    let(:parent_object) { described_class.create(oid: "16688180", admin_set: FactoryBot.create(:admin_set)) }
+    before do
+      stub_metadata_cloud("16688180")
+    end
+
+    it "will have Private as the default visibility" do
+      expect(parent_object.visibility).to eq "Private"
+    end
+  end
 end


### PR DESCRIPTION
To fix https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1570
Example: This object has empty itemPermission value.
<img width="1559" alt="Screen Shot 2021-09-01 at 5 50 08 PM" src="https://user-images.githubusercontent.com/46331329/131751928-dbb20aaf-b411-41b4-9375-fd47fd4ed456.png">
