### PR TITLE
removes last > from ancestor_titles_hierarchy_ssim

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -247,7 +247,8 @@ module SolrIndexable
     ancestor_title.each do |anc|
       prev_string += (ancestor_title[arr_size - 1]).to_s + " > " unless arr_size.zero?
       anc = prev_string + anc + " > "
-      anc_struct.push(anc)
+      formatted = anc[0...-3]
+      anc_struct.push(formatted)
       arr_size += 1
     end
     anc_struct


### PR DESCRIPTION
# Summary
Formatted the ancestor_structure method to remove the last ">" from ancestor_titles_hierarchy_ssim.  
  
![Image 2021-09-16 at 2 34 22 PM](https://user-images.githubusercontent.com/24666568/135355989-7e0d928e-d93f-46ab-b2f1-9d20629c8df0.jpg)

