### PR TITLE
Clear the interval when the page changes.

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -239,8 +239,11 @@ function select_all( select ) {
 // This will refresh batch process datatable every 30 seconds
 $( document ).on('turbolinks:load', function() {
     if ( dataTable && $(".is-datatable").data("refresh")) {
-      setInterval(function () {
+      let interval = setInterval(function () {
         dataTable.api().ajax.reload(null, false);
       }, 30000  );
+      $(document).on('turbolinks:before-cache turbolinks:before-render', function() {
+        clearTimeout(interval);
+      });
     }
 })


### PR DESCRIPTION
Clear the table refresh interval when turbo links loads another page.