### PR TITLE
Add guard for missing rights statement

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -233,7 +233,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.barcode = lb_record["orbisBarcode"]
     self.aspace_uri = lb_record["archiveSpaceUri"]
     self.visibility = lb_record["itemPermission"].nil? ? "Private" : lb_record["itemPermission"]
-    self.rights_statement = lb_record["rights"].join("\n")
+    self.rights_statement = lb_record["rights"]&.join("\n")
     self.extent_of_digitization = normalize_extent_of_digitization
     self.use_ladybird = false
   end


### PR DESCRIPTION
Add guard so that ladybird authority records without "rights" property can still be indexed.