### PR TITLE
Add Image ID: oid to PDF pages

### DIFF
--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -69,7 +69,10 @@ module PdfRepresentable
           "caption" => child['label'] || "",
           "file" => S3Service.presigned_url(child.remote_ptiff_path, 24_000)
         }
-        page['properties'] = [{ 'name' => 'Caption:', 'value' => child.caption }] if child.caption.present?
+        properties = []
+        properties << { 'name' => 'Caption:', 'value' => child.caption } if child.caption.present?
+        properties << { 'name' => 'Image ID:', 'value' => child.oid.to_s }
+        page['properties'] = properties if properties.present?
         pages << page
       end
       pages

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -392,6 +392,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         expect(parent_object.remote_pdf_path).not_to be_nil
       end
 
+      it "generates pdf json with the image ids for each child" do
+        pdf_json = parent_object.pdf_generator_json
+        parent_object.child_objects.each do |child|
+          expect(pdf_json).to include('{"name":"Image ID:","value":"' + child.oid.to_s + '"}')
+        end
+      end
+
       it "returns true from needs_a_manifest? only one time" do
         parent_object.generate_manifest = true
         parent_object.save!


### PR DESCRIPTION
Adds image id to each page of the PDF:

Sample PDF:

[https://app.zenhub.com/files/242185115/baa73276-928c-48ab-b208-90ec26bc9367/download](https://app.zenhub.com/files/242185115/baa73276-928c-48ab-b208-90ec26bc9367/download)