### PR TITLE
Automate scheduled metadata updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,8 +88,8 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'coveralls', require: false
   gem 'ffaker'
-  gem 'timecop'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.0'
+  gem 'timecop'
   gem 'webdrivers'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'activerecord-nulldb-adapter'
+# Reoccurring jobs
+gem 'activejob-scheduler', git: 'https://github.com/yalelibrary/activejob-scheduler', branch: 'main'
 gem 'ajax-datatables-rails'
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'coveralls', require: false
   gem 'ffaker'
+  gem 'timecop'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.0'
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,6 +409,7 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timecop (0.9.4)
     tins (1.25.0)
       sync
     travis-release (0.0.4)
@@ -501,6 +502,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.0)
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   vcr (~> 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/yalelibrary/activejob-scheduler
+  revision: 22850499dd0ab046eff2e1c113261782e7b8d8dc
+  branch: main
+  specs:
+    activejob-scheduler (1.0.0.pre)
+      actionmailer (> 5, < 7)
+      activejob (> 5, < 7)
+      activesupport (> 5, < 7)
+      fugit (~> 1.3)
+      travis-release (~> 0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -141,6 +153,8 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
+    et-orbi (1.2.6)
+      tzinfo
     execjs (2.7.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
@@ -156,6 +170,9 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fugit (1.5.2)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
     github_changelog_generator (1.15.2)
       activesupport
       faraday-http-cache
@@ -258,6 +275,7 @@ GEM
     public_suffix (4.0.6)
     puma (4.3.9)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-protection (2.0.8.1)
@@ -393,6 +411,9 @@ GEM
     tilt (2.0.10)
     tins (1.25.0)
       sync
+    travis-release (0.0.4)
+      bundler
+      rake
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -434,6 +455,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activejob-scheduler!
   activerecord-nulldb-adapter
   ajax-datatables-rails
   amazing_print (>= 1.2.1)

--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -123,3 +123,7 @@ DEFAULT DESKTOP STYLING
 .clear-filters-button {
   margin-right: 8px
 }
+
+.reoccurring-notice p {
+  font-size: 18px;
+}

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ReoccurringJobsController < ApplicationController
+  def index
+    @reoccuring_jobs = ActivityStreamLog.all
+    respond_to do |format|
+      format.html
+      format.json { render json: ReoccurringJobDatatable.new(params, view_context: view_context) }
+    end
+  end
+
+  # GET /reoccuring_jobs/1
+  # GET /reoccuring_jobs/1.json
+  def show
+    respond_to do |format|
+      format.html
+      format.json { render json: ReoccuringJobDatatable.new(params, view_context: view_context) }
+    end
+  end
+
+  # GET /reoccuring_jobs/new
+  def new
+    ActivityStreamReader.update
+  end
+
+  # GET /reoccuring_jobs/1/edit
+  def edit; end
+
+end

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -21,6 +21,10 @@ class ReoccurringJobsController < ApplicationController
   # POST ActivityStreamReader
   def create
     ActivityStreamReader.update
+    respond_to do |format|
+      format.html { redirect_to reoccurring_job_url, notice: 'Metadata update queued.' }
+      format.json { head :no_content }
+    end
   end
 
   # GET /reoccuring_jobs/1/edit

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -29,5 +29,4 @@ class ReoccurringJobsController < ApplicationController
 
   # GET /reoccuring_jobs/1/edit
   def edit; end
-
 end

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -22,7 +22,7 @@ class ReoccurringJobsController < ApplicationController
   def create
     ActivityStreamReader.update
     respond_to do |format|
-      format.html { redirect_to reoccurring_job_url, notice: 'Metadata update queued.' }
+      format.html { redirect_to reoccurring_jobs_url, notice: 'Metadata update queued.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -2,7 +2,7 @@
 
 class ReoccurringJobsController < ApplicationController
   def index
-    @reoccuring_jobs = ActivityStreamLog.all
+    @reoccurring_jobs = ActivityStreamLog.all
     respond_to do |format|
       format.html
       format.json { render json: ReoccurringJobDatatable.new(params, view_context: view_context) }
@@ -14,7 +14,7 @@ class ReoccurringJobsController < ApplicationController
   def show
     respond_to do |format|
       format.html
-      format.json { render json: ReoccuringJobDatatable.new(params, view_context: view_context) }
+      format.json { render json: ReoccurringJobDatatable.new(params, view_context: view_context) }
     end
   end
 

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -18,8 +18,8 @@ class ReoccurringJobsController < ApplicationController
     end
   end
 
-  # GET /reoccuring_jobs/new
-  def new
+  # POST ActivityStreamReader
+  def create
     ActivityStreamReader.update
   end
 

--- a/app/datatables/reoccurring_job_datatable.rb
+++ b/app/datatables/reoccurring_job_datatable.rb
@@ -14,13 +14,13 @@ class ReoccurringJobDatatable < AjaxDatatablesRails::ActiveRecord
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      process_id: { source:  "ActivityStreamLog.id", cond: :eq, searchable: true, orderable: true },
+      process_id: { source:  "ActivityStreamLog.id", cond: :eq, orderable: true },
       run_time: { source: "ActivityStreamLog.run_time", cond: :start_with, orderable: true },
       items: { source:  "ActivityStreamLog.activity_stream_items", cond: :like, orderable: true },
-      status: { source:  "ActivityStreamLog.status", searchable: false, orderable: false },
-      created: { source:  "ActivityStreamLog.created_at", searchable: false, orderable: false },
-      updated: { source:  "ActivityStreamLog.updated_at", searchable: false, orderable: false },
-      retrieved_records: { source:  "ActivityStreamLog.retrieved_records", searchable: true, orderable: true }
+      status: { source:  "ActivityStreamLog.status", searchable: false, orderable: true },
+      created: { source:  "ActivityStreamLog.created_at", searchable: false, orderable: true },
+      updated: { source:  "ActivityStreamLog.updated_at", searchable: false, orderable: true },
+      retrieved_records: { source:  "ActivityStreamLog.retrieved_records", orderable: true }
     }
   end
 

--- a/app/datatables/reoccurring_job_datatable.rb
+++ b/app/datatables/reoccurring_job_datatable.rb
@@ -14,13 +14,13 @@ class ReoccurringJobDatatable < AjaxDatatablesRails::ActiveRecord
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      process_id: { source:  "ActivityStreamLog.id", cond: :eq, orderable: true },
+      process_id: { source: "ActivityStreamLog.id", cond: :eq, orderable: true },
       run_time: { source: "ActivityStreamLog.run_time", cond: :start_with, orderable: true },
-      items: { source:  "ActivityStreamLog.activity_stream_items", cond: :like, orderable: true },
-      status: { source:  "ActivityStreamLog.status", searchable: false, orderable: true },
+      items: { source: "ActivityStreamLog.activity_stream_items", cond: :like, orderable: true },
+      status: { source: "ActivityStreamLog.status", searchable: false, orderable: true },
       created: { source:  "ActivityStreamLog.created_at", searchable: false, orderable: true },
       updated: { source:  "ActivityStreamLog.updated_at", searchable: false, orderable: true },
-      retrieved_records: { source:  "ActivityStreamLog.retrieved_records", orderable: true }
+      retrieved_records: { source: "ActivityStreamLog.retrieved_records", orderable: true }
     }
   end
 
@@ -34,12 +34,13 @@ class ReoccurringJobDatatable < AjaxDatatablesRails::ActiveRecord
         status: activity_stream.status,
         created: activity_stream.created_at,
         updated: activity_stream.updated_at,
-        retrieved_records: activity_stream.retrieved_records }
+        retrieved_records: activity_stream.retrieved_records
+      }
     end
     # rubocop:enable Rails/OutputSafety
   end
 
   def get_raw_records # rubocop:disable Naming/AccessorMethodName
