### PR TITLE
Increase coveralls code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ jobs:
           tag: $CIRCLE_TAG
 
 orbs:
-  docker: circleci/docker@1.0.1
   circleci-orb: samvera/circleci-orb@1.0.0
+  docker: circleci/docker@1.0.1
 version: 2.1
 workflows:
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,9 @@ jobs:
           command: |
             mkdir /tmp/test-results
             cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-      - coveralls/upload
+      - run:
+          name: Upload code coverage stats
+          command: curl -k https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN} -d "payload[build_num]=${CIRCLE_BUILD_NUM}&payload[status]=done"
 
   publish-latest:
     executor: docker/docker
@@ -102,7 +104,6 @@ jobs:
           tag: $CIRCLE_TAG
 
 orbs:
-  coveralls: coveralls/coveralls@1.0.6
   docker: circleci/docker@1.0.1
 version: 2.1
 workflows:
@@ -125,4 +126,8 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
-
+  test_parallel_then_upload:
+    jobs:
+      - run-tests
+      - done:
+        requires: [run-tests]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,9 @@ jobs:
           command: |
             mkdir /tmp/test-results
             cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-      - run:
-          name: Upload code coverage stats
-          command: curl -k https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN} -d "payload[build_num]=${CIRCLE_BUILD_NUM}&payload[status]=done"
+      - coveralls/upload:
+        parallel: true
+        flag_name: tests
 
   publish-latest:
     executor: docker/docker
@@ -102,9 +102,12 @@ jobs:
       - docker/push:
           image: yalelibraryit/dc-management
           tag: $CIRCLE_TAG
-
+  done:
+    steps:
+       - coveralls/upload:
+         parallel_finished: true
 orbs:
-  circleci-orb: samvera/circleci-orb@1.0.0
+  coveralls: coveralls/coveralls@1.0.6
   docker: circleci/docker@1.0.1
 version: 2.1
 workflows:
@@ -127,3 +130,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
+      - test_parallel_then_upload:
+        jobs:
+          -  run-tests
+          - done:
+            requires:
+              - run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       # Image pulled from registry
       - image: yalelibraryit/dc-management:$CIRCLE_SHA1
         environment:
+          COVERALLS_PARALLEL: true
           IIIF_IMAGE_BASE_URL: http://localhost:8182/iiif
           POSTGRES_HOST: localhost
           POSTGRES_DB: management_yul_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,7 @@
+version: 2.1
+
+orbs: circleci-orb: samvera/circleci-orb@1.0.0
+
 commands:
   docker-tag:
     description: "Add a new tag to a docker image that has already been pulled"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,5 +130,4 @@ workflows:
     jobs:
       - run-tests
       - done:
-        requires: 
-          - run-tests
+        requires: run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,11 @@ jobs:
       - docker/push:
           image: yalelibraryit/dc-management
           tag: $CIRCLE_TAG
+  done:
+    executor: docker/docker
+    steps:
+     - coveralls/upload:
+       parallel_finished: true
 
 orbs:
   docker: circleci/docker@1.0.1
@@ -127,3 +132,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
+      - done:
+          requires:
+            - run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
-orbs: circleci-orb: samvera/circleci-orb@1.0.0
+orbs: 
+  circleci-orb: samvera/circleci-orb@1.0.0
 
 commands:
   docker-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,4 +130,5 @@ workflows:
     jobs:
       - run-tests
       - done:
-        requires: [run-tests]
+        requires: 
+          - run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
-  test_parallel_then_upload:
-    jobs:
-      - run-tests
-      - done:
-        requires: run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ workflows:
               only: /^v\d+\.\d+\.\d+$/
       - test_parallel_then_upload:
         jobs:
-          -  run-tests
+          - run-tests
           - done:
             requires:
               - run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,7 @@ jobs:
           command: |
             mkdir /tmp/test-results
             cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-      - coveralls/upload:
-        parallel: true
-        flag_name: tests
+      - coveralls/upload
 
   publish-latest:
     executor: docker/docker
@@ -102,10 +100,7 @@ jobs:
       - docker/push:
           image: yalelibraryit/dc-management
           tag: $CIRCLE_TAG
-  done:
-    steps:
-       - coveralls/upload:
-         parallel_finished: true
+
 orbs:
   coveralls: coveralls/coveralls@1.0.6
   docker: circleci/docker@1.0.1
