### PR TITLE
Adds check for empty arrays

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -178,7 +178,7 @@ module SolrIndexable
       subject_topic_tsim: json_to_index["subjectTopic"], # replaced by subjectTopic_tesim and subjectTopic_ssim
       title_tsim: json_to_index["title"], # replaced by title_tesim
       type_ssi: 'parent'
-    }.delete_if { |_k, v| !v.present? } # Delete nil and empty values
+    }.delete_if { |_k, v| v.blank? } # Delete nil, [], and empty string values
   end
 
   def to_solr_full_text(json_to_index = nil)

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       expect(solr_document.values).not_to include("")
     end
 
+    it "does not have empty arrays in to_solr hash" do
+      parent_object.bib = []
+      parent_object.save!
+      solr_document = parent_object.reload.to_solr
+      expect(solr_document.values).not_to include([])
+    end
+
     it "will index the count of child objects" do
       solr_document = parent_object.reload.to_solr
       expect(solr_document[:imageCount_isi]).to eq 1


### PR DESCRIPTION
# Summary
Prior implementation used a `! .present?` which did not check for empty arrays so those were getting stored in solr and displaying the header information for these empty fields in the UV details.  This PR changes the guard to check for and reject empty arrays from being stored in Solr.

# Related Ticket
[#1673](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1673)