### PR TITLE
DigitalObject change notification

### DIFF
--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -32,7 +32,7 @@ module DigitalObjectManagement
     return unless (digital_object_json && digital_object_json.json || nil) != new_digital_object
     #  There has been a change that needs to be reported to metadata cloud
     if send_digital_object_update(
-      priorDigitalObject: digital_object_json.present? && JSON.parse(digital_object_json) || nil,
+      priorDigitalObject: digital_object_json.present? && JSON.parse(digital_object_json.json) || nil,
       digitalObject: new_digital_object.present? && JSON.parse(new_digital_object) || nil
     )
       # Only update the database is the update was sent to MC successfully.

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -38,7 +38,7 @@ module DigitalObjectManagement
 
   def send_digital_object_update(digital_object_update)
     return unless ENV["VPN"] == "true"
-    full_response = mc_post("http://docker.for.mac.host.internal:8080/api/digital_object_updates", digital_object_update)
+    full_response = mc_post("https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates", digital_object_update)
     case full_response.status
     when 200
       Rails.logger.info "Update sent successfully #{digital_object_update}"

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -24,8 +24,8 @@ module DigitalObjectManagement
     return unless digital_object_json != new_digital_object
     #  There has been a change that needs to be reported to metadata cloud
     send_digital_object_update(
-      prior_digital_object: digital_object_json.present? && JSON.parse(digital_object_json) || nil,
-      digital_object: new_digital_object.present? && JSON.parse(new_digital_object) || nil
+      priorDigitalObject: digital_object_json.present? && JSON.parse(digital_object_json) || nil,
+      digitalObject: new_digital_object.present? && JSON.parse(new_digital_object) || nil
     )
     ParentObject.update(oid, digital_object_json: new_digital_object)
   end

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -27,13 +27,19 @@ module DigitalObjectManagement
 
   def digital_object_check
     new_digital_object = generate_digital_object_json
-    return unless digital_object_json != new_digital_object
+    return unless (digital_object_json && digital_object_json.json || nil) != new_digital_object
     #  There has been a change that needs to be reported to metadata cloud
     send_digital_object_update(
       priorDigitalObject: digital_object_json.present? && JSON.parse(digital_object_json) || nil,
       digitalObject: new_digital_object.present? && JSON.parse(new_digital_object) || nil
     )
-    ParentObject.update(oid, digital_object_json: new_digital_object)
+    apply_new_digital_object_json(new_digital_object)
+  end
+
+  def apply_new_digital_object_json(json)
+    self.digital_object_json = DigitalObjectJson.new if digital_object_json.nil?
+    digital_object_json.json = json
+    digital_object_json.save
   end
 
   def mc_post(mc_url, data)

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -32,7 +32,7 @@ module DigitalObjectManagement
     return unless (digital_object_json && digital_object_json.json || nil) != new_digital_object
     #  There has been a change that needs to be reported to metadata cloud
     if send_digital_object_update(
-      priorDigitalObject: digital_object_json.present? && JSON.parse(digital_object_json.json) || nil,
+      priorDigitalObject: digital_object_json&.json.present? && JSON.parse(digital_object_json.json) || nil,
       digitalObject: new_digital_object.present? && JSON.parse(new_digital_object) || nil
     )
       # Only update the database is the update was sent to MC successfully.

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -30,7 +30,19 @@ module DigitalObjectManagement
     ParentObject.update(oid, digital_object_json: new_digital_object)
   end
 
+  def mc_post(mc_url, data)
+    metadata_cloud_username = ENV["MC_USER"]
+    metadata_cloud_password = ENV["MC_PW"]
+    HTTP.basic_auth(user: metadata_cloud_username, pass: metadata_cloud_password).post(mc_url, data)
+  end
+
   def send_digital_object_update(digital_object_update)
-    Rails.logger.info "\n\n\n\n\n*****************************************#{digital_object_update.to_json}\n*****************************************\n\n\n\n\n"
+    full_response = mc_post("https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates", digital_object_update)
+    case full_response.status
+    when 200
+      Rails.logger.info "Update sent successfully #{digital_object_update}"
+    else
+      Rails.logger.info "Error sending digital object update: #{full_response.status}, #{digital_object_update}"
+    end
   end
 end

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -37,12 +37,15 @@ module DigitalObjectManagement
   end
 
   def send_digital_object_update(digital_object_update)
-    full_response = mc_post("https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates", digital_object_update)
+    return unless ENV["VPN"] == "true"
+    full_response = mc_post("http://docker.for.mac.host.internal:8080/api/digital_object_updates", digital_object_update)
     case full_response.status
     when 200
       Rails.logger.info "Update sent successfully #{digital_object_update}"
     else
       Rails.logger.info "Error sending digital object update: #{full_response.status}, #{digital_object_update}"
     end
+  rescue => e
+    Rails.logger.info "Error sending digital object update: #{e}, #{digital_object_update}"
   end
 end

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -4,6 +4,7 @@ module DigitalObjectManagement
   extend ActiveSupport::Concern
 
   def generate_digital_object_json
