### PR TITLE
datatable export all

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -117,7 +117,7 @@ $( document ).on('turbolinks:load', function() {
       dt.one('preXhr', function (e, s, data) {
         // Just this once, load all data from the server...
         data.start = 0;
-        data.length = 2147483647;
+        data.length = 150000;
 
         dt.one('preDraw', function (e, settings) {
           // Call the original action function 
@@ -154,7 +154,7 @@ $( document ).on('turbolinks:load', function() {
       "bAutoWidth": false, // AutoWidth has issues with hiding and showing columns as startup
       "columns": columns,
       "order": columnOrder(columns),
-      "lengthMenu": [[1, 100, 500], [1, 100, 500]],
+      "lengthMenu": [[50, 100, 500], [50, 100, 500]],
       "sDom":hasSearch?'Blrtip':'<"row"<"col-sm-12 col-md-6"l><"col-sm-12 col-md-6"f>>rtip',
       buttons: [
         {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -97,6 +97,51 @@ $( document ).on('turbolinks:load', function() {
       return colVisibilityMap;
     }
 
+    var oldExportAction = function (self, e, dt, button, config) {
+      if (button[0].className.indexOf('buttons-csv') >= 0) {
+        if ($.fn.dataTable.ext.buttons.csvHtml5.available(dt, config)) {
+          $.fn.dataTable.ext.buttons.csvHtml5.action.call(self, e, dt, button, config);
+          }
+        else {
+          $.fn.dataTable.ext.buttons.csvFlash.action.call(self, e, dt, button, config);
+        }
+      } else if (button[0].className.indexOf('buttons-print') >= 0) {
+        $.fn.dataTable.ext.buttons.print.action(e, dt, button, config);
+      }
+    };
+  
+    var newExportAction = function (e, dt, button, config) {
+      var self = this;
+      var oldStart = dt.settings()[0]._iDisplayStart;
+  
+      dt.one('preXhr', function (e, s, data) {
+        // Just this once, load all data from the server...
+        data.start = 0;
+        data.length = 150000;
+
+        dt.one('preDraw', function (e, settings) {
+          // Call the original action function 
+          oldExportAction(self, e, dt, button, config);
+
+          dt.one('preXhr', function (e, s, data) {
+            // DataTables thinks the first item displayed is index 0, but we're not drawing that.
+            // Set the property to what it was before exporting.
+            settings._iDisplayStart = oldStart;
+            data.start = oldStart;
+          });
+
+          // Reload the grid with the original page. Otherwise, API functions like table.cell(this) don't work properly.
+          setTimeout(dt.ajax.reload, 0);
+
+          // Prevent rendering of the full data to the DOM
+          return false;
+        });
+      });
+  
+      // Requery the server with the new one-time export settings
+      dt.ajax.reload();
+    };
+
     dataTable = $('.is-datatable').dataTable({
       "deferLoading":true,
       "processing": true,
@@ -109,7 +154,7 @@ $( document ).on('turbolinks:load', function() {
       "bAutoWidth": false, // AutoWidth has issues with hiding and showing columns as startup
       "columns": columns,
       "order": columnOrder(columns),
-      "lengthMenu": [[50, 100, 500, -1], [50, 100, 500, "All"]],
+      "lengthMenu": [[50, 100, 500, -1], [50, 100, 500]],
       "sDom":hasSearch?'Blrtip':'<"row"<"col-sm-12 col-md-6"l><"col-sm-12 col-md-6"f>>rtip',
       buttons: [
         {
@@ -143,7 +188,8 @@ $( document ).on('turbolinks:load', function() {
         },
         {
           extend: 'csvHtml5',
-          text: "All Matching Entries"
+          text: "All Matching Entries",
+          action: newExportAction,
         }
       ],
       // pagingType is optional, if you want full pagination controls.

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -219,7 +219,6 @@ const format_csv = (csv) => {
     csv_content += csvRows[i]
     csv_content += '\n'
   }
-  console.log(formatted_header)
   return (formatted_header + '\n' + csv_content);
 }
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -172,7 +172,6 @@ $( document ).on('turbolinks:load', function() {
         {
           extend: 'csvHtml5',
           text: "CSV",
-          action: newExportAction,
           exportOptions: {
             columns: ':visible',
           },
@@ -189,6 +188,7 @@ $( document ).on('turbolinks:load', function() {
         },
         {
           extend: 'csvHtml5',
+          action: newExportAction,
           text: "All Matching Entries"
         }
       ],

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -140,6 +140,10 @@ $( document ).on('turbolinks:load', function() {
           exportOptions: {
             columns: ':visible'
           }
+        },
+        {
+          extend: 'csvHtml5',
+          text: "All Matching Entries"
         }
       ],
       // pagingType is optional, if you want full pagination controls.

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -101,7 +101,7 @@ $( document ).on('turbolinks:load', function() {
       if (button[0].className.indexOf('buttons-csv') >= 0) {
         if ($.fn.dataTable.ext.buttons.csvHtml5.available(dt, config)) {
           $.fn.dataTable.ext.buttons.csvHtml5.action.call(self, e, dt, button, config);
-          }
+        }
         else {
           $.fn.dataTable.ext.buttons.csvFlash.action.call(self, e, dt, button, config);
         }
@@ -109,15 +109,15 @@ $( document ).on('turbolinks:load', function() {
         $.fn.dataTable.ext.buttons.print.action(e, dt, button, config);
       }
     };
-  
+
     var newExportAction = function (e, dt, button, config) {
       var self = this;
       var oldStart = dt.settings()[0]._iDisplayStart;
-  
+
       dt.one('preXhr', function (e, s, data) {
         // Just this once, load all data from the server...
         data.start = 0;
-        data.length = 150000;
+        data.length = 2147483647;
 
         dt.one('preDraw', function (e, settings) {
           // Call the original action function 
@@ -137,7 +137,7 @@ $( document ).on('turbolinks:load', function() {
           return false;
         });
       });
-  
+
       // Requery the server with the new one-time export settings
       dt.ajax.reload();
     };
@@ -154,7 +154,7 @@ $( document ).on('turbolinks:load', function() {
       "bAutoWidth": false, // AutoWidth has issues with hiding and showing columns as startup
       "columns": columns,
       "order": columnOrder(columns),
-      "lengthMenu": [[50, 100, 500, -1], [50, 100, 500]],
+      "lengthMenu": [[1, 100, 500], [1, 100, 500]],
       "sDom":hasSearch?'Blrtip':'<"row"<"col-sm-12 col-md-6"l><"col-sm-12 col-md-6"f>>rtip',
       buttons: [
         {
@@ -172,6 +172,7 @@ $( document ).on('turbolinks:load', function() {
         {
           extend: 'csvHtml5',
           text: "CSV",
+          action: newExportAction,
           exportOptions: {
             columns: ':visible',
           },
@@ -188,8 +189,7 @@ $( document ).on('turbolinks:load', function() {
         },
         {
           extend: 'csvHtml5',
-          text: "All Matching Entries",
-          action: newExportAction,
+          text: "All Matching Entries"
         }
       ],
       // pagingType is optional, if you want full pagination controls.


### PR DESCRIPTION
Users can now export all filtered records to a CSV instead of just what's displayed on the table.