-   ActivityStreamLog.all
+    ActivityStreamLog.all
   end
 end

--- a/app/datatables/reoccurring_job_datatable.rb
+++ b/app/datatables/reoccurring_job_datatable.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class ReoccurringJobDatatable < AjaxDatatablesRails::ActiveRecord
+  extend Forwardable
+
+  def_delegators :@view, :link_to, :reoccurring_jobs_path
+
+  def initialize(params, opts = {})
+    @view = opts[:view_context]
+    super
+  end
+
+  def view_columns
+    # Declare strings in this format: ModelName.column_name
+    # or in aliased_join_table.column_name format
+    @view_columns ||= {
+      process_id: { source:  "ActivityStreamLog.id", cond: :eq, searchable: true, orderable: true },
+      run_time: { source: "ActivityStreamLog.run_time", cond: :start_with, orderable: true },
+      items: { source:  "ActivityStreamLog.activity_stream_items", cond: :like, orderable: true },
+      status: { source:  "ActivityStreamLog.status", searchable: false, orderable: false },
+      created: { source:  "ActivityStreamLog.created_at", searchable: false, orderable: false },
+      updated: { source:  "ActivityStreamLog.updated_at", searchable: false, orderable: false },
+      retrieved_records: { source:  "ActivityStreamLog.retrieved_records", searchable: true, orderable: true }
+    }
+  end
+
+  def data
+    # rubocop:disable Rails/OutputSafety
+    records.map do |activity_stream|
+      {
+        process_id: activity_stream.id,
+        run_time: activity_stream.run_time,
+        items: activity_stream.activity_stream_items,
+        status: activity_stream.status,
+        created: activity_stream.created_at,
+        updated: activity_stream.updated_at,
+        retrieved_records: activity_stream.retrieved_records }
+    end
+    # rubocop:enable Rails/OutputSafety
+  end
+
+  def get_raw_records # rubocop:disable Naming/AccessorMethodName
+   ActivityStreamLog.all
+  end
+end