@@ -130,9 +125,4 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
-      - test_parallel_then_upload:
-        jobs:
-          - run-tests
-          - done:
-            requires:
-              - run-tests
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
       # Image pulled from registry
       - image: yalelibraryit/dc-management:$CIRCLE_SHA1
         environment:
-          COVERALLS_PARALLEL: true
           IIIF_IMAGE_BASE_URL: http://localhost:8182/iiif
           POSTGRES_HOST: localhost
           POSTGRES_DB: management_yul_test
@@ -63,7 +62,13 @@ jobs:
           command: |
             mkdir /tmp/test-results
             cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-      - run:
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+      - deploy:
           name: Upload code coverage stats
           command: curl -k https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN} -d "payload[build_num]=${CIRCLE_BUILD_NUM}&payload[status]=done"
 
@@ -103,11 +108,6 @@ jobs:
       - docker/push:
           image: yalelibraryit/dc-management
           tag: $CIRCLE_TAG
-  done:
-    executor: docker/docker
-    steps:
-     - coveralls/upload:
-       parallel_finished: true
 
 orbs:
   docker: circleci/docker@1.0.1
@@ -132,6 +132,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
-      - done:
-          requires:
-            - run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,3 @@
-version: 2.1
-
-orbs: 
-  circleci-orb: samvera/circleci-orb@1.0.0
-
 commands:
   docker-tag:
     description: "Add a new tag to a docker image that has already been pulled"
@@ -110,6 +105,7 @@ jobs:
 
 orbs:
   docker: circleci/docker@1.0.1
+  circleci-orb: samvera/circleci-orb@1.0.0
 version: 2.1
 workflows:
   commit:

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -9,15 +9,6 @@ class ReoccurringJobsController < ApplicationController
     end
   end
 
-  # GET /reoccuring_jobs/1
-  # GET /reoccuring_jobs/1.json
-  def show
-    respond_to do |format|
-      format.html
-      format.json { render json: ReoccurringJobDatatable.new(params, view_context: view_context) }
-    end
-  end
-
   # POST ActivityStreamReader
   def create
     ActivityStreamReader.update
@@ -26,7 +17,4 @@ class ReoccurringJobsController < ApplicationController
       format.json { head :no_content }
     end
   end
-
-  # GET /reoccuring_jobs/1/edit
-  def edit; end
 end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -4,5 +4,7 @@ require "rails_helper"
 RSpec.describe ApplicationCable::Connection do
   it "exists" do
     expect(described_class).to be_a(Class)
+    expect(described_class).not_to be_a(Hash)
+    expect(described_class).not_to be_a(Array)
   end
 end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -2,9 +2,13 @@
 require "rails_helper"
 
 RSpec.describe ApplicationCable::Connection do
-  it "exists" do
+  it "exists as a class" do
     expect(described_class).to be_a(Class)
-    expect(described_class).not_to be_a(Hash)
+  end
+  it "is not an array" do
     expect(described_class).not_to be_a(Array)
+  end
+  it "is not a hash" do
+    expect(described_class).not_to be_a(Hash)
   end
 end

--- a/spec/datatables/reoccurring_job_datatable_spec.rb
+++ b/spec/datatables/reoccurring_job_datatable_spec.rb
@@ -14,7 +14,16 @@ RSpec.describe ReoccurringJobDatatable, type: :datatable, prep_metadata_sources:
     end
 
     it 'can handle a populated set' do
