### PR TITLE
added action column for batch delete csvs

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -144,11 +144,15 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def delete_objects
     parsed_csv.each_with_index do |row, index|
       oid = row['oid']
+      action = row['action']
       metadata_source = row['source']
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}, action value for oid must be 'delete' to complete deletion.", 'Invalid Vocab') if action != "delete"
+      next unless action == 'delete'
       parent_object = deletable_parent_object(oid, index)
       next unless parent_object
       setup_for_background_jobs(parent_object, metadata_source)
       parent_object.destroy
+      parent_object.processing_event("Parent #{parent_object.oid} has been deleted", 'deleted')
     end
   end
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -81,7 +81,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def finished_states
-    ['solr-indexed', 'pdf-generated', 'ptiffs-recreated', 'update-complete']
+    ['solr-indexed', 'pdf-generated', 'ptiffs-recreated', 'update-complete', 'deleted']
   end
 
   # Note - the upsert_all method skips ActiveRecord callbacks, and is entirely

--- a/public/batch_processes/templates/delete_parent_objects.csv
+++ b/public/batch_processes/templates/delete_parent_objects.csv
@@ -1,1 +1,1 @@
-oid,source,admin_set
+oid,action,source,admin_set

--- a/spec/fixtures/delete_sample_fixture_ids.csv
+++ b/spec/fixtures/delete_sample_fixture_ids.csv
@@ -1,2 +1,2 @@
-oid,source,admin_set
-16854285,ladybird,brbl
+oid,action,source,admin_set
+16854285,delete,ladybird,brbl


### PR DESCRIPTION
- Added an "action" column to the batch delete template.  
- Added processing event messages for batch delete.  

If action column value is missing or doesn't say 'delete' in the csv:  
![Image 2021-09-07 at 3 20 52 PM](https://user-images.githubusercontent.com/24666568/132417979-23c93e6a-4ec4-4dff-a1e4-c74a37907cae.jpg)  
  
If batch delete is successful:  
![Image 2021-09-07 at 3 22 18 PM](https://user-images.githubusercontent.com/24666568/132418070-edb90d18-e2a6-4808-8190-0d359c368228.jpg)
  
New CSV template:  
![Image 2021-09-07 at 3 23 02 PM](https://user-images.githubusercontent.com/24666568/132418126-da43396f-629c-45e9-bb80-34f0e7e81205.jpg)