--- a/app/jobs/activity_stream_job.rb
+++ b/app/jobs/activity_stream_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityStreamJob < ApplicationJob
-  repeat 'every day at 2am'
+  repeat 'every day at 1am'
 
   def perform
     ActivityStreamReader.update

--- a/app/jobs/activity_stream_job.rb
+++ b/app/jobs/activity_stream_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ActivityStreamJob < ApplicationJob
+  repeat 'every day at 2am'
+
+  def perform
+    ActivityStreamReader.update
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,6 +25,7 @@ class Ability
     can :read, ParentObject
     can :read, ChildObject
     can :read, PreservicaIngest
+    can :read, ReoccurringJobDatatable
     can :reindex_all, ParentObject
     can :update_metadata, ParentObject
     can :trigger_mets_scan, ParentObject

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -10,6 +10,7 @@
     <%= link_to 'Parent Objects', parent_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Child Objects', child_objects_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
+    <%= link_to 'Reoccurring Jobs', reoccurring_jobs_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Preservation', preservica_ingests_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% if current_user&.sysadmin %>
       <%= link_to 'Delayed Job Dashboard', delayed_job_web_path, class: 'list-group-item list-group-item-action bg-light' %>

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -2,19 +2,16 @@
 <div class='row datatable-heading'>
   <div class='col'>
     <h1>Reoccurring Jobs</h1>
-    <%
-=begin%>
- <%= render 'form' %> 
-<%
-=end%>
   </div>
   <div class='col'>
     <div class='float-right button-list'>
-      <%= button_to 'Trigger Job Manually', trigger_mets_scan_batch_processes_path, method: 'post', class: 'btn button secondary-button', data:{confirm: 'Are you sure you start a manual update outside of the regular schedule?'} %>
+      <%= button_to 'Trigger Job Manually', reoccurring_jobs_path, method: 'post', class: 'btn button secondary-button', data: {confirm: 'Are you sure you start a manual update outside of the regular schedule?'} %>
     </div>
   </div>
 </div>
-
+<div class='reoccurring-notice'>
+  <p>A reoccurring job is set to update metadata from Aspace and Voyager at 2:00am EST</p>
+</div><br />
 <div class='row datatable'>
   <div class='col overflow-auto'>
     <table id='reoccurring-job-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= reoccurring_jobs_path(format: :json) %>' data-refresh="true" >

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -10,7 +10,7 @@
   </div>
 </div>
 <div class='reoccurring-notice'>
