### PR TITLE
Preprocess Problematic Tiffs with Vips

### DIFF
--- a/app/lib/tiff_to_pyramid.bash
+++ b/app/lib/tiff_to_pyramid.bash
@@ -132,7 +132,7 @@ fi
 # cleanup temp files but leave the outputput file in place
 if [ -z "${savefiles}" ]; then rm -f $tmpprefix*; fi
 if [ -z "${savefiles}" ]; then rm -f $outprefix*; fi
-if [ -f "${tmpfix}" ]; then rm -f $tmpfix; fi
+if [ -z "${savefiles}" ]; then rm -f $tmpfix; fi
 
 # sanity check
 WF=$(vipsheader -f width $outfile)


### PR DESCRIPTION
If identify fails on a tiff, preprocess with vips and try again.

There are some tiffs from source systems that could not be processed because imagemagick identity fails to read the file.
If the file is first passed through vips, with tiffsave, then the file can be processed with image magick.

This changes the ptiff bash script so that it first tries identity with the original file as it typically does.  If that succeeds, processing continues as before.  If it fails, the input file is processed through vips into a temp file, and the input used for the remainder of the script is the temp file.  The temp file created by vips is deleted after the processing is complete.

Co-authored-by: Maggie Zhao <maggie.zhao@yale.edu>