### PR TITLE
Add simple object ingest

### DIFF
--- a/app/datatables/child_object_datatable.rb
+++ b/app/datatables/child_object_datatable.rb
@@ -22,6 +22,7 @@ class ChildObjectDatatable < AjaxDatatablesRails::ActiveRecord
       height: { source: 'ChildObject.height' },
       order: { source: 'ChildObject.order' },
       parent_object: { source: 'ChildObject.parent_object_oid' },
+      original_oid: { source: 'ChildObject.original_oid' },
       actions: { source: 'ChildObject.oid' }
     }
   end
@@ -37,6 +38,7 @@ class ChildObjectDatatable < AjaxDatatablesRails::ActiveRecord
         height: child_object.height,
         order: child_object.order,
         parent_object: child_object.parent_object_oid,
+        original_oid: child_object.original_oid,
         actions: actions(child_object).html_safe,
         DT_RowId: child_object.oid
       }

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -163,6 +163,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     parsed_csv.each_with_index do |row, index|
       oid = row['oid']
       metadata_source = row['source']
+      simple_object = row['parent_model'] == 'simple'
       admin_set = editable_admin_set(row['admin_set'], oid, index)
       next unless admin_set
 
@@ -172,6 +173,8 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         batch_processing_event("Skipping row [#{index + 2}] with existing parent oid: #{oid}", 'Skipped Row')
         next
       end
+
+      parent_object.simple_object = simple_object
 
       setup_for_background_jobs(parent_object, metadata_source)
       parent_object.admin_set = admin_set

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -163,7 +163,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     parsed_csv.each_with_index do |row, index|
       oid = row['oid']
       metadata_source = row['source']
-      simple_object = row['parent_model'] == 'simple'
+      model = row['parent_model'] | 'complex'
       admin_set = editable_admin_set(row['admin_set'], oid, index)
       next unless admin_set
 
@@ -174,7 +174,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         next
       end
 
-      parent_object.simple_object = simple_object
+      parent_object.parent_model = model
 
       setup_for_background_jobs(parent_object, metadata_source)
       parent_object.admin_set = admin_set

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -163,7 +163,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     parsed_csv.each_with_index do |row, index|
       oid = row['oid']
       metadata_source = row['source']
-      model = row['parent_model'] | 'complex'
+      model = row['parent_model'] || 'complex'
       admin_set = editable_admin_set(row['admin_set'], oid, index)
       next unless admin_set
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -94,7 +94,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     else
       return unless ladybird_json
-      return self.child_object_count = 0 if ladybird_json["children"].empty? && !simple_object
+      return self.child_object_count = 0 if ladybird_json["children"].empty? && parent_model != 'simple'
       upsert_child_objects(array_of_child_hashes)
     end
     self.child_object_count = child_objects.size
@@ -129,7 +129,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def array_of_child_hashes
     return unless ladybird_json
-    if simple_object
+    if parent_model == "simple"
       array_of_child_hashes_for_simple
     else
       ladybird_json["children"].map.with_index(1) do |child_record, index|

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # A parent object is the unit of discovery (what is represented as a single record in Blacklight).
 # It is synonymous with a parent oid in Ladybird.
+require 'fileutils'
 
 class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_paper_trail
@@ -93,7 +94,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     else
       return unless ladybird_json
-      return self.child_object_count = 0 if ladybird_json["children"].empty?
+      return self.child_object_count = 0 if ladybird_json["children"].empty? && !simple_object
       upsert_child_objects(array_of_child_hashes)
     end
     self.child_object_count = child_objects.size
@@ -128,16 +129,55 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def array_of_child_hashes
     return unless ladybird_json
-    ladybird_json["children"].map.with_index(1) do |child_record, index|
-      {
-        oid: child_record["oid"],
-        # Ladybird has only one field for both order label (7v, etc.), and descriptive captions ("Mozart at the Keyboard")
-        # For the first iteration we will map this field to label
-        label: child_record["caption"],
-        order: index,
-        parent_object_oid: oid
-      }
+    if simple_object
+      array_of_child_hashes_for_simple
+    else
+      ladybird_json["children"].map.with_index(1) do |child_record, index|
+        {
+          oid: child_record["oid"],
+          # Ladybird has only one field for both order label (7v, etc.), and descriptive captions ("Mozart at the Keyboard")
+          # For the first iteration we will map this field to label
+          label: child_record["caption"],
+          order: index,
+          parent_object_oid: oid
+        }
+      end
     end
