### PR TITLE
1845 Mapped aspace creator

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -45,16 +45,14 @@ module SolrIndexable
 
   def extract_creator(json_to_index)
     all_creators = []
-    [json_to_index["creator"], json_to_index["ancestorCreator"]].compact.each { |creator | all_creators +=creator }
+    [json_to_index["creator"], json_to_index["ancestorCreator"]].compact.each { |creator| all_creators += creator }
     all_creators.uniq
   end
 
   def from_the_collections(json_to_index)
     from_the_collections = json_to_index["ancestorCreator"]
-    if from_the_collections.present? && json_to_index["creator"].present?
-      from_the_collections-= json_to_index["creator"]
-    end
-    from_the_collections.uniq if from_the_collections
+    from_the_collections -= json_to_index["creator"] if from_the_collections.present? && json_to_index["creator"].present?
+    from_the_collections&.uniq
   end
 
   def to_solr(json_to_index = nil)

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -74,7 +74,7 @@ module SolrIndexable
         alternativeTitle_tesim: json_to_index["alternativeTitle"],
         alternativeTitleDisplay_tesim: json_to_index["alternativeTitleDisplay"],
         ancestorDisplayStrings_tesim: json_to_index["ancestorDisplayStrings"],
-        #collectionCreator name in mdc is ancestorCreator
+        # collectionCreator name in mdc is ancestorCreator
         collectionCreators_ssim: from_the_collections(json_to_index),
         ancestorTitles_tesim: generate_ancestor_title(json_to_index["ancestorTitles"]),
         ancestor_titles_hierarchy_ssim: ancestor_structure(generate_ancestor_title(json_to_index["ancestorTitles"])),

--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -76,6 +76,6 @@ class MetadataSource < ApplicationRecord
   end
 
   def self.metadata_cloud_host
-    ENV['METADATA_CLOUD_HOST'].present? ? ENV['METADATA_CLOUD_HOST'] : 'metadata-api-uat.library.yale.edu'
+    ENV['METADATA_CLOUD_HOST'].present? ? ENV['METADATA_CLOUD_HOST'] : 'metadata-api-test.library.yale.edu'
   end
 end

--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -76,6 +76,6 @@ class MetadataSource < ApplicationRecord
   end
 
   def self.metadata_cloud_host
-    ENV['METADATA_CLOUD_HOST'].present? ? ENV['METADATA_CLOUD_HOST'] : 'metadata-api-test.library.yale.edu'
+    ENV['METADATA_CLOUD_HOST'].present? ? ENV['METADATA_CLOUD_HOST'] : 'metadata-api-uat.library.yale.edu'
   end
 end

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -51,5 +51,4 @@ RSpec.describe SolrIndexable, type: :model do
     expect(solr_document[:creator_ssim]).to eq(['creator', 'creators', 'creatorx', 'ancestor creator king', 'ancestor creator'])
     expect(solr_document[:collectionCreators_ssim]).to eq(['ancestor creator'])
   end
-
 end

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -35,4 +35,21 @@ RSpec.describe SolrIndexable, type: :model do
     expect(solr_document[:subjectHeading_ssim]).to eq(['Test > Test2', 'Two > Three > Four'])
     expect(solr_document[:subjectHeadingFacet_ssim]).to eq(['Test', 'Test > Test2', 'Two', 'Two > Three', 'Two > Three > Four'])
   end
+
+  it "indexes the collect creators" do
+    solr_document = solr_indexable.to_solr('ancestorCreator' => ['ancestor creator'])
+    expect(solr_document[:collectionCreators_ssim]).to eq(['ancestor creator'])
+  end
+
+  it "indexes the collect creators" do
+    solr_document = solr_indexable.to_solr ({ 'ancestorCreator' => ['ancestor creator'], 'creator' => ['creator', 'creators', 'creatorx'] })
+    expect(solr_document[:creator_ssim]).to eq(['creator', 'creators', 'creatorx', 'ancestor creator'])
+  end
+
+  it "indexes the collect creators" do
+    solr_document = solr_indexable.to_solr ({ 'ancestorCreator' => ['ancestor creator', 'ancestor creator king'], 'creator' => ['creator', 'creators', 'creatorx', 'ancestor creator king'] })
+    expect(solr_document[:creator_ssim]).to eq(['creator', 'creators', 'creatorx', 'ancestor creator king', 'ancestor creator'])
+    expect(solr_document[:collectionCreators_ssim]).to eq(['ancestor creator'])
+  end
+
 end

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -40,15 +40,16 @@ RSpec.describe SolrIndexable, type: :model do
     solr_document = solr_indexable.to_solr('ancestorCreator' => ['ancestor creator'])
     expect(solr_document[:collectionCreators_ssim]).to eq(['ancestor creator'])
   end
-
-  it "indexes the collect creators" do
+  # rubocop:disable Lint/ParenthesesAsGroupedExpression
+  it "indexes the creators only" do
     solr_document = solr_indexable.to_solr ({ 'ancestorCreator' => ['ancestor creator'], 'creator' => ['creator', 'creators', 'creatorx'] })
     expect(solr_document[:creator_ssim]).to eq(['creator', 'creators', 'creatorx', 'ancestor creator'])
   end
 
-  it "indexes the collect creators" do
+  it "indexes the all the creators for the collect" do
     solr_document = solr_indexable.to_solr ({ 'ancestorCreator' => ['ancestor creator', 'ancestor creator king'], 'creator' => ['creator', 'creators', 'creatorx', 'ancestor creator king'] })
     expect(solr_document[:creator_ssim]).to eq(['creator', 'creators', 'creatorx', 'ancestor creator king', 'ancestor creator'])
     expect(solr_document[:collectionCreators_ssim]).to eq(['ancestor creator'])
   end
+  # rubocop:enable Lint/ParenthesesAsGroupedExpression
 end


### PR DESCRIPTION
Co-authored-by: Martin Lovell <martin.lovell@yale.edu>
Co-authored-by: Yue Ji <yue.ji@yale.edu>
Co-authored-by: Maggie Zhao <maggie.zhao@yale.edu>


DCS metadata mapping to ArchivesSpace currently pulls in creator information for an object from the collection level of a finding aid, if a creator is not presented at the file/item level. For example, for this parent object https://collections-uat.library.yale.edu/catalog/15603880 the creator listed, is the creator of the collection, listed at the collection level in ArchivesSpace for the collection this item belongs to. This is made obvious on the Archives at Yale record for this item https://archives.yale.edu/repositories/12/archival_objects/802216 which shows that the Creator is "From the collection".

We would like to follow this same principal in DCS. When the creator of an object is inherited from a higher level of description in the archival hierarchy in ASpace, the entry in DCS should be prepended with _From the Collection:_

So for the example listed above, the entry would be _From the Collection:_ Goel, Ravi D.

**Acceptance**
- [ ] For objects associated with ASpace, when Creator information is inherited from a higher level of description in ArchivesSpace, the entry should be prepended with the statement _From the Collection:_
- [ ] Reindex ASpace sources for all admin sets


-----
**ITEM PAGE**
![Screen Shot 2022-01-12 at 12.03.41 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/d3f20d8b-eba3-4084-95ca-8b84e131b7a2)

------
**RESULT PAGE**

![Screen Shot 2022-01-12 at 12.03.18 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/bf811faf-8e35-4f53-a176-dbe629dabc9f)

With the correct facet search: 
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/04611b6f-8c24-42fb-a5c4-524e5bfac525)
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1799