### PR TITLE
admin set export button

### DIFF
--- a/app/assets/stylesheets/admin_sets.scss
+++ b/app/assets/stylesheets/admin_sets.scss
@@ -3,6 +3,15 @@ DEFAULT DESKTOP STYLING
 ********************************************************/
 @import 'theme/colors', 'theme/typography', 'theme/breakpoints';
 
+#admin_set_button_row {
+  display: flex;
+  padding-bottom: 18px;
+}
+
+.export_button {
+  margin-left: 5px;
+}
+
 .table.admin-set-show-table {
   display: inline-block;
   width: auto;

--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -63,6 +63,22 @@ class BatchProcessesController < ApplicationController
     end
   end
 
+  def export_parent_objects
+    # RETURNS ADMIN SET KEY:
+    # admin_set = params.dig(:admin_set)
+
+    # RETURNS ADMIN SET ID FOR REDIRECTING
+    admin_set_id = params.dig(:admin_set_id)
+    redirect_to admin_set_path(admin_set_id), notice: "CSV is being generated. Please visit the Batch Process page to download."
+
+    # notice: "test"
+    # redirect_to admin_sets_path(admin_set), notice: "Test"
+    # pull in admin set id
+    # run create_parent_oid_csv job passing in the admin_set_id
+    # redirect to admin_set page
+    # success flash message user that informs the user that they can download the CSV from the Batch Process page 
+  end
+
   def download_csv
     # Add BOM to force Excel to open correctly
     send_data "\xEF\xBB\xBF" + @batch_process.csv,

--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -65,18 +65,15 @@ class BatchProcessesController < ApplicationController
 
   def export_parent_objects
     # RETURNS ADMIN SET KEY:
-    # admin_set = params.dig(:admin_set)
+    admin_set = params.dig(:admin_set)
 
     # RETURNS ADMIN SET ID FOR REDIRECTING
     admin_set_id = params.dig(:admin_set_id)
     redirect_to admin_set_path(admin_set_id), notice: "CSV is being generated. Please visit the Batch Process page to download."
 
-    # notice: "test"
-    # redirect_to admin_sets_path(admin_set), notice: "Test"
-    # pull in admin set id
-    # run create_parent_oid_csv job passing in the admin_set_id
-    # redirect to admin_set page
-    # success flash message user that informs the user that they can download the CSV from the Batch Process page 
+    batch_process = BatchProcess.new(batch_action: 'export all parent objects by admin set', user: current_user, file_name: "#{admin_set}_export.csv")
+    batch_process.save
+    CreateParentOidCsvJob.perform_now(batch_process, *admin_set_id)
   end
 
   def download_csv

--- a/app/jobs/create_parent_oid_csv_job.rb
+++ b/app/jobs/create_parent_oid_csv_job.rb
@@ -7,7 +7,7 @@ class CreateParentOidCsvJob < ApplicationJob
     -100
   end
 
-  def perform(batch_process)
-    batch_process.parent_output_csv
+  def perform(batch_process, *admin_set_id)
+    batch_process.parent_output_csv(*admin_set_id)
   end
 end

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -11,8 +11,6 @@ module CsvExportable
      'extent_of_digitization', 'digitization_note', 'project_identifier']
   end
 
-
-  
   # rubocop:disable Metrics/AbcSize
   def parent_output_csv(*admin_set_id)
     return nil unless batch_action == 'export all parent objects by admin set'

--- a/app/views/admin_sets/show.html.erb
+++ b/app/views/admin_sets/show.html.erb
@@ -1,8 +1,9 @@
 <%= render partial: "/management/flash_messages" %>
-<p>
-<a href="#BatchUpdateMetadata" role="button" class="btn btn-large btn-secondary" data-toggle="modal">Batch Update Metadata</a>
-<%= button_to "Export Parent Objects", export_parent_objects_batch_processes_url(admin_set: @admin_set.key, admin_set_id: @admin_set.id), method: :post %>
-</p>
+
+<div id="admin_set_button_row">
+  <a href="#BatchUpdateMetadata" role="button" class="btn btn-large btn-secondary" data-toggle="modal">Batch Update Metadata</a>
+  <%= button_to "Export Parent Objects", export_parent_objects_batch_processes_url(admin_set: @admin_set.key, admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary export_button" %>
+</div>
 
 <p>
   <strong>Key:</strong>

--- a/app/views/admin_sets/show.html.erb
+++ b/app/views/admin_sets/show.html.erb
@@ -1,6 +1,7 @@
 <%= render partial: "/management/flash_messages" %>
 <p>
 <a href="#BatchUpdateMetadata" role="button" class="btn btn-large btn-secondary" data-toggle="modal">Batch Update Metadata</a>
+<%= button_to "Export Parent Objects", export_parent_objects_batch_processes_url(admin_set: @admin_set.key, admin_set_id: @admin_set.id), method: :post %>
 </p>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resources :batch_processes do
     collection do
+      post :export_parent_objects
       post :import
       post :trigger_mets_scan
       get :download_template

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -214,20 +214,4 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       expect(page).to have_content("Access denied")
     end
   end
-
-  context 'test' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:admin_set) { FactoryBot.create(:admin_set, key: "brbl", label: "brbl") }
-
-    before do
-      admin_set
-      login_as user
-      user.add_role(:editor, admin_set)
-      visit admin_sets_path
-    end
-
-    it "hi" do
-      click_link "brbl"
-    end
-  end
 end

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -230,5 +230,4 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       click_link "brbl"
     end
   end
-
 end

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       end
     end
 
+    it 'can export parent objects' do
+      expect(BatchProcess.count).to eq 0
+      visit admin_sets_path
+      click_link(admin_set.key.to_s)
+      click_on("Export Parent Objects")
+      expect(page).to have_content "CSV is being generated. Please visit the Batch Process page to download."
+      expect(BatchProcess.count).to eq 1
+      expect(BatchProcess.last.created_file_name).to eq "#{admin_set.key}_export_bp_#{BatchProcess.last.id}.csv"
+    end
+
     it 'removes the viewer role from a user when they are given an editor role' do
       visit admin_sets_path
       click_link(admin_set.key.to_s)
@@ -204,4 +214,21 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       expect(page).to have_content("Access denied")
     end
   end
+
+  context 'test' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:admin_set) { FactoryBot.create(:admin_set, key: "brbl", label: "brbl") }
+
+    before do
+      admin_set
+      login_as user
+      user.add_role(:editor, admin_set)
+      visit admin_sets_path
+    end
+
+    it "hi" do
+      click_link "brbl"
+    end
+  end
+
 end


### PR DESCRIPTION
# Summary  

User can export an admin set via "Export Parent Objects" button on admin set showpage:  

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/24666568/148443194-a92d9a0d-99c3-4913-af2d-26fae127080d.png">  

<img width="1772" alt="image" src="https://user-images.githubusercontent.com/24666568/148443386-3770b8d6-f8bf-4d63-86b6-5e8aca42c934.png">  

File is located in S3:
<img width="1776" alt="image" src="https://user-images.githubusercontent.com/24666568/148443292-c7b4696c-c350-46ae-93eb-f761f12c6375.png">