+  end
+
+  def array_of_child_hashes_for_simple
+    new_oid = process_simple_object
+    [{
+      oid: new_oid,
+      original_oid: oid,
+      label: ladybird_json['title'][0],
+      order: 0,
+      parent_object_oid: oid
+    }]
+  end
+
+  # Mint new oid for child, rename access master tif to the new oid filename
+  def process_simple_object
+    image_mount = ENV['ACCESS_MASTER_MOUNT'] || "data"
+    new_oid = OidMinterService.generate_oids(1)[0]
+    pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
+    new_pairtree_path = Partridge::Pairtree.oid_to_pairtree(new_oid)
+
+    if image_mount == "s3"
+      ## should we move the file on S3? Probably not.  Image mount is s3 only in dev environments.
+      ## S3Service.move_image(File.join(pairtree_path, "#{oid}.tif"), File.join(new_pairtree_path, "#{new_oid}.tif"))
+    else
+      directory = format("%02d", pairtree_path.first)
+      parent_access_master_path = File.join(image_mount, directory, pairtree_path, "#{oid}.tif")
+
+      new_directory = format("%02d", new_pairtree_path.first)
+      FileUtils.mkdir_p(File.join(image_mount, new_directory, new_pairtree_path))
+      child_access_master_path = File.join(image_mount, new_directory, new_pairtree_path, "#{new_oid}.tif")
+
+      FileUtils.move parent_access_master_path, child_access_master_path
+    end
+
+    new_oid
   end
 
   def assign_dependent_objects(json = authoritative_json)

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -151,7 +151,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       oid: new_oid,
       original_oid: oid,
       label: ladybird_json['title'][0],
-      order: 0,
+      order: 1,
       parent_object_oid: oid
     }]
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -167,14 +167,18 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       ## should we move the file on S3? Probably not.  Image mount is s3 only in dev environments.
       ## S3Service.move_image(File.join(pairtree_path, "#{oid}.tif"), File.join(new_pairtree_path, "#{new_oid}.tif"))
     else
-      directory = format("%02d", pairtree_path.first)
-      parent_access_master_path = File.join(image_mount, directory, pairtree_path, "#{oid}.tif")
+      begin
+        directory = format("%02d", pairtree_path.first)
+        parent_access_master_path = File.join(image_mount, directory, pairtree_path, "#{oid}.tif")
 
-      new_directory = format("%02d", new_pairtree_path.first)
-      FileUtils.mkdir_p(File.join(image_mount, new_directory, new_pairtree_path))
-      child_access_master_path = File.join(image_mount, new_directory, new_pairtree_path, "#{new_oid}.tif")
+        new_directory = format("%02d", new_pairtree_path.first)
+        FileUtils.mkdir_p(File.join(image_mount, new_directory, new_pairtree_path))
+        child_access_master_path = File.join(image_mount, new_directory, new_pairtree_path, "#{new_oid}.tif")
 
-      FileUtils.move parent_access_master_path, child_access_master_path
+        FileUtils.move parent_access_master_path, child_access_master_path
+      rescue => e
+        Rails.logger.error("Unable to rename simple parent access master for parent_oid: #{oid} and new child: #{new_oid}: #{e}")
+      end
     end
 
     new_oid

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -130,6 +130,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def array_of_child_hashes
     return unless ladybird_json
     if parent_model == "simple"
+      raise "Can not import a Parent as simple if it has Children" if ladybird_json["children"].present?
       array_of_child_hashes_for_simple
     else
       ladybird_json["children"].map.with_index(1) do |child_record, index|

--- a/app/views/child_objects/index.html.erb
+++ b/app/views/child_objects/index.html.erb
@@ -22,6 +22,7 @@
           <th scope='col'>Height</th>
           <th scope='col'>Order</th>
           <th scope='col'>Parent Object</th>
+          <th scope='col'>Original Oid</th>
           <th scope='col'>Actions</th>
         </tr>
       </thead>

--- a/app/views/child_objects/show.html.erb
+++ b/app/views/child_objects/show.html.erb
@@ -50,6 +50,13 @@
   <%= image_tag @child_object.thumbnail_url %>
 </p>
 
+<% if @child_object.original_oid %>
+<p>
+  <strong>Original OID:</strong><br />
+  <%= @child_object.original_oid %>
+</p>
+<% end %>
+
 
 <% if can? :edit, @child_object %>
   <%= link_to 'Edit', edit_child_object_path(@child_object) %> |

--- a/db/migrate/20211025231147_simple_objects_migration.rb
+++ b/db/migrate/20211025231147_simple_objects_migration.rb
@@ -1,0 +1,7 @@
+class SimpleObjectsMigration < ActiveRecord::Migration[6.0]
+  def change
+    add_column :child_objects, :original_oid, :integer
+    add_index  :child_objects, :original_oid unless index_exists?(:child_objects, :original_oid)
+    add_column :parent_objects, :simple_object, :boolean
+  end
+end