-      output = ReoccurringJobDatatable.new(datatable_sample_params(columns), view_context: activity_stream_datatable_view_mock(activity_stream.id, activity_stream.run_time, activity_stream.activity_stream_items, activity_stream.status, activity_stream.created_at, activity_stream.updated_at, activity_stream.retrieved_records)).data
+      output = ReoccurringJobDatatable.new(datatable_sample_params(columns),
+                                           view_context: activity_stream_datatable_view_mock(
+                                             activity_stream.id,
+                                             activity_stream.run_time,
+                                             activity_stream.activity_stream_items,
+                                             activity_stream.status,
+                                             activity_stream.created_at,
+                                             activity_stream.updated_at,
+                                             activity_stream.retrieved_records
+                                           )).data
 
       expect(output).to include(
 

--- a/spec/datatables/reoccurring_job_datatable_spec.rb
+++ b/spec/datatables/reoccurring_job_datatable_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReoccurringJobDatatable, type: :datatable, prep_metadata_sources: true do
+  columns = ['process_id', 'run_time', 'items', 'status', 'created', 'updated', 'retrieved_records']
+  let(:activity_stream) { FactoryBot.create(:activity_stream_log) }
+
+  describe 'admin set data tables' do
+    it 'can handle an empty model set' do
+      output = ReoccurringJobDatatable.new(datatable_sample_params(columns)).data
+
+      expect(output).to eq([])
+    end
+
+    it 'can handle a populated set' do
+      output = ReoccurringJobDatatable.new(datatable_sample_params(columns), view_context: activity_stream_datatable_view_mock(activity_stream.id, activity_stream.run_time, activity_stream.activity_stream_items, activity_stream.status, activity_stream.created_at, activity_stream.updated_at, activity_stream.retrieved_records)).data
+
+      expect(output).to include(
+
+        process_id: activity_stream.id,
+        run_time: activity_stream.run_time,
+        items: activity_stream.activity_stream_items,
+        status: activity_stream.status,
+        created: activity_stream.created_at,
+        updated: activity_stream.updated_at,
+        retrieved_records: activity_stream.retrieved_records
+      )
+    end
+  end
+end

--- a/spec/helpers/json_helper_spec.rb
+++ b/spec/helpers/json_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe JsonHelper, type: :helper do
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:metadata_source) { FactoryBot.create(:metadata_source) }
+  let(:parent_object_with_authoritative_json) do
+    FactoryBot.create(
+      :parent_object,
+      oid: '16712419',
+      authoritative_metadata_source: metadata_source,
+      admin_set: admin_set,
+      ladybird_json: JSON.parse(File.read(File.join(fixture_path, "ladybird", "16712419.json")))
+    )
+  end
+
+  it 'formats json' do
+    formatted = formatted_json(parent_object_with_authoritative_json.authoritative_json)
+    expect(formatted).to include('<div class="CodeRay">')
+  end
+end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -2,16 +2,8 @@
 
 require 'rails_helper'
 
-# Specs in this file have access to a helper object that includes
-# the UsersHelper. For example:
-#
-# describe UsersHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe UsersHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "exists" do
+    expect(described_class).to be_a(Module)
+  end
 end

--- a/spec/jobs/add_extent_to_parent_job_spec.rb
+++ b/spec/jobs/add_extent_to_parent_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AddExtentOfDigitizationToParentObjectsJob, type: :job do
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::DelayedJobAdapter.new
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
+  let(:add_extent_job) { AddExtentOfDigitizationToParentObjectsJob.new }
+
+  it 'increments the job queue by one' do
+    ActiveJob::Base.queue_adapter = :delayed_job
+    expect do
+      described_class.perform_later(batch_process)
+    end.to change { Delayed::Job.count }.by(1)
+  end
+
+  it "has correct priority" do
+    expect(add_extent_job.default_priority).to eq(-100)
+  end
+
+  it "has correct queue" do
+    expect(add_extent_job.queue_name).to eq('default')
+  end
+end

--- a/spec/jobs/add_rights_to_parent_job_spec.rb
+++ b/spec/jobs/add_rights_to_parent_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AddRightsToParentObjectsJob, type: :job do
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::DelayedJobAdapter.new
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
+  let(:add_rights_job) { AddRightsToParentObjectsJob.new }
+
+  it 'increments the job queue by one' do
+    ActiveJob::Base.queue_adapter = :delayed_job
+    expect do
+      described_class.perform_later(batch_process)
+    end.to change { Delayed::Job.count }.by(1)
+  end
+
+  it "has correct priority" do
+    expect(add_rights_job.default_priority).to eq(-100)
+  end
+
+  it "has correct queue" do
+    expect(add_rights_job.queue_name).to eq('default')
+  end
+end

--- a/spec/jobs/create_child_oid_csv_job_spec.rb
+++ b/spec/jobs/create_child_oid_csv_job_spec.rb
@@ -8,12 +8,21 @@ RSpec.describe CreateChildOidCsvJob, type: :job do
 
   let(:user) { FactoryBot.create(:user) }
   let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
