### PR TITLE
added project identifier(ID) to parent objects

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -182,7 +182,7 @@ class ParentObjectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def parent_object_params
-      cur_params = params.require(:parent_object).permit(:oid, :admin_set, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
+      cur_params = params.require(:parent_object).permit(:oid, :admin_set, :project_identifier, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
                                                          :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
                                                          :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization, :digitization_note)
       cur_params[:admin_set] = AdminSet.find_by(key: cur_params[:admin_set])

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -101,6 +101,7 @@ module SolrIndexable
       orbisBarcode_ssi: barcode,
       orbisBibId_ssi: bib, # may change to orbisBibId
       preferredCitation_tesim: json_to_index["preferredCitation"],
+      project_identifier_tesi: json_to_index["project_identifier"],
       projection_tesim: json_to_index["projection"],
       public_bsi: true, # TEMPORARY, makes everything public
       publisher_tesim: json_to_index["publisher"],

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -28,6 +28,15 @@
        %>
     </div>
 
+    <div class="col-med-9">
+      <%= form.label :project_identifier, "Project ID" %>
+      <%= form.text_field :project_identifier %>
+    </div>
+
+  </div>
+  <br>
+
+  <div class="form-row">
     <div class="col-med-3">
       <%= form.label "Metadata Source" %>
       <%= form.select(:authoritative_metadata_source_id, [['Ladybird', 1], ['Voyager', 2], ['ArchiveSpace', 3]]) %>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -11,6 +11,11 @@
 </p>
 
 <p>
+  <strong>Project ID:</strong>
+  <%= @parent_object&.project_identifier %>
+</p>
+
+<p>
   <strong>MetadataCloud url:</strong><br>
   <small>Note: add "&mediaType=json" or "?mediaType=json" to open in your browser</small><br>
   <%= link_to "#{@parent_object.metadata_cloud_url}", "#{@parent_object.metadata_cloud_url}" %>

--- a/db/migrate/20210928204548_add_project_identifier_to_parent_object.rb
+++ b/db/migrate/20210928204548_add_project_identifier_to_parent_object.rb
@@ -1,0 +1,6 @@
+class AddProjectIdentifierToParentObject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :parent_objects, :project_identifier, :string
+    add_index  :parent_objects, :project_identifier unless index_exists?(:parent_objects, :project_identifier)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_02_190339) do
+ActiveRecord::Schema.define(version: 2021_09_28_204548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,9 +158,11 @@ ActiveRecord::Schema.define(version: 2021_09_02_190339) do
     t.string "digitization_note"
     t.string "call_number"
     t.string "container_grouping"
+    t.string "project_identifier"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true
+    t.index ["project_identifier"], name: "index_parent_objects_on_project_identifier"
   end
 
   create_table "preservica_ingests", force: :cascade do |t|

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -640,6 +640,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     it "has the expected defaults" do
       po = described_class.new
       expect(po.oid).to be nil
+      expect(po.project_identifier).to be nil
       expect(po.bib).to be nil
       expect(po.holding).to be nil
       expect(po.item).to be nil

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         expect(page).to have_content("This is a rights statement")
       end
 
+      it "can set the Project ID via the UI" do
+        click_on("Create Parent object")
+        click_on("Edit")
+        expect(page).to have_field("Project ID")
+        fill_in("Project ID", with: "This is the Project ID")
+        click_on(UPDATE_PARENT_OBJECT_BUTTON)
+        expect(page).to have_content("This is the Project ID")
+      end
+
       it "can show the representative thumbnail via the UI" do
         click_on("Create Parent object")
         expect(page).to have_content("Children:")


### PR DESCRIPTION
# Summary
Added project_identifier to Parent Objects.
Added the project_identifier index
Made requested view edits to the parent object showpage and edit page:  
  
![Image 2021-09-28 at 2 33 04 PM](https://user-images.githubusercontent.com/24666568/135169032-dfc447f9-7ca7-4b3d-8ba3-6991f62c526e.jpg)
  
  
![Image 2021-09-28 at 2 33 15 PM](https://user-images.githubusercontent.com/24666568/135169048-8c65c3f8-936b-4642-837e-8c65626bf2e3.jpg)  
  
NOTE: 
Do we want to add project_identifier to the search fields in Blacklight?