### PR TITLE
remove last > from hierarchy structure

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -234,7 +234,8 @@ module SolrIndexable
     ancestor_title.each do |anc|
       prev_string += (ancestor_title[arr_size - 1]).to_s + " > " unless arr_size.zero?
       anc = prev_string + anc + " > "
-      anc_struct.push(anc)
+      formatted = anc[0...-3]
+      anc_struct.push(formatted)
       arr_size += 1
     end
     anc_struct

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -170,9 +170,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
         expect(solr_document[:ancestorTitles_tesim]).to include "Oversize",
                                                                 "Abraham Lincoln collection (GEN MSS 257)",
                                                                 "Beinecke Rare Book and Manuscript Library (BRBL)"
-        expect(solr_document[:ancestor_titles_hierarchy_ssim].first).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > "
-        expect(solr_document[:ancestor_titles_hierarchy_ssim][1]).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257) > "
-        expect(solr_document[:ancestor_titles_hierarchy_ssim].last).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257) > Oversize > "
+        expect(solr_document[:ancestor_titles_hierarchy_ssim].first).to eq "Beinecke Rare Book and Manuscript Library (BRBL)"
+        expect(solr_document[:ancestor_titles_hierarchy_ssim][1]).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257)"
+        expect(solr_document[:ancestor_titles_hierarchy_ssim].last).to eq "Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257) > Oversize"
         expect(solr_document[:collection_title_ssi]).to include "Abraham Lincoln collection (GEN MSS 257)"
         expect(solr_document[:ancestorDisplayStrings_tesim]).to include "Oversize, n.d.",
                                                                         "Abraham Lincoln collection",


### PR DESCRIPTION
# Summary
Remove last ">" from the ancestor_titles_hierarchy structure.  

Before: 
![Image 2021-09-16 at 2 32 47 PM](https://user-images.githubusercontent.com/24666568/133690693-67306365-c1db-47b5-ac72-0faf21584778.jpg)  
  
After:  
![Image 2021-09-16 at 2 34 22 PM](https://user-images.githubusercontent.com/24666568/133690710-31e3ea55-b6f7-46f0-90ea-9359bfec8a1a.jpg)
  
  
NOTE: This will affect Blacklight specs once it gets merged. Particularly the view_fields_in_search_spec.rb, since it expects the hierarchy structure to have the ">"s
 
