### PR TITLE
Fixed parent object fulltext status bug

### DIFF
--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -103,7 +103,7 @@
 
 <p>
   <strong>Full Text Available:</strong>
-  <%= @parent_object.full_text? %>
+  <%= @parent_object.extent_of_full_text %>
 </p>
 
 <p>


### PR DESCRIPTION
**Story**

When 1 or more children attached to a parent have a full text status of No, the Parent Object full text status should show as "partial".

Currently, the full text status for a Parent Object shows as true, even if 1 or more children don't have full text e.g https://collections-uat.library.yale.edu/management/parent_objects/15475232. The status of true should only display for parents where all children have full text. If no children have full text, the status at the parent level should display as false. 

**Acceptance**
- [x] Parents with 1 or more children without full text display the full text status "partial"
 
![Screen Shot 2021-11-04 at 1 22 57 PM](https://user-images.githubusercontent.com/41123693/140388815-ae27c3be-8b0f-4708-9456-9bb1da4467d7.png)