+    return nil unless child_object_count > 0
     return nil unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
     return nil unless ['Public', 'Yale Community Only'].include? visibility
     # create digital object from data and return JSON

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -3,10 +3,15 @@
 module DigitalObjectManagement
   extend ActiveSupport::Concern
 
+  def digital_object_json_available?
+    return false unless child_object_count&.positive?
+    return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
+    return false unless ['Public', 'Yale Community Only'].include? visibility
+    true
+  end
+
   def generate_digital_object_json
-    return nil unless child_object_count > 0
-    return nil unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
-    return nil unless ['Public', 'Yale Community Only'].include? visibility
+    return nil unless digital_object_json_available?
     # create digital object from data and return JSON
     {   oid: oid,
         title: digital_object_title,

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DigitalObjectManagement
+  extend ActiveSupport::Concern
+
+  def generate_digital_object_json
+    return nil unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
+    return nil unless ['Public', 'Yale Community Only'].include? visibility
+    # create digital object from data and return JSON
+    {   oid: oid,
+        title: digital_object_title,
+        thumbnailOid: representative_child && representative_child.oid || nil,
+        thumbnailCaption: representative_child && representative_child.label || nil,
+        archivesSpaceUri: aspace_uri,
+        childCount: child_object_count }.to_json
+  end
+
+  def digital_object_title
+    authoritative_json && authoritative_json["title"] && authoritative_json["title"][0]
+  end
+
+  def digital_object_check
+    new_digital_object = generate_digital_object_json
+    return unless digital_object_check != new_digital_object
+    #  There has been a change that needs to be reported to metadata cloud
+    send_digital_object_update(
+      prior_digital_object: digital_object_json.present? && JSON.parse(digital_object_json) || nil,
+      digital_object: new_digital_object.present? && JSON.parse(new_digital_object) || nil
+    )
+    ParentObject.update(oid, digital_object_json: new_digital_object)
+  end
+
+  def send_digital_object_update(digital_object_update)
+    Rails.logger.info "\n\n\n\n\n*****************************************#{digital_object_update.to_json}\n*****************************************\n\n\n\n\n"
+  end
+end

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -21,7 +21,7 @@ module DigitalObjectManagement
 
   def digital_object_check
     new_digital_object = generate_digital_object_json
-    return unless digital_object_check != new_digital_object
+    return unless digital_object_json != new_digital_object
     #  There has been a change that needs to be reported to metadata cloud
     send_digital_object_update(
       prior_digital_object: digital_object_json.present? && JSON.parse(digital_object_json) || nil,

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -33,7 +33,7 @@ module DigitalObjectManagement
   def mc_post(mc_url, data)
     metadata_cloud_username = ENV["MC_USER"]
     metadata_cloud_password = ENV["MC_PW"]
-    HTTP.basic_auth(user: metadata_cloud_username, pass: metadata_cloud_password).post(mc_url, data)
+    HTTP.basic_auth(user: metadata_cloud_username, pass: metadata_cloud_password).post(mc_url, json: data)
   end
 
   def send_digital_object_update(digital_object_update)

--- a/app/models/digital_object_json.rb
+++ b/app/models/digital_object_json.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DigitalObjectJson < ApplicationRecord
+  belongs_to :parent_object
+end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -10,6 +10,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include Statable
   include PdfRepresentable
   include Delayable
+  include DigitalObjectManagement
   has_many :dependent_objects
   has_many :child_objects, -> { order('"order" ASC, oid ASC') }, primary_key: 'oid', foreign_key: 'parent_object_oid', dependent: :destroy
   has_many :batch_connections, as: :connectable
@@ -21,6 +22,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   attr_accessor :current_batch_connection
   self.primary_key = 'oid'
   after_save :setup_metadata_job
+  after_update :digital_object_check
   # after_update :solr_index_job # we index from the fetch job on create
   after_destroy :solr_delete
   after_destroy :note_deletion

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -17,6 +17,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :batch_processes, through: :batch_connections
   belongs_to :authoritative_metadata_source, class_name: "MetadataSource"
   belongs_to :admin_set
+  has_one :digital_object_json
   attr_accessor :metadata_update
   attr_accessor :current_batch_process
   attr_accessor :current_batch_connection

--- a/db/migrate/20211119150734_add_digital_object_json_field.rb
+++ b/db/migrate/20211119150734_add_digital_object_json_field.rb
@@ -1,0 +1,5 @@
+class AddDigitalObjectJsonField < ActiveRecord::Migration[6.0]
+  def change
+    add_column :parent_objects, :digital_object_json, :text
+  end
+end

--- a/db/migrate/20211119150734_add_digital_object_json_field.rb
+++ b/db/migrate/20211119150734_add_digital_object_json_field.rb
@@ -1,5 +1,9 @@
 class AddDigitalObjectJsonField < ActiveRecord::Migration[6.0]
   def change
-    add_column :parent_objects, :digital_object_json, :text
+    create_table :digital_object_jsons do |t|
+      t.text :json
+      t.references :parent_object
+      t.timestamps
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_25_231147) do
+ActiveRecord::Schema.define(version: 2021_11_19_150734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,6 +163,7 @@ ActiveRecord::Schema.define(version: 2021_10_25_231147) do
     t.string "container_grouping"
     t.string "project_identifier"
     t.string "parent_model"
+    t.text "digital_object_json"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -112,6 +112,14 @@ ActiveRecord::Schema.define(version: 2021_11_19_150734) do
     t.index ["parent_object_id"], name: "index_dependent_objects_on_parent_object_id"
   end
 
+  create_table "digital_object_jsons", force: :cascade do |t|
+    t.text "json"
+    t.bigint "parent_object_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["parent_object_id"], name: "index_digital_object_jsons_on_parent_object_id"
+  end
+
   create_table "ingest_events", force: :cascade do |t|
     t.string "reason"
     t.string "status"
@@ -163,7 +171,6 @@ ActiveRecord::Schema.define(version: 2021_11_19_150734) do
     t.string "container_grouping"
     t.string "project_identifier"
     t.string "parent_model"
-    t.text "digital_object_json"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -624,7 +624,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1"
         parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
         parent_object.authoritative_metadata_source_id = aspace
-        parent_object.save
+        parent_object.child_object_count = 1
+        parent_object.visibility = "Public"
+        parent_object.save!
       end
     end
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -615,7 +615,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       it "posts digital object changes when source changes" do
         stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
             .to_return(status: 200, body: { data: "fake data" }.to_json)
-        expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/16797069?include-children=1"
+        expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1"
         parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
         parent_object.authoritative_metadata_source_id = aspace
         parent_object.save

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -620,14 +620,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         parent_object.authoritative_metadata_source_id = aspace
         parent_object.save
       end
-      it "posts digital object changes when source changes" do
-        stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
-            .to_return(status: 200, body: { data: "fake data" }.to_json)
-        expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/16797069?include-children=1"
-        parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
-        parent_object.authoritative_metadata_source_id = aspace
-        parent_object.save
-      end
     end
 
     context 'with a bib but no barcode' do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -613,6 +613,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         ENV['VPN'] = original_vpn
       end
       it "posts digital object changes when source changes" do
+        stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1")
+            .to_return(status: 200, body: { dummy: "data" }.to_json)
+        stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/aspace/repositories/11/archival_objects/515305")
+            .to_return(status: 200, body: { dummy: "data" }.to_json)
         stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
             .to_return(status: 200, body: { data: "fake data" }.to_json)
         expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1"

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     stub_metadata_cloud("14716192")
     stub_metadata_cloud("16854285")
     stub_metadata_cloud("16057779")
+    stub_metadata_cloud("AS-16854285", "aspace")
     stub_ptiffs_and_manifests
     stub_full_text('1030368')
     stub_full_text('1032318')
@@ -601,6 +602,31 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           record = ladybird_source.fetch_record(parent_object)
           expect(record['data']).to eq("fake data")
         end
+      end
+    end
+
+    context "with vpn true" do
+      around do |example|
+        original_vpn = ENV['VPN']
+        ENV['VPN'] = "true"
+        example.run
+        ENV['VPN'] = original_vpn
+      end
+      it "posts digital object changes when source changes" do
+        stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
+            .to_return(status: 200, body: { data: "fake data" }.to_json)
+        expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/16797069?include-children=1"
+        parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
+        parent_object.authoritative_metadata_source_id = aspace
+        parent_object.save
+      end
+      it "posts digital object changes when source changes" do
+        stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
+            .to_return(status: 200, body: { data: "fake data" }.to_json)
+        expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/16797069?include-children=1"
+        parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
+        parent_object.authoritative_metadata_source_id = aspace
+        parent_object.save
       end
     end
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -614,12 +614,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
       it "posts digital object changes when source changes" do
         stub_full_text_not_found('2005512')
+        stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
+            .to_return(status: 200, body: { data: "fake data" }.to_json)
         stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1")
             .to_return(status: 200, body: { dummy: "data" }.to_json)
         stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/aspace/repositories/11/archival_objects/515305")
             .to_return(status: 200, body: { dummy: "data" }.to_json)
-        stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
-            .to_return(status: 200, body: { data: "fake data" }.to_json)
+        allow(S3Service).to receive(:upload_if_changed).and_return(true)
         expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1"
         parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
         parent_object.authoritative_metadata_source_id = aspace

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -613,6 +613,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         ENV['VPN'] = original_vpn
       end
       it "posts digital object changes when source changes" do
+        stub_full_text_not_found('2005512')
         stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1")
             .to_return(status: 200, body: { dummy: "data" }.to_json)
         stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/aspace/repositories/11/archival_objects/515305")


### PR DESCRIPTION
- Adds field to store digital_object_json in parent object
- Check to see if digital_object_json needs updating when parent object is updated
- If json changes, call send_digital_object_update (which currently just logs the information)