### PR TITLE
Resolves warning for more specific raise error matcher

### DIFF
--- a/spec/jobs/generate_ptiff_job_spec.rb
+++ b/spec/jobs/generate_ptiff_job_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe GeneratePtiffJob, type: :job do
       allow(child_object).to receive(:convert_to_ptiff!).and_return(false)
       expect do
         generate_ptiff_job.perform(child_object, batch_process)
-      end.to raise_error
+      end.to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       # rubocop:enable RSpec/AnyInstance
       expect do
         child_object.convert_to_ptiff
-      end.to raise_error
+      end.to raise_error(RuntimeError)
     end
   end
 


### PR DESCRIPTION
# Summary
Rspec output cluttered with warnings regarding non specific 'raise_error' usage.  This PR adds a more specific expected error to the specs that were causing the output.

# Related Ticket
[#1670](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1670)

# Screenshots
## Before
![image](https://user-images.githubusercontent.com/36549923/136116823-2d2f8362-4885-4311-bea6-70674ea7176f.png)
![image](https://user-images.githubusercontent.com/36549923/136116858-41f29f0a-0a16-41b1-8e8a-0db543fa845b.png)

## After
![image](https://user-images.githubusercontent.com/36549923/136116888-214185c2-454d-4fa0-b7b1-4f834e37e5f2.png)
![image](https://user-images.githubusercontent.com/36549923/136116929-5d4c2e9f-d843-46e2-a0b2-4ab79635ea52.png)