-  <p>A reoccurring job is set to update metadata from Aspace and Voyager at 2:00am EST</p>
+  <p>A reoccurring job is set to update metadata from Aspace and Voyager at 1:00am EST</p>
 </div><br />
 <div class='row datatable'>
   <div class='col overflow-auto'>

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -1,0 +1,40 @@
+<%= render partial: '/management/flash_messages' %>
+<div class='row datatable-heading'>
+  <div class='col'>
+    <h1>Reoccurring Jobs</h1>
+    <%
+=begin%>
+ <%= render 'form' %> 
+<%
+=end%>
+  </div>
+  <div class='col'>
+    <div class='float-right button-list'>
+      <%= button_to 'Trigger Job Manually', trigger_mets_scan_batch_processes_path, method: 'post', class: 'btn button secondary-button', data:{confirm: 'Are you sure you start a manual update outside of the regular schedule?'} %>
+    </div>
+  </div>
+</div>
+
+<div class='row datatable'>
+  <div class='col overflow-auto'>
+    <table id='reoccuring-job-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= reoccuring_jobs_path(format: :json) %>' data-refresh="true" >
+      <thead class='table-head'>
+        <tr>
+          <th scope='col'>Process ID</th>
+          <th scope='col'>Run Time</th>
+          <th scope='col'>Items</th>
+          <th scope='col'>Status</th>
+          <th scope='col'>Created At</th>
+          <th scope='col'>Updated At</th>
+          <th scope='col'>Retrieved Records</th>
+        </tr>
+      </thead>
+      <tbody class='datatable-body'>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div id='reoccuring-job-data' class='d-none datatable-data'>
+  <%= ReoccurringJobDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
+</div>

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -17,7 +17,7 @@
 
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='reoccuring-job-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= reoccuring_jobs_path(format: :json) %>' data-refresh="true" >
+    <table id='reoccurring-job-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= reoccurring_jobs_path(format: :json) %>' data-refresh="true" >
       <thead class='table-head'>
         <tr>
           <th scope='col'>Process ID</th>
@@ -35,6 +35,6 @@
   </div>
 </div>
 
-<div id='reoccuring-job-data' class='d-none datatable-data'>
+<div id='reoccurring-job-data' class='d-none datatable-data'>
   <%= ReoccurringJobDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
 </div>

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -21,8 +21,8 @@
           <th scope='col'>Run Time</th>
           <th scope='col'>Items</th>
           <th scope='col'>Status</th>
-          <th scope='col'>Created At</th>
-          <th scope='col'>Updated At</th>
+          <th scope='col'>Created</th>
+          <th scope='col'>Updated</th>
           <th scope='col'>Retrieved Records</th>
         </tr>
       </thead>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resources :child_objects
   resources :admin_sets
   resources :preservica_ingests
+  resources :reoccurring_jobs
 
   resources :parent_objects do
     collection do

--- a/ops/nginx.sh
+++ b/ops/nginx.sh
@@ -16,12 +16,12 @@ declare -p | grep -Ev 'BASHOPTS|PWD|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /co
 
 if [[ $PASSENGER_APP_ENV == "development" ]] || [[ $PASSENGER_APP_ENV == "test" ]]
 then
-    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && yarn && bundle exec rails db:migrate db:seed db:test:prepare'
+    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && yarn && bundle exec rails db:migrate db:seed db:test:prepare activejob:schedule'
 fi
 
 if [[ $PASSENGER_APP_ENV == "production" ]] || [[ $PASSENGER_APP_ENV == "staging" ]]
 then
-    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && bundle exec rake db:migrate db:seed'
+    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && bundle exec rake db:migrate db:seed activejob:schedule'
     if [ -d /home/app/webapp/public/assets-new ]; then
         /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && rsync -aP public/assets-new/ public/assets/'
     fi

--- a/ops/nginx.sh
+++ b/ops/nginx.sh
@@ -16,12 +16,12 @@ declare -p | grep -Ev 'BASHOPTS|PWD|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /co
 
 if [[ $PASSENGER_APP_ENV == "development" ]] || [[ $PASSENGER_APP_ENV == "test" ]]
 then
-    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && yarn && bundle exec rails db:migrate db:seed db:test:prepare activejob:schedule'
+    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && yarn && bundle exec rails db:migrate db:seed db:test:prepare'
 fi
 
 if [[ $PASSENGER_APP_ENV == "production" ]] || [[ $PASSENGER_APP_ENV == "staging" ]]
 then
-    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && bundle exec rake db:migrate db:seed activejob:schedule'
+    /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && bundle exec rake db:migrate db:seed'
     if [ -d /home/app/webapp/public/assets-new ]; then
         /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && rsync -aP public/assets-new/ public/assets/'
     fi

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe ActivityStreamJob, type: :job do
       Timecop.return
     end
 
-    xit "increments job queue once per day" do
+    it "increments job queue once per day" do
       now = Time.zone.today
