### PR TITLE
Updates webpacker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'turbolinks', '~> 5'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 4.0'
+gem 'webpacker'
 
 gem 'daemons'
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,7 @@ GEM
       rubyzip (>= 1.2.2)
     semantic_logger (4.7.4)
       concurrent-ruby (~> 1.0)
+    semantic_range (3.0.0)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
     simplecov (0.16.1)
@@ -417,10 +418,11 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webpacker (4.3.0)
-      activesupport (>= 4.2)
+    webpacker (5.4.3)
+      activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
-      railties (>= 4.2)
+      railties (>= 5.2)
+      semantic_range (>= 2.3.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -483,7 +485,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webmock (~> 3.8, >= 3.8.3)
-  webpacker (~> 4.0)
+  webpacker
 
 BUNDLED WITH
    2.1.4

--- a/babel.config.js
+++ b/babel.config.js
@@ -60,6 +60,12 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-property-in-object',
+        {
+          loose: true
+        }
+      ],
+      [
         '@babel/plugin-transform-runtime',
         {
           helpers: false,

--- a/babel.config.js
+++ b/babel.config.js
@@ -54,6 +54,12 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true
+        }
+      ],
+      [
         '@babel/plugin-transform-runtime',
         {
           helpers: false,


### PR DESCRIPTION
# Summary
Resolves babel warning output by upgrading webpacker gem. Also, sets the babel `plugin-proposal-private-method` & `plugin-proposal-private-property-in-object` loose settings to true to address warning from babel.

# Related Ticket
[#1671](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1671)

# Screenshot
Only raise errors in CI rspec output
![image](https://user-images.githubusercontent.com/36549923/136122263-56c23a5a-e7b2-44b0-a6de-3b05e5b3fccb.png)