--- a/db/migrate/20211025231147_simple_objects_migration.rb
+++ b/db/migrate/20211025231147_simple_objects_migration.rb
@@ -2,6 +2,7 @@ class SimpleObjectsMigration < ActiveRecord::Migration[6.0]
   def change
     add_column :child_objects, :original_oid, :integer
     add_index  :child_objects, :original_oid unless index_exists?(:child_objects, :original_oid)
-    add_column :parent_objects, :simple_object, :boolean
+    add_column :parent_objects, :parent_model, :string
+    ParentObject.update_all("parent_model = 'complex'")
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,6 @@ ActiveRecord::Schema.define(version: 2021_10_25_231147) do
     t.string "viewing_hint"
     t.datetime "ptiff_conversion_at"
     t.string "mets_access_master_path"
-    t.boolean "full_text", default: false
     t.integer "original_oid"
     t.index ["caption"], name: "index_child_objects_on_caption"
     t.index ["label"], name: "index_child_objects_on_label"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 2021_10_25_231147) do
     t.string "call_number"
     t.string "container_grouping"
     t.string "project_identifier"
-    t.boolean "simple_object"
+    t.string "parent_model"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_28_204548) do
+ActiveRecord::Schema.define(version: 2021_10_25_231147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,10 +73,13 @@ ActiveRecord::Schema.define(version: 2021_09_28_204548) do
     t.string "viewing_hint"
     t.datetime "ptiff_conversion_at"
     t.string "mets_access_master_path"
+    t.boolean "full_text", default: false
+    t.integer "original_oid"
     t.index ["caption"], name: "index_child_objects_on_caption"
     t.index ["label"], name: "index_child_objects_on_label"
     t.index ["oid"], name: "index_child_objects_on_oid", unique: true
     t.index ["order"], name: "index_child_objects_on_order"
+    t.index ["original_oid"], name: "index_child_objects_on_original_oid"
     t.index ["parent_object_oid"], name: "index_child_objects_on_parent_object_oid"
   end
 
@@ -159,6 +162,7 @@ ActiveRecord::Schema.define(version: 2021_09_28_204548) do
     t.string "call_number"
     t.string "container_grouping"
     t.string "project_identifier"
+    t.boolean "simple_object"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true

--- a/spec/datatables/child_object_datatable_spec.rb
+++ b/spec/datatables/child_object_datatable_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ChildObjectDatatable, type: :datatable, prep_metadata_sources: tr
       height: 1,
       order: 1,
       parent_object: 2_004_628,
+      original_oid: nil,
       actions:
       "<a data-confirm=\"Are you sure?\" rel=\"nofollow\" data-method=\"delete\" href=\"/management/child_objects/10736292\"><i class=\"fa fa-trash\"></i></a>",
       DT_RowId: 10_736_292

--- a/spec/fixtures/ladybird/2038133.json
+++ b/spec/fixtures/ladybird/2038133.json
@@ -1,0 +1,102 @@
+{
+  "jsonModelType": "LadybirdSolrRecord",
+  "source": "ladybird",
+  "recordType": "oid",
+  "uri": "/ladybird/oid/2038133",
+  "callNumber": "YCAL MSS 175",
+  "containerGrouping": "Folder 92",
+  "folder": "Folder 92",
+  "sourceCreator": "Jordan, Viola Baxter, 1887-1973",
+  "sourceTitle": "Viola Baxter Jordan Papers",
+  "sourceDate": "1905-1951",
+  "creator": [
+    "Rachewiltz, Mary de"
+  ],
+  "title": [
+    "[Autographed letter signed], 1946 March 29, Gais, Brunico, Bolzano, [Italy] [to] Mrs. Jordan"
+  ],
+  "creationPlace": [
+    "Gais, Brunico, Bolzano, [Italy]"
+  ],
+  "date": [
+    "1946 March 29"
+  ],
+  "extent": [
+    "1 l.",
+    "29 cm."
+  ],
+  "language": [
+    "English"
+  ],
+  "description": [
+    "Preservation photocopy available in library: original material restricted",
+    "Signed: \"Mary Rudge\"",
+    "Verso blank"
+  ],
+  "subjectName": [
+    "Jordan, Viola Baxter, 1887-1973",
+    "Pound, Ezra, 1885-1972",
+    "Rachewiltz, Mary de",
+    "Rudge, Olga"
+  ],
+  "subjectTopic": [
+    "Coffee",
+    "Imprisonment",
+    "World War, 1939-1945--Food supply",
+    "World War, 1939-1945--Personal narratives"
+  ],
+  "genre": [
+    "Autographs",
+    "Correspondence"
+  ],
+  "format": [
+    "text"
+  ],
+  "partOf": "Beinecke Library",
+  "rights": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "orbisBibId": "6296696",
+  "findingAid": [
+    "http://hdl.handle.net/10079/fa/beinecke.jordan"
+  ],
+  "itemPermission": "Public",
+  "dateStructured": [
+    "1946"
+  ],
+  "intStartYear": "1946",
+  "subjectEra": "World War, 1939-1945--Personal narratives",
+  "contributor": [
+    "Jordan, Viola Baxter, 1887-1973",
+    "Pound, Ezra, 1885-1972",
+    "Rachewiltz, Mary de",
+    "Rudge, Olga"
+  ],
+  "repository": "Beinecke Library",
+  "subjectTitle": "World War, 1939-1945--Personal narratives",
+  "subjectGeographic": [
+    "Italy"
+  ],
+  "subjectTitleDisplay": [
+    "Coffee",
+    "Imprisonment",
+    "World War, 1939-1945--Food supply",
+    "World War, 1939-1945--Personal narratives"
+  ],
+  "creatorDisplay": [
+    "Rachewiltz, Mary de"
+  ],
+  "contributorDisplay": [
+    "Jordan, Viola Baxter, 1887-1973",
+    "Pound, Ezra, 1885-1972",
+    "Rachewiltz, Mary de",
+    "Rudge, Olga"
+  ],
+  "dependentUris": [
+    "/ladybird/oid/2038133"
+  ],
+  "oid": 2038133,
+  "collectionId": 1,
+  "projectId": 3,
+  "children": []
+}

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -493,7 +493,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
 
       context "imported as a simple  object, with parent oid access master tif in place" do
-        let(:parent_object) { described_class.create(oid: "2038133", simple_object: true, admin_set: FactoryBot.create(:admin_set)) }
+        let(:parent_object) { described_class.create(oid: "2038133", parent_model: 'simple', admin_set: FactoryBot.create(:admin_set)) }
 
         around do |example|
           FileUtils.mkdir_p("spec/fixtures/images/access_masters/03/33/20/38/13/")

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -14,9 +14,12 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     ENV['SAMPLE_BUCKET'] = "yul-dc-development-samples"
     original_path_ocr = ENV['OCR_DOWNLOAD_BUCKET']
     ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
+    original_access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
+    ENV["ACCESS_MASTER_MOUNT"] = File.join("spec", "fixtures", "images", "access_masters")
     example.run
     ENV['SAMPLE_BUCKET'] = original_metadata_sample_bucket
     ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
+    ENV["ACCESS_MASTER_MOUNT"] = original_access_master_mount
   end
 
   before do
@@ -487,6 +490,42 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
 
       it 'returns an aspace url' do
         expect(parent_object.aspace_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/aspace/repositories/11/archival_objects/608223"
+      end
+
+      context "imported as a simple  object, with parent oid access master tif in place" do
+        let(:parent_object) { described_class.create(oid: "2038133", simple_object: true, admin_set: FactoryBot.create(:admin_set)) }
+
+        around do |example|
+          FileUtils.mkdir_p("spec/fixtures/images/access_masters/03/33/20/38/13/")
+          FileUtils.touch("spec/fixtures/images/access_masters/03/33/20/38/13/2038133.tif")
+          example.run
+          FileUtils.remove("spec/fixtures/images/access_masters/00/00/20/00/00/00/200000000.tif")
+        end
+
+        before do
+          allow(OidMinterService).to receive(:generate_oids).and_return([200_000_000])
+          stub_metadata_cloud("2038133")
+        end
+
+        it "will create ParentObject and ChildObject" do
+          parent_object.reload
+          expect(parent_object.oid).to eq(2_038_133)
+          expect(parent_object.child_objects.count).to eq(1)
+          child_object = parent_object.child_objects.first
+          expect(child_object.oid).to eq(200_000_000)
+        end
+
+        it "will set ChildObject original_oid on to ParentObject oid from LB" do
+          parent_object.reload
+          child_object = parent_object.child_objects.first
+          expect(child_object.original_oid).to eq(2_038_133)
+        end
+
+        it "will move the access master tiff" do
+          parent_object.reload
+          expect(File.exist?("spec/fixtures/images/access_masters/00/00/20/00/00/00/200000000.tif")).to be_truthy
+          expect(File.exist?("spec/fixtures/images/access_masters/03/33/20/38/13/2038133.tif")).to be_falsey
+        end
       end
 
       context "with the wrong metadata_cloud_version set" do


### PR DESCRIPTION
Adds Simple Object ingest

- Adds original_oid to ChildObject to hold original parent oid for image tracking
- Adds simple_object boolean to ParentObject to help with ingest.
- Create Parent Object batch can now have parent_model column which can be set to "simple"
- If a ParentObject is marked as simple in the CSV, the child is created with a new OID and the parent image is move to the newly minted oid location in access masters.

From there, normal processing finishes creation.