### PR TITLE
Remove nil child object full text from array before indexing with SOLR

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -196,7 +196,7 @@ module SolrIndexable
 
         child_object_to_solr(child_object, child_object_full_text) unless child_object_full_text.nil?
       end
-      return full_text_array
+      return full_text_array.compact
     end
     nil
   end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -96,6 +96,11 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           expect(solr_document).not_to be_nil
           expect(solr_document[:has_fulltext_ssi].to_s).to eq "Partial"
         end
+        it "does not include nil in child records" do
+          child_solr_documents = parent_of_four.to_solr_full_text.second
+          expect(child_solr_documents).not_to be_nil
+          expect(child_solr_documents).not_to include(nil)
+        end
       end
 
       context "with full text in s3" do


### PR DESCRIPTION
Compact the child object full text array so nils are not added to SOLR record.