-      # `bundle exec rails activejob:schedule`
+      ActiveJob::Scheduler.start
       new_time = Time.zone.local(now.year, now.month, now.day + 1, 12, 0, 0)
       Timecop.travel(new_time)
       expect(Delayed::Job.count).to eq 1

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityStreamJob, type: :job do
+
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::DelayedJobAdapter.new
+  end
+
+  let(:metadata_job) { ActivityStreamJob.new }
+
+  it 'increments the job queue by one' do
+    ActiveJob::Base.queue_adapter = :delayed_job
+    expect do
+      ActivityStreamJob.perform_later(metadata_job)
+    end.to change { Delayed::Job.count }.by(1)
+  end
+
+  xit 'job fails' do
+
+  end
+
+  it 'happens at 1am daily' do
+    now = Time.current
+    expect do
+      travel 1.day
+    end.to change { ActivityStreamLog.count }.by(1)
+  end
+end

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ActivityStreamJob, type: :job do
       # `bundle exec rails activejob:schedule`
       new_time = Time.zone.local(now.year, now.month, now.day + 1, 12, 0, 0)
       Timecop.travel(new_time)
-      expect(ActivityStreamLog.count).to eq 1
+      expect(Delayed::Job.count).to eq 1
     end
   end
 end

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ActivityStreamJob, type: :job do
-
   def queue_adapter_for_test
     ActiveJob::QueueAdapters::DelayedJobAdapter.new
   end
@@ -17,25 +16,26 @@ RSpec.describe ActivityStreamJob, type: :job do
     end.to change { Delayed::Job.count }.by(1)
   end
 
-  xit 'job fails' do
-
+  it 'job fails when not on VPN' do
+    expect do
+      ActivityStreamReader.update
+    end.to raise_error HTTP::ConnectionError
   end
 
-  describe 'time travel tests' do 
+  describe 'automated daily job' do
     before do
-      Timecop.freeze(Date.today)
+      Timecop.freeze(Time.zone.today)
     end
-  
+
     after do
       Timecop.return
     end
-  
-    it "increment job queue once" do
-      new_time = Time.local(2021, 11, 5, 12, 0, 0)
+
+    it "increments job queue once per day" do
+      now = Time.zone.today
+      new_time = Time.zone.local(now.year, now.month, now.day + 1, 12, 0, 0)
       Timecop.travel(new_time)
       expect(ActivityStreamLog.count).to eq 1
     end
-  
   end
-  
 end

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe ActivityStreamJob, type: :job do
       Timecop.return
     end
 
-    it "increments job queue once per day" do
+    xit "increments job queue once per day" do
       now = Time.zone.today
+      # `bundle exec rails activejob:schedule`
       new_time = Time.zone.local(now.year, now.month, now.day + 1, 12, 0, 0)
       Timecop.travel(new_time)
       expect(ActivityStreamLog.count).to eq 1

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -31,16 +31,11 @@ RSpec.describe ActivityStreamJob, type: :job do
     end
   
     it "increment job queue once" do
-      byebug
-      # Timecop.free
+      new_time = Time.local(2021, 11, 5, 12, 0, 0)
+      Timecop.travel(new_time)
+      expect(ActivityStreamLog.count).to eq 1
     end
   
   end
-
-  it 'happens at 1am daily' do
-    now = Time.current
-    expect do
-      travel 1.day
-    end.to change { ActivityStreamLog.count }.by(1)
-  end
+  
 end

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe ActivityStreamJob, type: :job do
 
   end
 
+  describe 'time travel tests' do 
+    before do
+      Timecop.freeze(Date.today)
+    end
+  
+    after do
+      Timecop.return
+    end
+  
+    it "increment job queue once" do
+      byebug
+      # Timecop.free
+    end
+  
+  end
+
   it 'happens at 1am daily' do
     now = Time.current
     expect do


### PR DESCRIPTION
# Summary
Implement a scheduled job to run every night at 1 am that will enqueue an `ActivityStreamReader.update`

# Related Ticket
[#1620](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1620)

# Engineering Notes
UI and manual job button is currently setup and working.  TODO: Confirm that activejob-scheduler runs on schedule. (specs)

# Screenshots
Running task enqueues job at 1 am.
![image](https://user-images.githubusercontent.com/36549923/141343784-5cf4e8d4-593b-4232-aed2-68254cca609c.png)

![image](https://user-images.githubusercontent.com/36549923/141344199-bc6db06f-82f9-47f3-98a8-e19908421a3e.png)

