### PR TITLE
Child object parent title should expect an array

### DIFF
--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -53,7 +53,7 @@ module Reassociatable
       elsif h == 'call_number'
         co.parent_object.call_number = row[h]
       elsif h == 'parent_title'
-        co.parent_object.authoritative_json["title"] = row[h]
+        co.parent_object.authoritative_json["title"] = row[h].split("  ")
       elsif values_to_update.include? h
         if h == 'label'
           co.label = row[h]

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -53,7 +53,7 @@ module Reassociatable
       elsif h == 'call_number'
         co.parent_object.call_number = row[h]
       elsif h == 'parent_title'
-        co.parent_object.authoritative_json["title"] = row[h].split("  ")
+        co.parent_object.authoritative_json["title"] = row[h]&.split("  ")
       elsif values_to_update.include? h
         if h == 'label'
           co.label = row[h]

--- a/spec/fixtures/csv/reassociation_example_child_object_all_columns.csv
+++ b/spec/fixtures/csv/reassociation_example_child_object_all_columns.csv
@@ -1,2 +1,2 @@
 child_oid,parent_oid,order,parent_title,call_number,label,caption,viewing_hint
-1030368,2005512,1,[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion],GEN MSS 257,,,
+1030368,2005512,1,The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion,GEN MSS 257,,,

--- a/spec/system/batch_process_reassociation_spec.rb
+++ b/spec/system/batch_process_reassociation_spec.rb
@@ -35,14 +35,13 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     end
 
     it "does not update already existing values if column is missing" do
-      # byebug
       expect(page).to have_content "Your job is queued for processing in the background"
       co = parent_object.child_objects.first
       expect(co.order).to eq 1
       expect(co.label).to be_nil
       expect(co.caption).to be_nil
       expect(co.viewing_hint).to be_nil
-      expect(co.parent_object.authoritative_json["title"]).to eq "[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion]"
+      expect(co.parent_object.authoritative_json["title"]).to eq ["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion"]
       expect(co.parent_object.call_number).to eq "GEN MSS 257"
       # csv has only child oid, parent oid, and label
       visit batch_processes_path
@@ -55,7 +54,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       expect(co.label).to eq "note"
       expect(co.caption).to be_nil
       expect(co.viewing_hint).to be_nil
-      expect(co.parent_object.authoritative_json["title"]).to eq "[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion]"
+      expect(co.parent_object.authoritative_json["title"]).to eq ["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion"]
       expect(co.parent_object.call_number).to eq "GEN MSS 257"
     end
   end
@@ -78,7 +77,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       expect(co.label).to be_nil
       expect(co.caption).to be_nil
       expect(co.viewing_hint).to be_nil
-      expect(co.parent_object.authoritative_json["title"]).to eq "[The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion]"
+      expect(co.parent_object.authoritative_json["title"]).to eq ["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion"]
       expect(co.parent_object.call_number).to eq "GEN MSS 257"
     end
   end


### PR DESCRIPTION
# Summary
Updates expectation and how parent title's are stored in reassociation.

# Related Ticket
[#1584](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1584)