### PR TITLE
Adds indexes to parent object table

### DIFF
--- a/db/migrate/20211118205946_add_parent_object_indexes.rb
+++ b/db/migrate/20211118205946_add_parent_object_indexes.rb
@@ -1,0 +1,19 @@
+class AddParentObjectIndexes < ActiveRecord::Migration[6.0]
+  def up
+    add_index  :parent_objects, :aspace_uri unless index_exists?(:parent_objects, :aspace_uri)
+    add_index  :parent_objects, :barcode unless index_exists?(:parent_objects, :barcode)
+    add_index  :parent_objects, :bib unless index_exists?(:parent_objects, :bib)
+    add_index  :parent_objects, :call_number unless index_exists?(:parent_objects, :call_number)
+    add_index  :parent_objects, :holding unless index_exists?(:parent_objects, :holding)
+    add_index  :parent_objects, :item unless index_exists?(:parent_objects, :item)
+  end
+
+  def down
+    remove_index :parent_objects, :aspace_uri
+    remove_index :parent_objects, :barcode
+    remove_index :parent_objects, :bib
+    remove_index :parent_objects, :call_number
+    remove_index :parent_objects, :holding
+    remove_index :parent_objects, :item
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_25_231147) do
+ActiveRecord::Schema.define(version: 2021_11_18_205946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -164,7 +164,13 @@ ActiveRecord::Schema.define(version: 2021_10_25_231147) do
     t.string "project_identifier"
     t.string "parent_model"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
+    t.index ["aspace_uri"], name: "index_parent_objects_on_aspace_uri"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
+    t.index ["barcode"], name: "index_parent_objects_on_barcode"
+    t.index ["bib"], name: "index_parent_objects_on_bib"
+    t.index ["call_number"], name: "index_parent_objects_on_call_number"
+    t.index ["holding"], name: "index_parent_objects_on_holding"
+    t.index ["item"], name: "index_parent_objects_on_item"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true
     t.index ["project_identifier"], name: "index_parent_objects_on_project_identifier"
   end


### PR DESCRIPTION
# Summary
Adds indexes to Parent Objects table for faster sorting.

# Related Ticket
[#1763](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1763)

Co-authored by: @jpengst 