### PR TITLE
Adds validation for metadata source during update parent object

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -232,6 +232,16 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     object.current_batch_connection.save! if object.class == ChildObject
   end
 
+  # CHECKS THAT METADATA SOURCE IS VALID - USED BY UPDATE
+  def validate_metadata_source(metadata_source, index)
+    if metadata_source == 'aspace' || metadata_source == 'ils' || metadata_source == 'ladybird'
+      true
+    else
+      batch_processing_event("Skipping row [#{index + 2}] with unknown metadata source: #{metadata_source}.  Accepted values are 'ladybird', 'aspace', or 'ils'.", 'Skipped Row')
+      false
+    end
+  end
+
   # RECREATE CHILD OID PTIFFS: -------------------------------------------------------------------- #
 
   # RECREATES CHILD OID PTIFFS FROM INGESTED CSV

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -25,6 +25,7 @@ module Updatable
       metadata_source = row['source'].presence || parent_object.authoritative_metadata_source.metadata_cloud_name
 
       processed_fields = validate_field(parent_object, row)
+      next unless validate_metadata_source(metadata_source, index)
       setup_for_background_jobs(parent_object, metadata_source)
       parent_object.update(processed_fields)
       trigger_setup_metadata(parent_object)

--- a/spec/fixtures/csv/update_example_invalid_source.csv
+++ b/spec/fixtures/csv/update_example_invalid_source.csv
@@ -1,0 +1,2 @@
+oid,source,admin_set
+2005512,bird,brbl

--- a/spec/system/batch_process_update_parent_spec.rb
+++ b/spec/system/batch_process_update_parent_spec.rb
@@ -127,6 +127,27 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     end
   end
 
+  context "with a user with edit permissions but with invalid metadata source value", solr: true do
+    context "updating a batch of parent objects" do
+      before do
+        login_as user
+        user.add_role(:editor, admin_set)
+      end
+
+      it "triggers a metadata update" do
+        # perform batch update
+        visit batch_processes_path
+        select("Update Parent Objects")
+        page.attach_file("batch_process_file", Rails.root + "spec/fixtures/csv/update_example_invalid_source.csv")
+        click_button("Submit")
+
+        visit "/batch_processes/#{BatchProcess.last.id}/"
+        expect(page).to have_content "Batch status unknown"
+        expect(page).to have_content "Skipping row [2] with unknown metadata source: bird. Accepted values are 'ladybird', 'aspace', or 'ils'."
+      end
+    end
+  end
+
   context "with a user without edit permissions" do
     let(:admin_user) { FactoryBot.create(:sysadmin_user) }
 


### PR DESCRIPTION
# Summary
Update parent object jobs were failing silently when a user input an invalid metadata source.  This MR will provide an error message to the user.

# Related Ticket
[#1653](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1653)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/135537746-31e9e3e6-7a11-407b-ab03-4994db8df7c8.png)
