### PR TITLE
Changed circle ci to use latest solr i1545

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           POSTGRES_PASSWORD: password
           SOLR_CORE: blacklight-test
           SOLR_BASE_URL: http://localhost:8983/solr
-      - image: yalelibraryit/dc-solr:1362_fulltext_suggest_retain_case
+      - image: yalelibraryit/dc-solr:v1.0.8
         command: bash -c 'precreate-core blacklight-test /opt/config; chown -R solr:solr /var/solr/data/ ; /boot.sh'
       - image: circleci/postgres:9.5-alpine-ram
         environment:


### PR DESCRIPTION
Co-authored-by: Keith Boyd-Carter <keith.boyd-carter@yale.edu>
Co-authored-by: McClain Looney <mcclain@curationexperts.com>

**Story**

We want to use the latest Solr release, v1.0.8; however,  the configuration file references a branch build.

**Acceptance**
- [x] use the latest Solr image. 
