### PR TITLE
Generate ancestor titles for breadcrumbs

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -51,8 +51,8 @@ module SolrIndexable
       alternativeTitle_tesim: json_to_index["alternativeTitle"],
       alternativeTitleDisplay_tesim: json_to_index["alternativeTitleDisplay"],
       ancestorDisplayStrings_tesim: json_to_index["ancestorDisplayStrings"],
-      ancestorTitles_tesim: json_to_index["ancestorTitles"],
-      ancestor_titles_hierarchy_ssim: ancestor_structure(json_to_index["ancestorTitles"]),
+      ancestorTitles_tesim: generate_ancestor_title(json_to_index["ancestorTitles"]),
+      ancestor_titles_hierarchy_ssim: ancestor_structure(generate_ancestor_title(json_to_index["ancestorTitles"])),
       archivalSort_ssi: json_to_index["archivalSort"],
       archiveSpaceUri_ssi: aspace_uri,
       callNumber_ssim: json_to_index["callNumber"],
@@ -265,5 +265,10 @@ module SolrIndexable
 
   def generate_digitization_note(digitization_note)
     digitization_note.presence || self&.digitization_note || nil
+  end
+
+  # not ASpace records will use the repository value
+  def generate_ancestor_title(ancestor_title)
+    ancestor_title.presence || [self&.admin_set&.label] || nil
   end
 end

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SolrIndexable, type: :model do
     solr_document = solr_indexable.to_solr('digitization_note' => ['digitization note'])
     expect(solr_document[:digitization_note_tesi]).to eq(['digitization note'])
   end
-  
+
   it "indexes the ancestor titles" do
     solr_document = solr_indexable.to_solr('ancestorTitles' => ['ancestor title'])
     expect(solr_document[:ancestorTitles_tesim]).to eq(['ancestor title'])

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -24,4 +24,9 @@ RSpec.describe SolrIndexable, type: :model do
     solr_document = solr_indexable.to_solr('digitization_note' => ['digitization note'])
     expect(solr_document[:digitization_note_tesi]).to eq(['digitization note'])
   end
+  
+  it "indexes the ancestor titles" do
+    solr_document = solr_indexable.to_solr('ancestorTitles' => ['ancestor title'])
+    expect(solr_document[:ancestorTitles_tesim]).to eq(['ancestor title'])
+  end
 end

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -206,6 +206,12 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
         expect(solr_document[:title_tsim]).to eq ["Walt Whitman collection, 1842-1949"]
         expect(solr_document[:visibility_ssi]).to include "Public"
       end
+      
+      it "can generate ancestor titles" do
+        solr_document = parent_object_with_public_visibility.reload.to_solr
+        expect(solr_document[:ancestorTitles_tesim]).to eq ["MyString"]
+        expect(solr_document[:ancestor_titles_hierarchy_ssim]).to eq ["MyString"]
+      end
     end
 
     context "with mocked items without a metadatacloud equivalent" do

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
         expect(solr_document[:title_tsim]).to eq ["Walt Whitman collection, 1842-1949"]
         expect(solr_document[:visibility_ssi]).to include "Public"
       end
-      
+
       it "can generate ancestor titles" do
         solr_document = parent_object_with_public_visibility.reload.to_solr
         expect(solr_document[:ancestorTitles_tesim]).to eq ["MyString"]


### PR DESCRIPTION
# Summary
For non ASpace records they will use the repository value for the ancestor titles so that in Blacklight it displays the breadcrumb for Voyager records as well.

# Related Ticket
[#1630](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1630)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/138147082-b3b14551-9364-475c-a988-de50ad0a3fb4.png)
