### PR TITLE
Set project_identifier the first time LB metadata is set

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -235,6 +235,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.visibility = lb_record["itemPermission"].nil? ? "Private" : lb_record["itemPermission"]
     self.rights_statement = lb_record["rights"]&.join("\n")
     self.extent_of_digitization = normalize_extent_of_digitization
+    self.project_identifier = lb_record["projectId"]
     self.use_ladybird = false
   end
 

--- a/spec/fixtures/ladybird/2004628.json
+++ b/spec/fixtures/ladybird/2004628.json
@@ -68,5 +68,6 @@
   ],
   "abstract": [
     "A series of six framed oil paintings, four of them attributed to Paul Kane. Paintings depict Fort Vancouver, Snake River, buffalo, and buffalo hunting. This painting was a part of Mr. Coe's gift of his Western Collection, acquired from the widow of a grandson of Sir George Simpson, Governor of the Hudson’s Bay Company’s Territories in North America."
-  ]
+  ],
+  "projectId": 8
 }

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -233,6 +233,20 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     end
   end
 
+  context do
+    let(:parent_object) { FactoryBot.create(:parent_object) }
+
+    it "will not overwrite the project id set after initial ingest" do
+      json = JSON.parse(File.open("spec/fixtures/ladybird/2004628.json").read)
+      parent_object.ladybird_json = json
+      expect(parent_object.project_identifier).to eq "8"
+      parent_object.project_identifier = 3
+      parent_object.save!
+      parent_object.ladybird_json = json
+      expect(parent_object.project_identifier).to eq "3"
+    end
+  end
+
   context "a newly created ParentObject with different visibilities" do
     let(:parent_object_nil) { described_class.create(visibility: nil) }
     it "nil does not validate" do


### PR DESCRIPTION
- New imports of Ladybird objects read the field and store it in the Parent Object
- Metadata Updates of existing objects do not overwrite or change the value of the field in the Parent Object.