### PR TITLE
Add alternative dashboard for DelayedJob

### DIFF
--- a/app/controllers/delayed_job_dashboard_controller.rb
+++ b/app/controllers/delayed_job_dashboard_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+#
 
 class DelayedJobDashboardController < ApplicationController
   def index
@@ -33,7 +34,7 @@ class DelayedJobDashboardController < ApplicationController
 
   def show
     @job = Delayed::Job.find(params[:id])
-    @handler = YAML.safe_load(Delayed::Job.find(params[:id]).handler)
+    @handler = YAML.safe_load(@job.handler, [ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper])
   end
 
   def delete_job

--- a/app/controllers/delayed_job_dashboard_controller.rb
+++ b/app/controllers/delayed_job_dashboard_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class DelayedJobDashboardController < ApplicationController
+  def index
+    res = Delayed::Job.connection.execute("select count(*) as total,
+              sum(case when locked_at is not null and failed_at is null then 1 else 0 end) as working,
+              sum(case when last_error is not null then 1 else 0 end) as failed,
+              sum(case when attempts=0 and locked_at is null then 1 else 0 end) as pending
+              from delayed_jobs").first
+    @all_jobs_count = res['total']
+    @working = res['working']
+    @failed = res['failed']
+    @pending = res['pending']
+  end
+
+  def failed_jobs
+    @jobs = Delayed::Job.page(params[:page]).where("last_error is not null").order("run_at desc")
+    @job_types = "Failed"
+    render :jobs
+  end
+
+  def working_jobs
+    @jobs = Delayed::Job.page(params[:page]).where("locked_at is not null and failed_at is null").order("run_at desc")
+    @job_types = "Working"
+    render :jobs
+  end
+
+  def pending_jobs
+    @jobs = Delayed::Job.page(params[:page]).where("attempts=0 and locked_at is null").order("run_at desc")
+    @job_types = "Pending"
+    render :jobs
+  end
+
+  def show
+    @job = Delayed::Job.find(params[:id])
+    @handler = YAML.safe_load(Delayed::Job.find(params[:id]).handler)
+  end
+
+  def delete_job
+    Delayed::Job.find(params[:id]).destroy
+    flash[:notice] = "Job #{params[:id]} deleted."
+    redirect_to dashboard_path
+  end
+
+  def requeue
+    Delayed::Job.find(params[:id]).update!(run_at: Time.now.utc, last_error: nil)
+    flash[:notice] = "Job was re-queued"
+    redirect_to show_job_path(params[:id])
+  end
+end

--- a/app/views/delayed_job_dashboard/index.html.erb
+++ b/app/views/delayed_job_dashboard/index.html.erb
@@ -15,18 +15,18 @@
   </thead>
   <tr>
     <td> <%= link_to "Working", working_jobs_path %>  </td>
-    <td> <%= "#{@working}" %>  </td>
+    <td> <%= @working %>  </td>
   </tr>
   <tr>
     <td> <%= link_to "Pending", pending_jobs_path %></td>
-     <td> <%=  "#{@pending}" %></td>
+     <td> <%=  @pending %></td>
   </tr>
   <tr>
     <td> <%= link_to "Failed", failed_jobs_path %></td>
-    <td> <%= "#{@failed}" %></td>
+    <td> <%= @failed %></td>
   </tr>
 </table>
 
 <div class="dataTables_info" >
-<%= link_to 'View Old Dashboard', delayed_job_web_path %>
+  <%= link_to 'View Old Dashboard', delayed_job_web_path %>
 </div>

--- a/app/views/delayed_job_dashboard/index.html.erb
+++ b/app/views/delayed_job_dashboard/index.html.erb
@@ -14,16 +14,16 @@
   </tr>
   </thead>
   <tr>
-    <td> <%= link_to "Working #{@working}", working_jobs_path %>  </td>
-    <td> <%= link_to {@working} %>  </td>
+    <td> <%= link_to "Working", working_jobs_path %>  </td>
+    <td> <%= link_to "#{@working}" %>  </td>
   </tr>
   <tr>
-    <td> <%= link_to "Pending #{@pending}", pending_jobs_path %></td>
-     <td> <%= link_to {@pending} %> </td>
+    <td> <%= link_to "Pending", pending_jobs_path %></td>
+     <td> <%= link_to "#{@pending}" %></td>
   </tr>
   <tr>
-    <td> <%= link_to "Failed #{@failed}", failed_jobs_path %></td>
-    <td> <%= link_to  {@failed} %> </td>
+    <td> <%= link_to "Failed", failed_jobs_path %></td>
+    <td> <%= link_to  "#{@failed}" %></td>
   </tr>
 </table>
 

--- a/app/views/delayed_job_dashboard/index.html.erb
+++ b/app/views/delayed_job_dashboard/index.html.erb
@@ -15,15 +15,15 @@
   </thead>
   <tr>
     <td> <%= link_to "Working", working_jobs_path %>  </td>
-    <td> <%= link_to "#{@working}" %>  </td>
+    <td> <%= "#{@working}" %>  </td>
   </tr>
   <tr>
     <td> <%= link_to "Pending", pending_jobs_path %></td>
-     <td> <%= link_to "#{@pending}" %></td>
+     <td> <%=  "#{@pending}" %></td>
   </tr>
   <tr>
     <td> <%= link_to "Failed", failed_jobs_path %></td>
-    <td> <%= link_to  "#{@failed}" %></td>
+    <td> <%= "#{@failed}" %></td>
   </tr>
 </table>
 

--- a/app/views/delayed_job_dashboard/index.html.erb
+++ b/app/views/delayed_job_dashboard/index.html.erb
@@ -1,0 +1,9 @@
+<%= render partial: '/management/flash_messages' %>
+<pre>
+  Total Jobs: <%= @all_jobs_count %>
+  <%= link_to "Working Jobs: #{@working}", working_jobs_path %>
+  <%= link_to "Pending Jobs: #{@pending}", pending_jobs_path %>
+  <%= link_to "Failed Jobs: #{@failed}", failed_jobs_path %>
+</pre>
+
+<%= link_to 'Old Delayed Job Dashboard', delayed_job_web_path %>

--- a/app/views/delayed_job_dashboard/index.html.erb
+++ b/app/views/delayed_job_dashboard/index.html.erb
@@ -1,9 +1,32 @@
 <%= render partial: '/management/flash_messages' %>
-<pre>
-  Total Jobs: <%= @all_jobs_count %>
-  <%= link_to "Working Jobs: #{@working}", working_jobs_path %>
-  <%= link_to "Pending Jobs: #{@pending}", pending_jobs_path %>
-  <%= link_to "Failed Jobs: #{@failed}", failed_jobs_path %>
-</pre>
+<div class="datatable-heading">
+  <h1>Job Status</h1>
+</div>
+<div class = "JobTotal-subheading">
+  <h3>Total Jobs: <%= @all_jobs_count %></h3>
+</div>
 
-<%= link_to 'Old Delayed Job Dashboard', delayed_job_web_path %>
+<table class="table table-bordered table-responsive table-striped">
+  <thead class="thead-dark">
+  <tr>
+    <th scope="col"> Job Type </th>
+    <th scope="col"> Job Count </th>
+  </tr>
+  </thead>
+  <tr>
+    <td> <%= link_to "Working #{@working}", working_jobs_path %>  </td>
+    <td> <%= link_to {@working} %>  </td>
+  </tr>
+  <tr>
+    <td> <%= link_to "Pending #{@pending}", pending_jobs_path %></td>
+     <td> <%= link_to {@pending} %> </td>
+  </tr>
+  <tr>
+    <td> <%= link_to "Failed #{@failed}", failed_jobs_path %></td>
+    <td> <%= link_to  {@failed} %> </td>
+  </tr>
+</table>
+
+<div class="dataTables_info" >
+<%= link_to 'View Old Dashboard', delayed_job_web_path %>
+</div>

--- a/app/views/delayed_job_dashboard/jobs.html.erb
+++ b/app/views/delayed_job_dashboard/jobs.html.erb
@@ -1,0 +1,26 @@
+<h1>
+  <%= @job_types %> Jobs
+</h1>
+<%= paginate @jobs %>
+<table border=1>
+  <tr>
+    <th>Id</th>
+    <th>Attempts</th>
+    <th>Error</th>
+    <th>Run at</th>
+    <th>Failed at</th>
+    <th>Queue at</th>
+    <th>Created at at</th>
+  </tr>
+  <% @jobs.each do |f| %>
+    <tr>
+      <td><%= link_to f.id, show_job_path(f.id) %></td>
+      <td><%= f.attempts %></td>
+      <td><%= f.last_error&.split("\n")&.reject { |x| x =~ /bundle/ }&.join("\n") %></td>
+      <td><%= f.run_at %></td>
+      <td><%= f.failed_at %></td>
+      <td><%= f.queue %></td>
+      <td><%= f.created_at %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/delayed_job_dashboard/show.html.erb
+++ b/app/views/delayed_job_dashboard/show.html.erb
@@ -1,0 +1,21 @@
+<h1>Job <%= @job.id %></h1>
+<p>
+  [<%= link_to "requeue", requeue_path(@job.id), method: :post %>]
+  [<%= link_to "delete", delete_job_path(@job.id), method: :delete %>]
+</p>
+<%= render partial: '/management/flash_messages' %>
+
+
+<h2>Info</h2>
+<%= @handler.display_name %>
+<h2>Attempts</h2>
+<%= @job.attempts %>
+<h2>Next run</h2> <%= @job.run_at %>
+<% if @job.last_error  %>
+<h2>Full Stack Trace</h2>
+  <pre>
+    <%= @job.last_error %>
+  </pre>
+  <% else %>
+  <pre>No Errors</pre>
+<% end %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -12,7 +12,7 @@
     <%= link_to 'Batch Process', batch_processes_path, class: 'list-group-item list-group-item-action bg-light' %>
     <%= link_to 'Preservation', preservica_ingests_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% if current_user&.sysadmin %>
-      <%= link_to 'Delayed Job Dashboard', delayed_job_web_path, class: 'list-group-item list-group-item-action bg-light' %>
+      <%= link_to 'Delayed Job Dashboard', dashboard_path, class: 'list-group-item list-group-item-action bg-light' %>
     <% end %>
     <% if current_user %>
       <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'list-group-item list-group-item-action bg-light sign-button' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,14 +50,23 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   devise_scope :user do
     authenticated :user, ->(user) { user.sysadmin } do
       mount DelayedJobWeb, at: '/delayed_job'
+      get '/delayed_job_dashboard', to: 'delayed_job_dashboard#index', as: 'dashboard'
+      get '/delayed_job_dashboard/failed', to: 'delayed_job_dashboard#failed_jobs', as: "failed_jobs"
+      get '/delayed_job_dashboard/working', to: 'delayed_job_dashboard#working_jobs', as: "working_jobs"
+      get '/delayed_job_dashboard/pending', to: 'delayed_job_dashboard#pending_jobs', as: "pending_jobs"
+      get '/delayed_job_dashboard/show/:id', to: 'delayed_job_dashboard#show', as: "show_job"
+      post '/delayed_job_dashboard/requeue/:id', to: 'delayed_job_dashboard#requeue', as: "requeue"
+      delete '/delayed_job_dashboard/delete/:id', to: 'delayed_job_dashboard#delete_job', as: "delete_job"
     end
 
-    authenticated :user do
+    authenticated :user, ->(user) { user.sysadmin } do
       # authenticated user without the sysadmin role
+      get '/*delayed_job_dashboard', to: 'application#access_denied'
       get '/*delayed_job', to: 'application#access_denied'
     end
   end
 
   # fall back if not authenticated
   get '/delayed_job', to: redirect('/management/users/auth/cas')
+  get '/delayed_job_dashboard', to: redirect('/management/users/auth/cas')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,6 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   end
 
   # fall back if not authenticated
-  get '/delayed_job', to: redirect('/users/auth/cas')
-  get '/delayed_job_dashboard', to: redirect('/users/auth/cas')
+  get '/delayed_job', to: redirect('users/auth/cas')
+  get '/delayed_job_dashboard', to: redirect('users/auth/cas')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,10 +63,16 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       # authenticated user without the sysadmin role
       get '/*delayed_job_dashboard', to: 'application#access_denied'
       get '/*delayed_job', to: 'application#access_denied'
+      get '/delayed_job_dashboard/:all', to: redirect('users/auth/cas')
+      post '/delayed_job_dashboard/requeue/:all', to: redirect('users/auth/cas')
+      delete '/delayed_job_dashboard/delete/:all', to: redirect('users/auth/cas')
     end
   end
 
   # fall back if not authenticated
   get '/delayed_job', to: redirect('users/auth/cas')
   get '/delayed_job_dashboard', to: redirect('users/auth/cas')
+  get '/delayed_job_dashboard/:all', to: redirect('users/auth/cas')
+  post '/delayed_job_dashboard/requeue/:all', to: redirect('users/auth/cas')
+  delete '/delayed_job_dashboard/delete/:all', to: redirect('users/auth/cas')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,6 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   end
 
   # fall back if not authenticated
-  get '/delayed_job', to: redirect('/management/users/auth/cas')
-  get '/delayed_job_dashboard', to: redirect('/management/users/auth/cas')
+  get '/delayed_job', to: redirect('/users/auth/cas')
+  get '/delayed_job_dashboard', to: redirect('/users/auth/cas')
 end

--- a/spec/factories/delayed_job.rb
+++ b/spec/factories/delayed_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  # User objects are created from data passed from CAS.
+  # The only field we get is uid. All user objects are given the
+  # provider "cas"
+  factory :job, class: Delayed::Job do
+    handler { "Test Handler" }
+  end
+end

--- a/spec/requests/delayed_job_dashboard_request_spec.rb
+++ b/spec/requests/delayed_job_dashboard_request_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Delayed Jobs Dashboard', type: :request do
+  let(:authorized_user) { FactoryBot.create(:sysadmin_user) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:delayed_job) { FactoryBot.create(:job) }
+
+  after do
+    Delayed::Job.delete_all
+  end
+
+  describe 'with authorized user' do
+    before do
+      login_as authorized_user
+    end
+
+    it 'displays working jobs' do
+      get working_jobs_path
+      expect(response).to have_http_status(200)
+    end
+
+    it 'displays failed jobs' do
+      get failed_jobs_url
+      expect(response).to have_http_status(200)
+    end
+
+    it 'displays pending jobs' do
+      get pending_jobs_path
+      expect(response).to have_http_status(200)
+    end
+
+    it 'displays dashboard' do
+      get delayed_job_dashboard_path
+      expect(response).to have_http_status(200)
+    end
+
+    it 'redirects after delete' do
+      delete delete_job_path(delayed_job.id)
+      expect(response).to have_http_status(302)
+    end
+
+    it 'redirects after requeue' do
+      post requeue_path(delayed_job.id)
+      expect(response).to have_http_status(302)
+    end
+  end
+
+  describe 'with unauthorized user' do
+    before do
+      login_as user
+    end
+
+    it 'redirects working jobs' do
+      get working_jobs_url
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects failed jobs' do
+      get failed_jobs_path
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects pending jobs' do
+      get pending_jobs_path
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects attempts to delete' do
+      delete delete_job_path(delayed_job.id)
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects attempts to requeue' do
+      post requeue_path(delayed_job.id)
+      expect(response).to have_http_status(301)
+    end
+  end
+
+  describe 'not logged in' do
+    it 'redirects working jobs' do
+      get working_jobs_url
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects failed jobs' do
+      get failed_jobs_path
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects pending jobs' do
+      get pending_jobs_path
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects attempts to delete' do
+      delete delete_job_path(delayed_job.id)
+      expect(response).to have_http_status(301)
+    end
+
+    it 'redirects attempts to requeue' do
+      post requeue_path(delayed_job.id)
+      expect(response).to have_http_status(301)
+    end
+  end
+end

--- a/spec/system/delayed_job_spec.rb
+++ b/spec/system/delayed_job_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe 'Delayed Jobs', type: :system, js: true do
     end
     it 'are inaccessible manually through the delayed jobs endpoint' do
       visit delayed_job_web_path
-      expect(current_path).to eq(delayed_job_web_path)
-      expect(page).to have_content('Access denied')
+      expect(current_path).to eq('/users/auth/cas')
+      expect(page).to have_content('Authentication passthru')
     end
   end
 


### PR DESCRIPTION
Co-authored-by: McClain Looney <mcclain@curationexperts.com>

Creates an alternative dashboard for delayed jobs that uses more reasonable queries to get the statistics about jobs.
The old delayed job dashboard is still available for those brave enough to try it, and when there are not > 500,000 jobs.