+  let(:create_child_oid_csv_job) { CreateChildOidCsvJob.new }
 
   it 'increments the job queue by one' do
     ActiveJob::Base.queue_adapter = :delayed_job
     expect do
       described_class.perform_later(batch_process)
     end.to change { Delayed::Job.count }.by(1)
+  end
+
+  it "has correct priority" do
+    expect(create_child_oid_csv_job.default_priority).to eq(-100)
+  end
+
+  it "has correct queue" do
+    expect(create_child_oid_csv_job.queue_name).to eq('default')
   end
 
   it 'calls output_csv when performed' do

--- a/spec/jobs/create_child_oid_csv_job_spec.rb
+++ b/spec/jobs/create_child_oid_csv_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CreateChildOidCsvJob, type: :job do
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::DelayedJobAdapter.new
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
+
+  it 'increments the job queue by one' do
+    ActiveJob::Base.queue_adapter = :delayed_job
+    expect do
+      described_class.perform_later(batch_process)
+    end.to change { Delayed::Job.count }.by(1)
+  end
+
+  it 'calls output_csv when performed' do
+    expect(batch_process).to receive(:output_csv).once
+    described_class.new.perform(batch_process)
+  end
+
+  it 'reports error when output_csv fails' do
+    allow(batch_process).to receive(:output_csv).and_raise('boom!')
+    inst = described_class.new
+    expect do
+      inst.perform(batch_process)
+    end.to raise_error('boom!')
+  end
+end

--- a/spec/jobs/mets_directory_scan_job_spec.rb
+++ b/spec/jobs/mets_directory_scan_job_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe MetsDirectoryScanJob, type: :job do
     ActiveJob::QueueAdapters::DelayedJobAdapter.new
   end
 
+  let(:mets_directory_scan_job) { MetsDirectoryScanJob.new }
+
   it 'increments the job queue by one' do
     ActiveJob::Base.queue_adapter = :delayed_job
     expect do
@@ -16,5 +18,13 @@ RSpec.describe MetsDirectoryScanJob, type: :job do
   it 'runs scanner when performed' do
     expect(MetsDirectoryScanner).to receive(:perform_scan).once
     described_class.new.perform
+  end
+
+  it "has correct priority" do
+    expect(mets_directory_scan_job.default_priority).to eq(100)
+  end
+
+  it "has correct queue" do
+    expect(mets_directory_scan_job.queue_name).to eq('default')
   end
 end

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -192,6 +192,11 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
                                              'X-Amz-Meta-Height' => '60',
                                              'Content-Type' => 'image/tiff' })
       end
+      
+      it "has expected start states" do
+        expect(child_object.start_states).to eq ["ptiff-queued", "processing-queued"]
+      end
+
       it "can receive width and height if they are cached" do
         # expect(StaticChildInfo).to receive(:size_for).and_return(width: 50, height: 60)
         expect(child_object).to receive(:remote_ptiff_exists?).and_return true

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       end
 
       it "can return a the remote ocr path" do
+        expect(child_object.remote_ocr_exists?).to eq(true)
         expect(child_object.remote_ocr_path).to eq "fulltext/89/45/67/89/456789.txt"
       end
 

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
                                              'X-Amz-Meta-Height' => '60',
                                              'Content-Type' => 'image/tiff' })
       end
-      
+
       it "has expected start states" do
         expect(child_object.start_states).to eq ["ptiff-queued", "processing-queued"]
       end

--- a/spec/models/dependent_object_spec.rb
+++ b/spec/models/dependent_object_spec.rb
@@ -3,5 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe DependentObject, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "exists" do
+    expect(described_class).to be_a(Class)
+  end
+
+  it { is_expected.to belong_to :parent_object }
 end

--- a/spec/models/ingest_event_spec.rb
+++ b/spec/models/ingest_event_spec.rb
@@ -3,5 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe IngestEvent, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "exists" do
+    expect(described_class).to be_a(Class)
+  end
+
+  it { is_expected.to belong_to :batch_connection }
 end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -769,10 +769,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     context 'with voyager_json' do
       let(:parent_object) do
         FactoryBot.build(:parent_object, oid: '16797069', bib: '3435140', barcode: '39002075038423',
+                                         authoritative_metadata_source_id: voyager,
                                          voyager_json: JSON.parse(File.read(File.join(fixture_path, "ils", "V-16797069.json"))))
       end
 
       it 'returns a voyager url' do
