### PR TITLE
Ensures project identifier can index to solr document

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -106,7 +106,7 @@ module SolrIndexable
       orbisBarcode_ssi: barcode,
       orbisBibId_ssi: bib, # may change to orbisBibId
       preferredCitation_tesim: json_to_index["preferredCitation"],
-      project_identifier_tesi: json_to_index["project_identifier"],
+      project_identifier_tesi: generate_pid(json_to_index["project_identifier"], oid),
       projection_tesim: json_to_index["projection"],
       public_bsi: true, # TEMPORARY, makes everything public
       publisher_tesim: json_to_index["publisher"],
@@ -256,5 +256,11 @@ module SolrIndexable
 
   def generate_hash
     Digest::MD5.hexdigest oid.to_s
+  end
+
+  def generate_pid(project_identifier, oid)
+    parent_object = ParentObject.find_by(oid: oid)
+    # byebug
+    project_identifier.presence || parent_object.project_identifier || " "
   end
 end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -260,7 +260,6 @@ module SolrIndexable
 
   def generate_pid(project_identifier, oid)
     parent_object = ParentObject.find_by(oid: oid)
-    # byebug
-    project_identifier.presence || parent_object.project_identifier || " "
+    project_identifier.presence || parent_object.project_identifier || "unspecified"
   end
 end

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -260,6 +260,6 @@ module SolrIndexable
 
   def generate_pid(project_identifier, oid)
     parent_object = ParentObject.find_by(oid: oid)
-    project_identifier.presence || parent_object.project_identifier || "unspecified"
+    project_identifier.presence || parent_object&.project_identifier || nil
   end
 end

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -73,6 +73,12 @@ METADATA_FIELDS = {
       'projection_tesim'
     ]
   },
+  project_identifier: {
+    label: 'Project ID',
+    solr_fields: [
+      'project_identifier_tesi'
+    ]
+  },
   scale: {
     label: 'Scale',
     solr_fields: [

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe SolrIndexable, type: :model do
     expect(solr_document[:languageCode_ssim]).to eq(['eng'])
     expect(solr_document[:language_ssim]).to eq(['English'])
   end
+
+  it "indexes the project identifier" do
+    solr_document = solr_indexable.to_solr('project_identifier' => ['project id'])
+    expect(solr_document[:project_identifier_tesi]).to eq(['project id'])
+  end
 end

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       solr_document = parent_object.reload.to_solr
       expect(solr_document[:thumbnail_path_ss]).to eq "http://localhost:8182/iiif/2/1126257/full/!200,200/0/default.jpg"
     end
+
+    it "can index project identifier" do
+      parent_object.project_identifier = "Library"
+      parent_object.save!
+      solr_document = parent_object.reload.to_solr
+      expect(solr_document[:project_identifier_tesi]).to eq "Library"
+    end
   end
 
   describe "changing the authoritative metadata source", solr: true do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         parent_of_four.setup_metadata_job
       end
     end
+
     # rubocop:enable RSpec/AnyInstance
     context "with full_text? true" do
       around do |example|
@@ -451,7 +452,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
                          "/aspace/repositories/11/archival_objects/555042",
                          "/aspace/repositories/11/archival_objects/554841",
                          "/aspace/repositories/11/resources/1453"].to_set
-        puts(parent_object.reload.dependent_objects.map(&:dependent_uri))
         expect(parent_object.reload.dependent_objects.count).to eq expected_uris.count
         expect(parent_object.dependent_objects.all? { |dobj| dobj.metadata_source == 'aspace' }).to be_truthy
         uris = parent_object.dependent_objects.map(&:dependent_uri).to_set


### PR DESCRIPTION
# Summary
Ensures that a value will be saved to the solr document for the project identifier field.

# Related Ticket
[#1655](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1665)

# Screenshots
![image](https://user-images.githubusercontent.com/36549923/137023291-c2a8c30a-56c3-49a0-aaa2-9562a73da7ba.png)

![image](https://user-images.githubusercontent.com/36549923/137023007-c90b7b40-1a7f-456a-adf7-c00e40a05b66.png)

![image](https://user-images.githubusercontent.com/36549923/137022891-b5f3e02b-9c77-4e5d-b133-f17de8cd7fdb.png)
