### PR TITLE
Adds project identifier to update parent batch process

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -35,7 +35,7 @@ module Updatable
   end
 
   def validate_field(parent_object, row)
-    fields = ['aspace_uri', 'barcode', 'bib', 'digitization_note', 'holding', 'item', 'rights_statement']
+    fields = ['aspace_uri', 'barcode', 'bib', 'digitization_note', 'holding', 'item', 'project_identifier', 'rights_statement']
     validation_fields = { "display_layout" => 'viewing_hints', "extent_of_digitization" => 'extent_of_digitizations', "viewing_direction" => 'viewing_directions', "visibility" => 'visibilities' }
 
     processed_fields = {}

--- a/public/batch_processes/templates/update_parent_objects.csv
+++ b/public/batch_processes/templates/update_parent_objects.csv
@@ -1,1 +1,1 @@
-oid,source,admin_set,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout
+oid,source,admin_set,project_identifier,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout

--- a/spec/fixtures/csv/update_example.csv
+++ b/spec/fixtures/csv/update_example.csv
@@ -1,2 +1,2 @@
-oid,source,admin_set,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout
-2034600,ladybird,brbl,Public,The use of this image may be subject to the copyright law of the United States,Completely digitized,5678,12307100,temporary,reel,39002102340669,/repositories/11/archival_objects/515305,left-to-right,paged
+oid,source,admin_set,project_identifier,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout
+2034600,ladybird,brbl,Beinecke,Public,The use of this image may be subject to the copyright law of the United States,Completely digitized,5678,12307100,temporary,reel,39002102340669,/repositories/11/archival_objects/515305,left-to-right,paged

--- a/spec/fixtures/csv/update_example_small.csv
+++ b/spec/fixtures/csv/update_example_small.csv
@@ -1,2 +1,2 @@
-oid,source,admin_set,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout
-2005512,ladybird,brbl,Public,The use of this image may be subject to the copyright law of the United States,Completely digitized,5678,12307100,temporary,reel,39002102340669,/repositories/11/archival_objects/515305,left-to-right,paged
+oid,source,admin_set,project_identifier,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout
+2005512,ladybird,brbl,Beinecke,Public,The use of this image may be subject to the copyright law of the United States,Completely digitized,5678,12307100,temporary,reel,39002102340669,/repositories/11/archival_objects/515305,left-to-right,paged

--- a/spec/system/batch_process_update_parent_spec.rb
+++ b/spec/system/batch_process_update_parent_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(p_o.holding).to be_nil
         expect(p_o.item).to be_nil
         expect(p_o.barcode).to eq("39002093768050")
+        expect(p_o.project_identifier).to be_nil
 
         # perform batch update
         visit batch_processes_path
@@ -48,6 +49,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(p_o_a.holding).to eq("temporary")
         expect(p_o_a.item).to eq("reel")
         expect(p_o_a.barcode).to eq("39002102340669")
+        expect(p_o_a.project_identifier).to eq("Beinecke")
 
         visit "/batch_processes/#{BatchProcess.last.id}/parent_objects/2005512"
         expect(page).to have_content "Status Complete"
@@ -69,6 +71,8 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(p_o.holding).to be_nil
         expect(p_o.item).to be_nil
         expect(p_o.barcode).to eq("39002093768050")
+        # column not present - should not update value
+        expect(p_o.project_identifier).to be_nil
 
         # perform batch update
         visit batch_processes_path
@@ -81,6 +85,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(p_o.holding).to be_nil
         expect(p_o.item).to be_nil
         expect(p_o.barcode).to eq("39002093768050")
+        expect(p_o.project_identifier).to be_nil
 
         visit "/batch_processes/#{BatchProcess.last.id}/parent_objects/2005512"
         expect(page).to have_content "Status Complete"


### PR DESCRIPTION
# Summary
Add the project identifier field to the fields available to be updated via batch process.

# Related Ticket
[#1677](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1677)

# Screenshots

### CSV Template
<img width="622" alt="image" src="https://user-images.githubusercontent.com/36549923/136245740-020ada5a-d430-4b65-8125-70ec10df5a00.png">

### Updated Parent when using ' ' for value remains nil
![image](https://user-images.githubusercontent.com/36549923/136245683-d2e17380-7f75-4d71-9bea-840f3b445210.png)
