### PR TITLE
Process the activity stream page by page.

### DIFF
--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -11,10 +11,17 @@ class ReoccurringJobsController < ApplicationController
 
   # POST ActivityStreamReader
   def create
-    ActivityStreamReader.update
-    respond_to do |format|
-      format.html { redirect_to reoccurring_jobs_url, notice: 'Metadata update queued.' }
-      format.json { head :no_content }
+    if ActivityStreamLog.where(status: "Running").exists?
+      respond_to do |format|
+        format.html { redirect_to reoccurring_jobs_url, notice: 'An update is already in progress.' }
+        format.json { head :no_content }
+      end
+    else
+      ActivityStreamManualJob.perform_later
+      respond_to do |format|
+        format.html { redirect_to reoccurring_jobs_url, notice: 'Metadata update queued.' }
+        format.json { head :no_content }
+      end
     end
   end
 end

--- a/app/jobs/activity_stream_manual_job.rb
+++ b/app/jobs/activity_stream_manual_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-class ActivityStreamJob < ApplicationJob
-  repeat 'every day at 1am'
-
+# A separate job is needed for manual run, or it will enqueue itself again after it has finished
+class ActivityStreamManualJob < ApplicationJob
   def perform
     ActivityStreamReader.update unless ActivityStreamLog.where(status: "Running").exists?
   end

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -22,14 +22,19 @@ class ActivityStreamReader
     @most_recent_update = nil
     log = ActivityStreamLog.create(status: "Running")
     log.save
-    # recursively look at activity stream and add to parent_object_refs
-    process_recursive("https://#{MetadataSource.metadata_cloud_host}/metadatacloud/streams/activity")
-    refresh_updated_items(parent_object_refs)
-    return unless @most_recent_update
-    log.run_time = @most_recent_update
-    log.activity_stream_items = @tally_activity_stream_items
-    log.retrieved_records = @tally_queued_records
-    log.status = "Success"
+    begin
+      # recursively look at activity stream and add to parent_object_refs
+      process_recursive("https://#{MetadataSource.metadata_cloud_host}/metadatacloud/streams/activity")
+      refresh_updated_items(parent_object_refs)
+      return unless @most_recent_update
+      log.run_time = @most_recent_update
+      log.activity_stream_items = @tally_activity_stream_items
+      log.retrieved_records = @tally_queued_records
+    rescue => e
+      log.statue = "Failed: #{e}"
+    else
+      log.status = "Success"
+    end
     log.save
   end
 

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -31,7 +31,7 @@ class ActivityStreamReader
       log.activity_stream_items = @tally_activity_stream_items
       log.retrieved_records = @tally_queued_records
     rescue => e
-      log.statue = "Failed: #{e}"
+      log.status = "Failed: #{e}"
     else
       log.status = "Success"
     end

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # An ActivityStreamReader reads json formatted activity stream documents from the MetadataCloud
+# rubocop:disable Metrics/ClassLength
 class ActivityStreamReader
   attr_reader :tally_activity_stream_items, :tally_queued_records
 
@@ -17,6 +18,7 @@ class ActivityStreamReader
   end
 
   # Logs and kicks off processing the activity stream from the MetadataCloud
+  # rubocop:disable Metrics/MethodLength
   def process_activity_stream
     @updated_uris = []
     @most_recent_update = nil
@@ -32,11 +34,16 @@ class ActivityStreamReader
       @log.retrieved_records = @tally_queued_records
     rescue => e
       @log.status = "Failed: #{e}"
+    rescue SignalException => sigterm
+      @log.status = "Terminated: #{sigterm}"
+      @log.save
+      raise sigterm
     else
       @log.status = "Success"
     end
     @log.save
   end
+  # rubocop:enable Metrics/MethodLength
 
   ##
   # It takes the url for an Activity Stream page, and if there is a link to a previous page,
@@ -165,3 +172,4 @@ class ActivityStreamReader
     false
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -52,10 +52,8 @@ class ActivityStreamReader
     page = fetch_and_parse_page(page_url)
     page["orderedItems"].each do |item|
       @most_recent_update = item["endTime"] if @most_recent_update.nil?
-      if relevant?(item)
-        process_item(item)
-        @tally_activity_stream_items += 1
-      end
+      @tally_activity_stream_items += 1
+      process_item(item) if relevant?(item)
     end
     earliest_item_on_page = page["orderedItems"].last["endTime"].to_datetime
     @parent_object_refs += parents_for_update_from_dependent_uris(updated_uris)

