### PR TITLE
Prevent multiple solr index jobs to be queued simultaneously

### DIFF
--- a/app/jobs/solr_index_job.rb
+++ b/app/jobs/solr_index_job.rb
@@ -7,7 +7,9 @@ class SolrIndexJob < ApplicationJob
     -50
   end
 
-  def perform(parent_object)
+  def perform(parent_object, current_batch_process = nil, current_batch_connection = parent_object.current_batch_connection)
+    parent_object.current_batch_process = current_batch_process
+    parent_object.current_batch_connection = current_batch_connection
     parent_object.solr_index
   end
 end

--- a/app/models/concerns/delayable.rb
+++ b/app/models/concerns/delayable.rb
@@ -11,6 +11,10 @@ module Delayable
     Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "%job_class: %SetupMetadataJob%", "%#{self.class}/#{oid}%")
   end
 
+  def solr_index_jobs
+    Delayed::Job.where("handler LIKE ? AND handler LIKE ?", "%job_class: %SolrIndexJob%", "%#{self.class}/#{oid}%")
+  end
+
   def solr_reindex_jobs
     Delayed::Job.where("handler LIKE ?", "%job_class: SolrReindexAllJob%")
   end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -9,12 +9,23 @@ module SolrIndexable
   end
 
   def solr_index
-    indexable, child_solr_documents = to_solr_full_text
-    return unless indexable.present?
-    solr = SolrService.connection
-    solr.add([indexable])
-    solr.add(child_solr_documents) unless child_solr_documents.nil?
-    solr.commit
+    begin
+      indexable, child_solr_documents = to_solr_full_text
+      return unless indexable.present?
+      solr = SolrService.connection
+      solr.add([indexable])
+      solr.add(child_solr_documents) unless child_solr_documents.nil?
+      result = solr.commit
+      if (result&.[]("responseHeader")&.[]("status"))&.zero?
+        processing_event("Solr index updated", "solr-indexed")
+      else
+        processing_event("Solr index after manifest generation failed", "failed")
+      end
+    rescue => e
+      processing_event("Solr indexing failed due to #{e.message}", "failed")
+      raise # this reraises the error after we document it
+    end
+    result
   end
 
   def solr_delete
@@ -24,7 +35,8 @@ module SolrIndexable
   end
 
   def solr_index_job
-    SolrIndexJob.perform_later(self)
+    current_batch_connection&.save
+    SolrIndexJob.perform_later(self, current_batch_process, current_batch_connection) if solr_index_jobs.empty?
   end
 
   def to_solr(json_to_index = nil)

--- a/spec/jobs/generate_manifest_job_spec.rb
+++ b/spec/jobs/generate_manifest_job_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe GenerateManifestJob, type: :job do
       let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
 
       it 'notifies on Solr index failure' do
-        allow(parent_object).to receive(:solr_index).and_raise('boom!')
+        allow(parent_object).to receive(:solr_index_job).and_raise('boom!')
         expect(parent_object).to receive(:processing_event).twice
         expect { generate_manifest_job.perform(parent_object, batch_process) }.to raise_error('boom!')
       end
 
       it 'notifies when save fails' do
         allow(parent_object.iiif_presentation).to receive(:save).and_return(false)
-        expect(parent_object).to receive(:processing_event).twice
+        expect(parent_object).to receive(:processing_event).with("IIIF Manifest not saved to S3", "failed")
         generate_manifest_job.perform(parent_object, batch_process)
       end
 

--- a/spec/jobs/solr_index_job_spec.rb
+++ b/spec/jobs/solr_index_job_spec.rb
@@ -15,4 +15,13 @@ RSpec.describe SolrIndexJob, type: :job do
       SolrIndexJob.perform_later(parent_object)
     end.to change { Delayed::Job.count }.by(1)
   end
+
+  it 'increments the job queue by just one with multiple calls to solr_index_job' do
+    ActiveJob::Base.queue_adapter = :delayed_job
+    expect do
+      parent_object.solr_index_job
+      parent_object.solr_index_job
+      parent_object.solr_index_job
+    end.to change { Delayed::Job.count }.by(1)
+  end
 end

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.file = csv_upload
           batch_process.save
           expect(ParentObject.count).to eq(5)
-          expect(IngestEvent.count).to eq(456)
+          expect(IngestEvent.count).to eq(466)
         end
 
         it "fails if the user is not an editor on the admin set of the parent object" do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         batch_process.save
         batch_process.run_callbacks :create
       end.to change { batch_process.batch_connections.where(connectable_type: "ParentObject").count }.from(0).to(5)
-        .and change { IngestEvent.count }.from(0).to(456)
+        .and change { IngestEvent.count }.from(0).to(466)
       statuses = IngestEvent.all.map(&:status)
       expect(statuses).to include "processing-queued"
       expect(statuses).to include "metadata-fetched"


### PR DESCRIPTION
- Only queue a SolrIndexJob if there is not one already in place for the parent
- Change Manifest job to perform index asynchronously using a separate job (as we do in other places)
- Move processing events that were in manifest jobs synchronous indexing to parent object so they are always sent to the batch