### PR TITLE
added preservica form fields

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -198,7 +198,7 @@ class ParentObjectsController < ApplicationController
     def parent_object_params
       cur_params = params.require(:parent_object).permit(:oid, :admin_set, :project_identifier, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
                                                          :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
-                                                         :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization, :digitization_note, :redirect_to)
+                                                         :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization, :digitization_note, :redirect_to, :preservica_uri, :digital_object_source)
       cur_params[:admin_set] = AdminSet.find_by(key: cur_params[:admin_set]) if cur_params[:admin_set]
       cur_params
     end

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -198,7 +198,8 @@ class ParentObjectsController < ApplicationController
     def parent_object_params
       cur_params = params.require(:parent_object).permit(:oid, :admin_set, :project_identifier, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
                                                          :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
-                                                         :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization, :digitization_note, :redirect_to, :preservica_uri, :digital_object_source)
+                                                         :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization,
+                                                         :digitization_note, :redirect_to, :preservica_uri, :digital_object_source)
       cur_params[:admin_set] = AdminSet.find_by(key: cur_params[:admin_set]) if cur_params[:admin_set]
       cur_params
     end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -35,7 +35,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/LineLength
   validates :redirect_to, format: { with: /\A((http|https):\/\/)?(collections-test.|collections-uat.|collections.)?library.yale.edu\/catalog\//, message: " in incorrect format. Please enter DCS url https://collections.library.yale.edu/catalog/123", allow_blank: true }
   # rubocop:enable Metrics/LineLength
-  validates :preservica_uri, presence: true, format: { with: %r{\A/}, message: " in incorrect format. URI must start with a /" }, if: proc { self.digital_object_source.present? }
+  validates :preservica_uri, presence: true, format: { with: %r{\A/}, message: " in incorrect format. URI must start with a /" }, if: proc { digital_object_source.present? }
 
   def check_for_redirect
     minify if redirect_to.present?

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -35,6 +35,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/LineLength
   validates :redirect_to, format: { with: /\A((http|https):\/\/)?(collections-test.|collections-uat.|collections.)?library.yale.edu\/catalog\//, message: " in incorrect format. Please enter DCS url https://collections.library.yale.edu/catalog/123", allow_blank: true }
   # rubocop:enable Metrics/LineLength
+  validates :preservica_uri, presence: true, format: { with: %r{\A/}, message: " in incorrect format. URI must start with a /" }, if: proc { self.digital_object_source.present? }
 
   def check_for_redirect
     minify if redirect_to.present?

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -115,6 +115,20 @@
       <%= form.text_field :aspace_uri %>
     </div>
   </div>
+
+  <br>
+  <h6 class="form-subgroup-title">Digital Object Identifiers</h6>
+  <div class="digital_object_identifiers, form-row">
+    <div class="col-med-3">
+      <%= form.label :digital_object_source %>
+      <%= form.select(:digital_object_source, [['Preservica', 'preservica']], { include_blank: true, default: nil }) %>
+    </div>
+
+    <div class="col-med-3">
+      <%= form.label :preservica_uri %>
+      <%= form.text_field :preservica_uri %>
+    </div>
+  </div>
   <br>
 
   <h6 class="form-subgroup-title">IIIF Values</h6>

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -121,7 +121,7 @@
   <div class="digital_object_identifiers, form-row">
     <div class="col-med-3">
       <%= form.label :digital_object_source %>
-      <%= form.select(:digital_object_source, [['Preservica', 'preservica']], { include_blank: true, default: nil }) %>
+      <%= form.select(:digital_object_source, ['Preservica'], { include_blank: true, default: nil }) %>
     </div>
 
     <div class="col-med-3">

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -64,6 +64,16 @@
 </p>
 
 <p>
+  <strong>Digital Object Source:</strong>
+  <%= @parent_object.digital_object_source %>
+</p>
+
+<p>
+  <strong>Preservica URI:</strong>
+  <%= @parent_object.preservica_uri %>
+</p>
+
+<p>
   <strong>Last ladybird update:</strong>
   <%= @parent_object.last_ladybird_update %>
 </p>

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -123,6 +123,21 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         click_on("Back")
         expect(page).to have_content "Child Object Count"
       end
+
+      it "validates preservica uri based on digital object source presence" do
+        select('Preservica')
+        click_on("Create Parent object")
+        expect(page).to have_content "Preservica uri can't be blank"
+        expect(page).to have_content "Preservica uri in incorrect format. URI must start with a /"
+      end
+
+      it "validates preservica uri format" do
+        select('Preservica')
+        expect(page).to have_field("Preservica uri")
+        fill_in('Preservica uri', with: "/preservica_uri")
+        click_on("Create Parent object")
+        expect(page).to have_content '/preservica_uri'
+      end
     end
 
     context "with a ParentObject whose authoritative_metadata_source is Ladybird" do


### PR DESCRIPTION
## Summary
Preservica fields are now on the Parent Object forms:  
  
Incorrect URI format:  
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/24666568/149427157-c3ef5e67-5b5e-4c71-9961-1ed99e252c81.png">
  
Showpage:  
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/24666568/149427320-3bf9202c-2d31-4e3d-b8f9-86e0fc6f3693.png">
