### PR TITLE
Adds error handling to reassociate child oid job

### DIFF
--- a/app/jobs/reassociate_child_oids_job.rb
+++ b/app/jobs/reassociate_child_oids_job.rb
@@ -9,5 +9,7 @@ class ReassociateChildOidsJob < ApplicationJob
 
   def perform(batch_process)
     batch_process.reassociate_child_oids
+  rescue => e
+    batch_process.batch_processing_event("ReassociateChildOidsJob failed due to #{e.message}", "failed")
   end
 end

--- a/spec/jobs/reassociate_child_oids_job_spec.rb
+++ b/spec/jobs/reassociate_child_oids_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReassociateChildOidsJob, type: :job do
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::DelayedJobAdapter.new
+  end
+
+  let(:metadata_job) { ReassociateChildOidsJob.new }
+
+  it 'increments the job queue by one' do
+    ActiveJob::Base.queue_adapter = :delayed_job
+    expect do
+      ReassociateChildOidsJob.perform_later(metadata_job)
+    end.to change { Delayed::Job.count }.by(1)
+  end
+
+  context 'job fails' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:batch_process) { FactoryBot.create(:batch_process, batch_action: 'reassociate child oids', user: user) }
+    let(:metadata_source) { FactoryBot.create(:metadata_source) }
+
+    it 'notifies on save failure' do
+      allow(batch_process).to receive(:reassociate_child_oids).and_raise('boom!')
+      expect { metadata_job.perform(batch_process) }.to change { IngestEvent.count }.by(1)
+      expect(IngestEvent.last.reason).to eq "ReassociateChildOidsJob failed due to boom!"
+      expect(IngestEvent.last.status).to eq "failed"
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Adds error handling to ReassociateChildOidsJob.  Job will not retry and will log an error to the user.

# Related Ticket
[#1608](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1608)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/133509669-a134fd5a-22ce-4039-8fc2-633de6d4db2f.png)
