### PR TITLE
Sent MC a DigitalObject update when Parent is Deleted

### DIFF
--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -7,6 +7,7 @@ module DigitalObjectManagement
     return false unless child_object_count&.positive?
     return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
     return false unless ['Public', 'Yale Community Only'].include? visibility
+    return false unless digital_object_title
     true
   end
 
@@ -42,6 +43,19 @@ module DigitalObjectManagement
   end
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
+
+  def digital_object_delete
+    unless digital_object_json&.json
+      digital_object_json&.delete
+      return
+    end
+    if send_digital_object_update(
+      priorDigitalObject: JSON.parse(digital_object_json.json),
+      digitalObject: nil
+    )
+      digital_object_json.delete
+    end
+  end
 
   def apply_new_digital_object_json(json)
     self.digital_object_json = DigitalObjectJson.new if digital_object_json.nil?

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -29,6 +29,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   after_destroy :note_deletion
   after_destroy :delayed_jobs_deletion
   after_destroy :pdf_deletion
+  after_destroy :digital_object_delete
   paginates_per 50
 
   def self.visibilities

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -618,9 +618,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       before do
         stub_full_text_not_found('2005512')
         stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1")
-            .to_return(status: 200, body: { dummy: "data" }.to_json)
+            .to_return(status: 200, body: { "title" => ["data"] }.to_json)
         stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/aspace/repositories/11/archival_objects/515305")
-            .to_return(status: 200, body: { dummy: "data" }.to_json)
+            .to_return(status: 200, body: { "title" => ["data"] }.to_json)
         allow(S3Service).to receive(:upload_if_changed).and_return(true)
       end
       it "posts digital object changes when source changes" do
@@ -632,6 +632,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         parent_object.child_object_count = 1
         parent_object.visibility = "Public"
         expect(parent_object).to receive(:mc_post).once
+        parent_object.aspace_json = { "title": ["test title"] }
         parent_object.save!
       end
       it "posts digital object changes when source changes, and continues if post fails" do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -615,6 +615,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         ENV['VPN'] = original_vpn
         ENV['FEATURE_FLAGS'] = original_flags
       end
+
       before do
         stub_full_text_not_found('2005512')
         stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1")
@@ -623,6 +624,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
             .to_return(status: 200, body: { "title" => ["data"] }.to_json)
         allow(S3Service).to receive(:upload_if_changed).and_return(true)
       end
+
       it "posts digital object changes when source changes" do
         stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
             .to_return(status: 200, body: { data: "fake data" }.to_json)
@@ -631,10 +633,46 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         parent_object.authoritative_metadata_source_id = aspace
         parent_object.child_object_count = 1
         parent_object.visibility = "Public"
-        expect(parent_object).to receive(:mc_post).once
+        expect(parent_object).to receive(:mc_post).once.and_return(OpenStruct.new(status: 200))
         parent_object.aspace_json = { "title": ["test title"] }
         parent_object.save!
       end
+
+      it "posts digital object changes when parent is deleted" do
+        stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
+            .to_return(status: 200, body: { data: "fake data" }.to_json)
+        expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1"
+        parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
+        parent_object.authoritative_metadata_source_id = aspace
+        parent_object.child_object_count = 1
+        parent_object.visibility = "Public"
+        expect(parent_object).to receive(:mc_post).twice.and_return(OpenStruct.new(status: 200))
+        parent_object.aspace_json = { "title": ["test title"] }
+        parent_object.save!
+        parent_object.reload
+        parent_object.digital_object_delete
+      end
+
+      it "deletes DigitalObjectJson on delete" do
+        stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
+            .to_return(status: 200, body: { data: "fake data" }.to_json)
+        expect(parent_object.ladybird_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1"
+        parent_object.aspace_uri = '/repositories/11/archival_objects/515305'
+        parent_object.authoritative_metadata_source_id = aspace
+        parent_object.child_object_count = 1
+        parent_object.visibility = "Public"
+        expect(parent_object).to receive(:mc_post).exactly(2).time.and_return(OpenStruct.new(status: 200))
+        parent_object.aspace_json = { "title": ["test title"] }
+        parent_object.save!
+        parent_object.reload
+        parent_object.authoritative_metadata_source_id = ladybird
+        parent_object.save!
+        parent_object.reload
+        parent_object.digital_object_delete
+        parent_object.reload
+        expect(parent_object.digital_object_json).to be_nil
+      end
+
       it "posts digital object changes when source changes, and continues if post fails" do
         stub_request(:post, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates")
             .to_return(status: 200, body: { data: "fake data" }.to_json)


### PR DESCRIPTION
- Send a DigitalObjectUpdate to metadata cloud when a ParentObject is deleted.
- Clean up DigitalObjectJson when ParentObject is delete and message is sent successfully.
- Do not send a DigitalObjectUpdate until the title is available.  (This will prevent the update from being called before the authoritative metadata has arrived when switching to ASpace from some other source.)

If the Parent has a DIgitalObjectJson, and the send to metadata cloud fails, the DigitalObjectJson will not be deleted.
We can process orphaned DigitalObjectJson to clean up if there is an error sending the update.
If the parent is re-ingested before the orphan is cleaned up, the DigitalObject will be deleted or updated appropriately during re-ingest.