--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -128,7 +128,7 @@ class ActivityStreamReader
 
       po = ParentObject.find_by_oid(oid)
       # skip it if the metadata source does not match (This should never happen after dependent uris are updating properly)
-      next unless po.authoritative_metadata_source.metadata_cloud_name == metadata_source
+      next unless po&.authoritative_metadata_source&.metadata_cloud_name == metadata_source
 
       #  if po was updated after the most recent update of one of all the dependent uris, skip it
       last_update = metadata_source == 'aspace' ? po.last_aspace_update : po.last_voyager_update

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -11,7 +11,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include PdfRepresentable
   include Delayable
   include DigitalObjectManagement
-  has_many :dependent_objects
+  has_many :dependent_objects, dependent: :delete_all
   has_many :child_objects, -> { order('"order" ASC, oid ASC') }, primary_key: 'oid', foreign_key: 'parent_object_oid', dependent: :destroy
   has_many :batch_connections, as: :connectable
   has_many :batch_processes, through: :batch_connections

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -6,7 +6,7 @@
 #   import: { priority: 20}
 # }
 Delayed::Worker.destroy_failed_jobs = false
-Delayed::Worker.max_run_time = 1.hour
+Delayed::Worker.max_run_time = 2.hours
 Delayed::Worker.default_queue_name = :default
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.logger = Rails.logger

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe ActivityStreamJob, type: :job do
     ActiveJob::QueueAdapters::DelayedJobAdapter.new
   end
 
+  around do |example|
+    original_mc_host = ENV["METADATA_CLOUD_HOST"]
+    ENV["METADATA_CLOUD_HOST"] = "not-a-real-host"
+    example.run
+    ENV["METADATA_CLOUD_HOST"] = original_mc_host
+  end
+
   let(:metadata_job) { ActivityStreamJob.new }
 
   it 'increments the job queue by one' do
@@ -24,9 +31,8 @@ RSpec.describe ActivityStreamJob, type: :job do
   end
 
   it 'job fails when not on VPN' do
-    expect do
-      ActivityStreamReader.update
-    end.to raise_error HTTP::ConnectionError
+    ActivityStreamReader.update
+    expect(ActivityStreamLog.last.status).to include("Fail")
   end
 
   describe 'automated daily job' do

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe ActivityStreamJob, type: :job do
     end.to change { Delayed::Job.count }.by(1)
   end
 
+  it 'increments the job queue by one for manual job' do
+    ActiveJob::Base.queue_adapter = :delayed_job
+    expect do
+      ActivityStreamManualJob.perform_later(metadata_job)
+    end.to change { Delayed::Job.count }.by(1)
+  end
+
   it 'job fails when not on VPN' do
     expect do
       ActivityStreamReader.update

--- a/spec/jobs/activity_stream_job_spec.rb
+++ b/spec/jobs/activity_stream_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ActivityStreamJob, type: :job do
   it 'increments the job queue by one for manual job' do
     ActiveJob::Base.queue_adapter = :delayed_job
     expect do
-      ActivityStreamManualJob.perform_later(metadata_job)
+      ActivityStreamManualJob.perform_later
     end.to change { Delayed::Job.count }.by(1)
   end
 

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe ActivityStreamReader, prep_metadata_sources: true do
         expect(ActivityStreamLog.count).to eq 1
         described_class.update
         expect(ActivityStreamLog.count).to eq 2
-        expect(ActivityStreamLog.last.activity_stream_items).to be > 1000
+        expect(ActivityStreamLog.last.activity_stream_items).to be 6
         expect(ActivityStreamLog.last.retrieved_records).to eq 2
       end
     end

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe ActivityStreamReader, prep_metadata_sources: true do
         expect(ActivityStreamLog.count).to eq 1
         described_class.update
         expect(ActivityStreamLog.count).to eq 2
-        expect(ActivityStreamLog.last.activity_stream_items).to be 6
+        expect(ActivityStreamLog.last.activity_stream_items).to be > 2000
         expect(ActivityStreamLog.last.retrieved_records).to eq 2
       end
     end


### PR DESCRIPTION
- Changes the processing of the activity stream to process dependent URIs on a page by page basis.  The parent object references are still collected for the entire job.
- Run manually triggered update in job.  (This needs to be a different job that the job that schedules itself.)
- Don't start a job if one is in progress by setting the status of the ActivityStreamLog to Running during processing.
- Increase max runtime for jobs to 2 hours.
- Delete DependentObjects when a ParentObject is deleted.
