### PR TITLE
Remove delayed job query from ERB

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -59,7 +59,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.cannot_reindex
-    return true if Delayable.solr_reindex_jobs.count.positive?
+    return true unless Delayable.solr_reindex_jobs.empty?
   end
 
   # Returns true if last_ladybird_update has changed from nil to some value, indicating initial ladybird fetch

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -6,7 +6,7 @@
   <div class='col'>
     <div class='float-right button-list'>
       <%= button_to 'Reindex', reindex_parent_objects_path, method: 'post', class: 'btn button secondary-button', id: 'reindex',
-        data:( ParentObject.cannot_reindex ? nil : { confirm: 'Are you sure you want to proceed? This action will reindex the entire contents of the system.' }),
+        data: { confirm: 'Are you sure you want to proceed? This action will reindex the entire contents of the system.' },
         disabled: !(can? :reindex_all, ParentObject)
       %>
       <%= button_to 'Update Metadata', all_metadata_parent_objects_path, method: 'post', class: 'btn button secondary-button',


### PR DESCRIPTION
- Removes check for reindex all job in ERB which caused performance problems (and is called during rendering)
- Replace call to count.positive? with exists?