+        source = MetadataSource.find(parent_object.authoritative_metadata_source_id)
+        expect(source.url_type).to eq 'voyager_cloud_url'
         expect(parent_object.voyager_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ils/barcode/39002075038423?bib=3435140"
       end
     end
@@ -787,11 +790,14 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     context 'with aspace_json' do
       let(:parent_object) do
         FactoryBot.build(:parent_object, oid: '2012036', bib: '3435140', barcode: '39002075038423',
+                                         authoritative_metadata_source_id: aspace,
                                          aspace_uri: '/repositories/11/archival_objects/555049',
                                          aspace_json: JSON.parse(File.read(File.join(fixture_path, "aspace", "AS-2012036.json"))))
       end
 
       it 'returns an aspace url' do
+        source = MetadataSource.find(parent_object.authoritative_metadata_source_id)
+        expect(source.url_type).to eq 'aspace_cloud_url'
         expect(parent_object.aspace_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/aspace/repositories/11/archival_objects/555049"
       end
     end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -761,7 +761,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
   end
 
   context "a newly created ParentObject with an expected (voyager) authoritative_metadata_source" do
-
     around do |example|
       perform_enqueued_jobs do
         example.run
@@ -780,7 +779,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
   end
 
   context "a newly created ParentObject with an expected (aspace) authoritative_metadata_source" do
-
     around do |example|
       perform_enqueued_jobs do
         example.run

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -768,7 +768,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     end
     context 'with voyager_json' do
       let(:parent_object) do
-        FactoryBot.build(:parent_object, oid: '16797069', bib: '3435140', barcode: '39002075038423',
+        FactoryBot.build(:parent_object, oid: '16797069', bib: '3435140', item: '8114701',
                                          authoritative_metadata_source_id: voyager,
                                          voyager_json: JSON.parse(File.read(File.join(fixture_path, "ils", "V-16797069.json"))))
       end
@@ -776,7 +776,8 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       it 'returns a voyager url' do
         source = MetadataSource.find(parent_object.authoritative_metadata_source_id)
         expect(source.url_type).to eq 'voyager_cloud_url'
-        expect(parent_object.voyager_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ils/barcode/39002075038423?bib=3435140"
+        parent_object.holding = nil
+        expect(parent_object.voyager_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ils/item/8114701?bib=3435140"
       end
     end
   end

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -759,4 +759,43 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       expect(parent_object.visibility).to eq "Private"
     end
   end
+
+  context "a newly created ParentObject with an expected (voyager) authoritative_metadata_source" do
+
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
+    context 'with voyager_json' do
+      let(:parent_object) do
+        FactoryBot.build(:parent_object, oid: '16797069', bib: '3435140', barcode: '39002075038423',
+                                         voyager_json: JSON.parse(File.read(File.join(fixture_path, "ils", "V-16797069.json"))))
+      end
+
+      it 'returns a voyager url' do
+        expect(parent_object.voyager_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ils/barcode/39002075038423?bib=3435140"
+      end
+    end
+  end
+
+  context "a newly created ParentObject with an expected (aspace) authoritative_metadata_source" do
+
+    around do |example|
+      perform_enqueued_jobs do
+        example.run
+      end
+    end
+    context 'with aspace_json' do
+      let(:parent_object) do
+        FactoryBot.build(:parent_object, oid: '2012036', bib: '3435140', barcode: '39002075038423',
+                                         aspace_uri: '/repositories/11/archival_objects/555049',
+                                         aspace_json: JSON.parse(File.read(File.join(fixture_path, "aspace", "AS-2012036.json"))))
+      end
+
+      it 'returns an aspace url' do
+        expect(parent_object.aspace_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/aspace/repositories/11/archival_objects/555049"
+      end
+    end
+  end
 end

--- a/spec/models/preservica_ingest_spec.rb
+++ b/spec/models/preservica_ingest_spec.rb
@@ -3,5 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PreservicaIngest, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "exists" do
+    expect(described_class).to be_a(Class)
+  end
 end

--- a/spec/requests/preservica_ingest_request_spec.rb
+++ b/spec/requests/preservica_ingest_request_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Preservica Ingest", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'with logged in user' do
+    before do
+      login_as user
+    end
+
+    describe "GET /index" do
+      it "returns http success" do
+        get preservica_ingests_url
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+  end
+end

--- a/spec/requests/preservica_ingest_request_spec.rb
+++ b/spec/requests/preservica_ingest_request_spec.rb
@@ -16,6 +16,5 @@ RSpec.describe "Preservica Ingest", type: :request do
         expect(response).to have_http_status(:success)
       end
     end
-
   end
 end

--- a/spec/requests/reoccurring_jobs_request_spec.rb
+++ b/spec/requests/reoccurring_jobs_request_spec.rb
@@ -26,5 +26,12 @@ RSpec.describe "Reoccurring Jobs", type: :request do
         expect(response).to have_http_status(:success)
       end
     end
+
+    describe "POST /create" do
+      it "correctly responds with invalid attributes" do
+        post reoccurring_jobs_url
+        expect(response).to redirect_to(reoccurring_jobs_url)
+      end
+    end
   end
 end

--- a/spec/requests/reoccurring_jobs_request_spec.rb
+++ b/spec/requests/reoccurring_jobs_request_spec.rb
@@ -5,6 +5,16 @@ require 'rails_helper'
 RSpec.describe "Reoccurring Jobs", type: :request do
   let(:user) { FactoryBot.create(:user) }
 
+  around do |example|
+    original_vpn = ENV['VPN']
+    original_metadata_cloud_host = ENV['METADATA_CLOUD_HOST']
+    ENV['METADATA_CLOUD_HOST'] = "metadata-api.library.yale.edu"
+    ENV['VPN'] = 'true'
+    example.run
+    ENV['VPN'] = original_vpn
+    ENV['METADATA_CLOUD_HOST'] = original_metadata_cloud_host
+  end
+
   describe 'with logged in user' do
     before do
       login_as user

--- a/spec/requests/reoccurring_jobs_request_spec.rb
+++ b/spec/requests/reoccurring_jobs_request_spec.rb
@@ -5,16 +5,6 @@ require 'rails_helper'
 RSpec.describe "Reoccurring Jobs", type: :request do
   let(:user) { FactoryBot.create(:user) }
 
-  around do |example|
-    original_vpn = ENV['VPN']
-    original_metadata_cloud_host = ENV['METADATA_CLOUD_HOST']
-    ENV['METADATA_CLOUD_HOST'] = "metadata-api.library.yale.edu"
-    ENV['VPN'] = 'true'
-    example.run
-    ENV['VPN'] = original_vpn
-    ENV['METADATA_CLOUD_HOST'] = original_metadata_cloud_host
-  end
-
   describe 'with logged in user' do
     before do
       login_as user
@@ -24,13 +14,6 @@ RSpec.describe "Reoccurring Jobs", type: :request do
       it "returns http success" do
         get reoccurring_jobs_url
         expect(response).to have_http_status(:success)
-      end
-    end
-
-    describe "POST /create" do
-      it "correctly responds with invalid attributes" do
-        post reoccurring_jobs_url
-        expect(response).to redirect_to(reoccurring_jobs_url)
       end
     end
   end

--- a/spec/requests/reoccurring_jobs_request_spec.rb
+++ b/spec/requests/reoccurring_jobs_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Reoccurring Jobs", type: :request do
     describe "POST /create" do
       it "correctly responds with invalid attributes" do
         post reoccurring_jobs_url
-        expect(response).to be_successful
+        expect(response).to redirect_to(reoccurring_jobs_url)
       end
     end
   end

--- a/spec/requests/reoccurring_jobs_request_spec.rb
+++ b/spec/requests/reoccurring_jobs_request_spec.rb
@@ -16,12 +16,5 @@ RSpec.describe "Reoccurring Jobs", type: :request do
         expect(response).to have_http_status(:success)
       end
     end
-
-    describe "POST /create" do
-      it "correctly responds with invalid attributes" do
-        post reoccurring_jobs_url
-        expect(response).to redirect_to(reoccurring_jobs_url)
-      end
-    end
   end
 end

--- a/spec/requests/reoccurring_jobs_request_spec.rb
+++ b/spec/requests/reoccurring_jobs_request_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Reoccurring Jobs", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'with logged in user' do
+    before do
+      login_as user
+    end
+
+    describe "GET /index" do
+      it "returns http success" do
+        get reoccurring_jobs_url
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "POST /create" do
+      it "correctly responds with invalid attributes" do
+        post reoccurring_jobs_url
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/requests/roles_request_spec.rb
+++ b/spec/requests/roles_request_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe 'Roles', type: :request do
             post roles_url, params: valid_parameters
           end.to change(user.roles, :count).by(1)
         end
+
+        it 'does not add duplicate role' do
+          expect do
+            post roles_url, params: valid_parameters
+          end.to change(user.roles, :count).by(1)
+          expect do
+            post roles_url, params: valid_parameters
+          end.not_to change(user.roles, :count)
+          expect(response).to have_http_status(302)
+        end
       end
 
       context 'with invalid parameters' do

--- a/spec/services/fixture_parsing_service_spec.rb
+++ b/spec/services/fixture_parsing_service_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe FixtureParsingService, prep_metadata_sources: true do
         expect(DependentObject.find_by(parent_object_id: private_oid).dependent_uri).to include "/ladybird/oid/10000016189097"
         expect(DependentObject.find_by(parent_object_id: yale_only_oid).dependent_uri).to include "/ladybird/oid/2004443"
       end
+
+      it "finds the correct file prefix" do
+        expect(described_class.file_prefix("ladybird")).to eq ""
+        expect(described_class.file_prefix("ils")).to eq "V-"
+        expect(described_class.file_prefix("aspace")).to eq "AS-"
+      end
     end
   end
 

--- a/spec/services/s3_service_spec.rb
+++ b/spec/services/s3_service_spec.rb
@@ -114,6 +114,10 @@ RSpec.describe S3Service, type: :has_vcr do
     child_object_oid = "1014543"
     remote_path = "fulltext/43/10/14/54/#{child_object_oid}.txt"
     expect(described_class.full_text_exists?(remote_path)).to eq(true)
+
+    child_object_oid_too = "12345678"
+    remote_path_too = "fulltext/78/12/34/56/#{child_object_oid_too}.txt"
+    expect(described_class.full_text_exists?(remote_path_too)).to eq(false)
   end
 
   it 'can delete a PDF' do

--- a/spec/support/datatables_helper.rb
+++ b/spec/support/datatables_helper.rb
@@ -135,7 +135,9 @@ def admin_set_datatable_view_mock(id, key, homepage) # rubocop:disable Metrics/A
   @datatable_view_mock
 end
 
-def activity_stream_datatable_view_mock(process_id, run_time, items, status, created, updated, retrieved_records)
+# rubocop:disable Metrics/ParameterLists
+def activity_stream_datatable_view_mock(_process_id, _run_time, _items, _status, _created, _updated, _retrieved_records)
   @datatable_view_mock ||= double
   @datatable_view_mock
 end
+# rubocop:enable Metrics/ParameterLists

--- a/spec/support/datatables_helper.rb
+++ b/spec/support/datatables_helper.rb
@@ -134,3 +134,8 @@ def admin_set_datatable_view_mock(id, key, homepage) # rubocop:disable Metrics/A
   allow(@datatable_view_mock).to receive(:link_to).with("/admin_sets/#{id}/edit", {}).and_return("<a href='/admin_sets/#{id}/edit'><i class=\"fa fa-pencil-alt></i>\"</a>")
   @datatable_view_mock
 end
+
+def activity_stream_datatable_view_mock(process_id, run_time, items, status, created, updated, retrieved_records)
+  @datatable_view_mock ||= double
+  @datatable_view_mock
+end

--- a/spec/views/batch_processes/create.html.erb_spec.rb
+++ b/spec/views/batch_processes/create.html.erb_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe "batch_processes/create.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -3,5 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe "users/index.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "displays the users datatable" do
+    render
+
+    expect(rendered).to have_css('#users-datatable')
+  end
 end


### PR DESCRIPTION
# Summary
Increase code coverage.

# Related Ticket
[#1766](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1766)

# Notes
- Modified circleci config to store parallel rspec test coverage
- Removed unused controller actions in reoccurring jobs
- Removed view spec for batch process create - template does not exist
- Added datatable specs for reoccurring jobs
- Added helper specs for json and user helpers
- Added job spec for create child oid csv job, add extent and add rights to parent jobs and added to job specs for mets directory scan
- Added to model specs for child object, dependent object, ingest event, parent object, and preservica ingest
- Added request specs to preservica ingest, roles, and reoccurring jobs.
- Added service specs for fixture parsing and s3
- Added to view spec for users index