### PR TITLE
Change from IIIF v2 startCanvas to IIIF v3 start requires id/type

### DIFF
--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -232,8 +232,7 @@ class IiifPresentationV3
       canvas['width'] = image_anno["width"]
       canvas['behavior'] = [child.viewing_hint] unless child.viewing_hint.nil? || child.viewing_hint.empty?
       add_metadata_to_canvas(canvas, child)
-
-      @manifest["start"] = canvas['id'] if child_is_start_canvas? child.oid, index
+      @manifest["start"] = { 'id' => canvas['id'], 'type' => 'Canvas' } if child_is_start_canvas? child.oid, index
       items << canvas
     end
   end

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -330,16 +330,17 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
         parent_object_rep_edited = parent_object_rep
         parent_object_rep_edited.representative_child_oid = parent_object_rep.child_objects[8].oid
         iiif_presentation_rep = described_class.new(parent_object_rep_edited)
-        expect(iiif_presentation_rep.manifest["start"]).to include parent_object_rep_edited.representative_child_oid.to_s
+        expect(iiif_presentation_rep.manifest["start"]["id"]).to include parent_object_rep_edited.representative_child_oid.to_s
       end
     end
+
     context 'representative child is not one of the first 10 children' do
       it 'uses the first child as the startCanvas' do
         parent_object_rep_edited = parent_object_rep
         parent_object_rep_edited.representative_child_oid = parent_object_rep.child_objects[20].oid
 
         iiif_presentation_rep = described_class.new(parent_object_rep_edited)
-        expect(iiif_presentation_rep.manifest["startCanvas"]).to be_nil
+        expect(iiif_presentation_rep.manifest["start"]).to be_nil
       end
     end
   end


### PR DESCRIPTION
In IIIF Presentation v2 `startCanvas` is a string.  In v3 `start` is a resource with an `id` and `type`.