### PR TITLE
Restore repository_ssi field to Solr index

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -112,6 +112,7 @@ module SolrIndexable
       publisher_ssim: json_to_index["publisher"],
       recordType_ssi: json_to_index["recordType"],
       relatedResourceOnline_ssim: json_to_index["relatedResourceOnline"],
+      repository_ssi: json_to_index["repository"],
       repository_ssim: json_to_index["repository"],
       resourceType_ssim: json_to_index["itemType"],
       resourceType_tesim: json_to_index["itemType"],


### PR DESCRIPTION
Adds the repository_ssi field back after the archival branch merge.  See #798 