### PR TITLE
Add redirect to reassociate batch process

### DIFF
--- a/app/models/concerns/deletable.rb
+++ b/app/models/concerns/deletable.rb
@@ -53,7 +53,7 @@ module Deletable
       child_object.destroy
       child_object.parent_object.processing_event("child #{child_object.oid} has been deleted", 'deleted')
     end
-    update_related_parent_objects(parents_needing_update)
+    update_related_parent_objects(parents_needing_update, {})
   end
 
   # CHECKS TO SEE IF USER HAS ABILITY TO DELETE OBJECTS:

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -52,7 +52,6 @@ module Reassociatable
       parents_needing_update << co.parent_object.oid
       parents_needing_update << row["parent_oid"].to_i
 
-      # byebug
       reassociate_child(co, po)
 
       values_to_update = check_headers(child_headers, row)
@@ -101,7 +100,6 @@ module Reassociatable
   # assigns the child to the new parent
   def reassociate_child(co, po)
     if po.redirect_to.present?
-      # byebug
       failure_event_for_child(co, po.oid)
     else
       co.parent_object = po

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -4,18 +4,32 @@
 module Reassociatable
   extend ActiveSupport::Concern
 
+  #xx parse csv
+  # look at each row
+  # check the parent destination of the children
+  # track which parent objects (reassociated FROM: old po) that have children removed from them
+  # check old parent object to see if any children remain
+  # if a child remains, do nothing to old parent redirect_to and no message/error
+  # if no children remain and all children go to the same parent, redirect the old parent to the new parent 
+  
+  # triggers the reassociate process
   def reassociate_child_oids
     return unless batch_action == "reassociate child oids"
     parents_needing_update = update_child_objects
+    # childern_neededing_update = update_child_objects
     update_related_parent_objects(parents_needing_update)
   end
 
+  # finds which parents are needed to update
   def update_child_objects
     return unless batch_action == "reassociate child oids"
     parents_needing_update = []
+    children_needing_update = []
+
     parsed_csv.each_with_index do |row, index|
       co = load_child(index, row["child_oid"].to_i)
       po = load_parent(index, row["parent_oid"].to_i)
+      
       next unless co.present? && po.present?
 
       attach_item(po)
@@ -28,11 +42,13 @@ module Reassociatable
 
       reassociate_child(co, po)
       values_to_update = check_headers(child_headers, row)
-      update_child_parent_values(values_to_update, co, row, index)
+      update_child_values(values_to_update, co, row, index)
     end
+    # childern_needing_update
     parents_needing_update
   end
 
+  # verifies headers are included. child headers found in csv_exportable:90
   def check_headers(headers, row)
     possible_headers = headers
     values_to_update = []
@@ -44,7 +60,8 @@ module Reassociatable
 
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/MethodLength
-  def update_child_parent_values(values_to_update, co, row, index)
+  # updates values based on column values for child object
+  def update_child_values(values_to_update, co, row, index)
     values_to_update.each do |h|
       if h == 'viewing_hint'
         co.viewing_hint = valid_view(row[h], co.oid)
@@ -68,12 +85,14 @@ module Reassociatable
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/MethodLength
 
+  # assigns the child to the new parent
   def reassociate_child(co, po)
     co.parent_object = po
     processing_event_for_child(co)
     co.save!
   end
 
+  # alerts user of batch event
   def processing_event_for_child(co)
     co.current_batch_process = self
     co.current_batch_connection = batch_connections.find_or_create_by(connectable: co)
@@ -81,6 +100,7 @@ module Reassociatable
     co.processing_event("Child has parent #{co.parent_object.oid}", 'reassociate-complete')
   end
 
+  # checks the increment is correct and in order
   def extract_order(index, row)
     unless row["order"]&.to_i&.positive? || row["order"] == '0'
       batch_processing_event("Skipping row [#{index + 2}] with invalid order [#{row['order']}] (Parent: #{row['parent_oid']}, Child: #{row['child_oid']})", 'Skipped Row')
@@ -89,12 +109,14 @@ module Reassociatable
     row["order"].to_i
   end
 
+  # finds child object and adds alert if child cannot be found
   def load_child(index, oid)
     co = ChildObject.find_by_oid(oid)
     batch_processing_event("Skipping row [#{index + 2}] with Child Missing #{oid}", 'Skipped Row') unless co
     co
   end
 
+  # finds parent object and adds alert if parent cannot be found
   def load_parent(index, oid)
     po = ParentObject.find_by_oid(oid)
     batch_processing_event("Skipping row [#{index + 2}] with Parent Missing #{oid}", 'Skipped Row') unless po
@@ -102,6 +124,7 @@ module Reassociatable
   end
 
   # rubocop:disable Metrics/LineLength
+  # checks if viewing hint is valid
   def valid_view(viewing_hint, oid)
     if ChildObject.viewing_hints.include? viewing_hint
       viewing_hint
@@ -112,6 +135,7 @@ module Reassociatable
   end
   # rubocop:enable Metrics/LineLength
 
+  # updates count of parent objects and regenerates manifest pdf and reindexes solr.
   def update_related_parent_objects(parents_needing_update)
     return unless batch_action == "reassociate child oids" || batch_action == "delete child objects"
     parents_needing_update.uniq.each do |oid|

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -167,7 +167,6 @@ module Reassociatable
       # & that all children went to the same destination
       next unless sp.child_objects.count.zero? && destination_parents.uniq.count == 1
       # create the redirect
-      # byebug
       sp.redirect_to = "https://collections.library.yale.edu/catalog/#{destination_parents.first}"
       sp.save!
     end

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -110,10 +110,7 @@ module Reassociatable
 
   # alerts user of unsuccessful reassociation event
   def failure_event_for_child(co, po_oid)
-    co.current_batch_process = self
-    co.current_batch_connection = batch_connections.find_or_create_by(connectable: co)
-    co.current_batch_connection.save!
-    co.processing_event("Child #{co.oid} cannot be reassociated to redirected parent object: #{po_oid}", 'Skipped Row')
+    batch_processing_event("Child #{co.oid} cannot be reassociated to redirected parent object: #{po_oid}", 'Skipped Row')
   end
 
   # alerts user of successful reassociation event

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -19,6 +19,10 @@ module Reassociatable
 
   # updates constants with source and destination parents
   def check_for_redirects
+    # reset values
+    SOURCE_PARENTS.clear
+    DESTINATION_PARENTS.clear
+
     parsed_csv.each do |row|
       co = ChildObject.find_by_oid(row["child_oid"].to_i)
       po = ParentObject.find_by_oid(row["parent_oid"].to_i)
@@ -173,7 +177,7 @@ module Reassociatable
   end
 
   def create_redirect(source_parents, destination_parents)
-    source_parents.each do |sp_oid|
+    source_parents.uniq.each do |sp_oid|
       sp = ParentObject.find_by_oid(sp_oid)
       # check if there are no child objects
       # & that all children went to the same destination
@@ -181,6 +185,7 @@ module Reassociatable
       # create the redirect
       sp.redirect_to = "https://collections.library.yale.edu/catalog/#{destination_parents.first}"
       sp.save!
+      # byebug
     end
   end
 end

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -52,6 +52,7 @@ module Reassociatable
       parents_needing_update << co.parent_object.oid
       parents_needing_update << row["parent_oid"].to_i
 
+      # byebug
       reassociate_child(co, po)
 
       values_to_update = check_headers(child_headers, row)
@@ -100,6 +101,7 @@ module Reassociatable
   # assigns the child to the new parent
   def reassociate_child(co, po)
     if po.redirect_to.present?
+      # byebug
       failure_event_for_child(co, po.oid)
     else
       co.parent_object = po
@@ -185,7 +187,6 @@ module Reassociatable
       # create the redirect
       sp.redirect_to = "https://collections.library.yale.edu/catalog/#{destination_parents.first}"
       sp.save!
-      # byebug
     end
   end
 end

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -4,72 +4,30 @@
 module Reassociatable
   extend ActiveSupport::Concern
 
-  def check_for_redirects
-    # byebug
-    source_parents = []
-    destination_parents = []
-    
-    parsed_csv.each do |row|
-      co = ChildObject.find_by_oid(row["child_oid"].to_i)
-      po = ParentObject.find_by_oid(row["parent_oid"].to_i)
-      source_parents << co.parent_object.oid
-      destination_parents << row["parent_oid"].to_i
-      # byebug
-      # reassociate_child(co, po)
-    end
-    # source_parents.each do |sp_oid|
-    #   sp = ParentObject.find_by_oid(sp_oid)
-    #   # check if there are no child objects
-    #   # & that all children went to the same destination
-    #   if sp.child_objects.count.zero? && destination_parents.uniq.count == 1
-    #     # create the redirect
-    #     # byebug
-    #     sp.redirect_to = "https://collections.library.yale.edu/catalog/#{destination_parents.first}"
-    #     # sp.current_batch_process = self
-    #     # sp.current_batch_connection = batch_connections.find_or_create_by(connectable: sp)
-    #     # sp.current_batch_connection.save!
-    #     sp.save!
-    #     byebug
-    #   end
-    # end
-
-    source_parents
-    destination_parents
-  end
-
-  def create_redirect(source_parents, destination_parents)
-    source_parents.each do |sp_oid|
-      sp = ParentObject.find_by_oid(sp_oid)
-      # check if there are no child objects
-      # & that all children went to the same destination
-      if sp.child_objects.count.zero? && destination_parents.uniq.count == 1
-        # create the redirect
-        # byebug
-        sp.redirect_to = "https://collections.library.yale.edu/catalog/#{destination_parents.first}"
-        # sp.current_batch_process = self
-        # sp.current_batch_connection = batch_connections.find_or_create_by(connectable: sp)
-        # sp.current_batch_connection.save!
-        sp.save!
-        # byebug
-      end
-    end
-
-  end
-  # xx parse csv
-  # look at each row
-  # check the parent destination of the children
-  # track which parent objects (reassociated FROM: old po) that have children removed from them
-  # check old parent object to see if any children remain
-  # if a child remains, do nothing to old parent redirect_to and no message/error
-  # if no children remain and all children go to the same parent, redirect the old parent to the new parent
+  # rubocop:disable Style/MutableConstant
+  SOURCE_PARENTS = []
+  DESTINATION_PARENTS = []
+  # rubocop:enable Style/MutableConstant
 
   # triggers the reassociate process
   def reassociate_child_oids
     return unless batch_action == "reassociate child oids"
     check_for_redirects
     parents_needing_update = update_child_objects
-    byebug
-    update_related_parent_objects(parents_needing_update, source_parents, destination_parents) 
+    update_related_parent_objects(parents_needing_update)
+  end
+
+  # updates constants with source and destination parents
+  def check_for_redirects
+    parsed_csv.each do |row|
+      co = ChildObject.find_by_oid(row["child_oid"].to_i)
+      po = ParentObject.find_by_oid(row["parent_oid"].to_i)
+      # error messaging for user if parent or child object is not found issued from load_child in update_child_objects
+      next unless co.present? && po.present?
+
+      SOURCE_PARENTS << co.parent_object.oid
+      DESTINATION_PARENTS << row["parent_oid"].to_i
+    end
   end
 
   # finds which parents are needed to update
@@ -137,13 +95,12 @@ module Reassociatable
 
   # assigns the child to the new parent
   def reassociate_child(co, po)
-    # byebug
     co.parent_object = po
     processing_event_for_child(co)
     co.save!
   end
 
-  # alerts user of batch event
+  # alerts user of successful reassociation event
   def processing_event_for_child(co)
     co.current_batch_process = self
     co.current_batch_connection = batch_connections.find_or_create_by(connectable: co)
@@ -187,23 +144,32 @@ module Reassociatable
   # rubocop:enable Metrics/LineLength
 
   # updates count of parent objects and regenerates manifest pdf and reindexes solr.
-  def update_related_parent_objects(parents_needing_update, source_parents, destination_parents)
+  def update_related_parent_objects(parents_needing_update)
     return unless batch_action == "reassociate child oids" || batch_action == "delete child objects"
     parents_needing_update.uniq.each do |oid|
       po = ParentObject.find(oid)
-      # TODO: What do we want to happen if the parent object no longer has any associated child objects?
       po.child_object_count = po.child_objects.count
-      # byebug
-      create_redirect(source_parents, destination_parents)
+      create_redirect(SOURCE_PARENTS, DESTINATION_PARENTS)
       # If the child objects have changed, we'll need to re-create the manifest and PDF objects
       # and re-index to Solr
-      
       po.current_batch_process = self
       po.current_batch_connection = batch_connections.find_or_create_by(connectable: po)
       po.current_batch_connection.save!
       po.save!
-      # byebug
       GenerateManifestJob.perform_later(po, self, po.current_batch_connection)
+    end
+  end
+
+  def create_redirect(source_parents, destination_parents)
+    source_parents.each do |sp_oid|
+      sp = ParentObject.find_by_oid(sp_oid)
+      # check if there are no child objects
+      # & that all children went to the same destination
+      next unless sp.child_objects.count.zero? && destination_parents.uniq.count == 1
+      # create the redirect
+      # byebug
+      sp.redirect_to = "https://collections.library.yale.edu/catalog/#{destination_parents.first}"
+      sp.save!
     end
   end
 end

--- a/spec/fixtures/csv/reassociation_example_do_not_reassociate.csv
+++ b/spec/fixtures/csv/reassociation_example_do_not_reassociate.csv
@@ -1,0 +1,2 @@
+child_oid,parent_oid,order,parent_title,label,caption,viewing_hint
+12345,2004554,1,Roe,[Portrait of Grace Nail Johnson],,

--- a/spec/fixtures/csv/reassociation_example_do_not_redirect.csv
+++ b/spec/fixtures/csv/reassociation_example_do_not_redirect.csv
@@ -1,0 +1,4 @@
+child_oid,parent_oid,order,parent_title,label,caption,viewing_hint
+12345,2004550,1,Roe,[Portrait of Grace Nail Johnson],,
+67890,2004548,2,Roe,[Portrait of Grace Nail Johnson],,
+12,2004550,1,Roe,[Portrait of Grace Nail Johnson],,

--- a/spec/fixtures/csv/reassociation_example_redirect.csv
+++ b/spec/fixtures/csv/reassociation_example_redirect.csv
@@ -1,0 +1,4 @@
+child_oid,parent_oid,order,parent_title,label,caption,viewing_hint
+12345,2004550,1,Roe,[Portrait of Grace Nail Johnson],,
+67890,2004550,2,Roe,[Portrait of Grace Nail Johnson],,
+12,2004550,1,Roe,[Portrait of Grace Nail Johnson],,

--- a/spec/fixtures/csv/reassociation_example_redirect_system.csv
+++ b/spec/fixtures/csv/reassociation_example_redirect_system.csv
@@ -1,0 +1,3 @@
+child_oid,parent_oid,order,parent_title,label,caption,viewing_hint
+1030368,2004550,1,Roe,[Portrait of Grace Nail Johnson],,
+1032318,2004550,2,Roe,[Portrait of Grace Nail Johnson],,

--- a/spec/models/batch_process_reassociation_redirect_spec.rb
+++ b/spec/models/batch_process_reassociation_redirect_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
   let(:admin_set) { FactoryBot.create(:admin_set) }
   let(:role) { FactoryBot.create(:role, name: editor) }
-  let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_small.csv")) }
   let(:redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_redirect.csv")) }
   let(:do_not_redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_do_not_redirect.csv")) }
   let(:do_not_reassociate) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_do_not_reassociate.csv")) }
@@ -104,7 +103,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   end
 
   describe "reassociation batch process that attempts to reassociate children to a redirected parent object" do
-    # Original oid 
+    # Original oid 2004551
     before do
       parent_object_old_three
       parent_object_redirect.save
@@ -121,7 +120,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       expect(co.parent_object).to eq po_old_three
 
       # did not change the redirect
-      expect(parent_object_redirect.redirect_to).to be_nil
+      expect(parent_object_redirect.redirect_to).to eq "https://collections.library.yale.edu/catalog/#{parent_object_2.oid}"
       expect(parent_object_redirect.visibility).to eq("Redirect")
       expect(parent_object_redirect.child_objects.count).to eq 0
     end

--- a/spec/models/batch_process_reassociation_redirect_spec.rb
+++ b/spec/models/batch_process_reassociation_redirect_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_small.csv")) }
   let(:redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_redirect.csv")) }
   let(:do_not_redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_do_not_redirect.csv")) }
+  let(:do_not_reassociate) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_do_not_reassociate.csv")) }
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
   let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2004550", admin_set_id: admin_set.id) }
+  let(:parent_object_redirect) { FactoryBot.create(:parent_object, oid: "2004554", admin_set_id: admin_set.id, redirect_to: "https://collections.library.yale.edu/catalog/#{parent_object_2.oid}") }
   let(:parent_object_old_one) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
   let(:parent_object_old_two) { FactoryBot.create(:parent_object, oid: "2004549", admin_set_id: admin_set.id) }
   let(:parent_object_old_three) { FactoryBot.create(:parent_object, oid: "2004551", admin_set_id: admin_set.id, bib: "34567", call_number: "MSS MS 345") }
@@ -98,6 +100,30 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
       # still has child object
       po_old_one = ParentObject.find(parent_object_old_one.oid)
       expect(po_old_one.redirect_to).to be_nil
+    end
+  end
+
+  describe "reassociation batch process that attempts to reassociate children to a redirected parent object" do
+    # Original oid 
+    before do
+      parent_object_old_three
+      parent_object_redirect.save
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      batch_process.file = do_not_reassociate
+      batch_process.save
+    end
+
+    it "does not permit children to be reassociated" do
+      co = ChildObject.find(child_object_1.oid)
+      po_old_three = ParentObject.find(parent_object_old_three.oid)
+      # did not perform the reassociation
+      expect(co.parent_object).to eq po_old_three
+
+      # did not change the redirect
+      expect(parent_object_redirect.redirect_to).to be_nil
+      expect(parent_object_redirect.visibility).to eq("Redirect")
+      expect(parent_object_redirect.child_objects.count).to eq 0
     end
   end
 end

--- a/spec/models/batch_process_reassociation_redirect_spec.rb
+++ b/spec/models/batch_process_reassociation_redirect_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
+  subject(:batch_process) { described_class.new(batch_action: "reassociate child oids") }
+  let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:role) { FactoryBot.create(:role, name: editor) }
+  let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_small.csv")) }
+  let(:redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_redirect.csv")) }
+  let(:do_not_redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_do_not_redirect.csv")) }
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
+  let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2004550", admin_set_id: admin_set.id) }
+  let(:parent_object_old_one) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
+  let(:parent_object_old_two) { FactoryBot.create(:parent_object, oid: "2004549", admin_set_id: admin_set.id) }
+  let(:parent_object_old_three) { FactoryBot.create(:parent_object, oid: "2004551", admin_set_id: admin_set.id, bib: "34567", call_number: "MSS MS 345") }
+  let(:child_object_1) { FactoryBot.create(:child_object, oid: "12345", parent_object: parent_object_old_three) }
+  let(:child_object_2) { FactoryBot.create(:child_object, oid: "67890", parent_object: parent_object_old_three) }
+  let(:child_object_3) { FactoryBot.create(:child_object, oid: "12", parent_object: parent_object_old_one) }
+  let(:child_object_4) { FactoryBot.create(:child_object, oid: "123", parent_object: parent_object_old_one) }
+
+  around do |example|
+    perform_enqueued_jobs do
+      original_path_ocr = ENV['OCR_DOWNLOAD_BUCKET']
+      ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
+      example.run
+      ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
+    end
+  end
+
+  before do
+    stub_metadata_cloud("2002826")
+    stub_metadata_cloud("2004548")
+    stub_metadata_cloud("2004549")
+    stub_ptiffs_and_manifests
+    parent_object
+    parent_object_old_one
+    parent_object_old_two
+    child_object_1
+    child_object_2
+    child_object_3
+    login_as(:user)
+  end
+
+  describe "redirect objects that lose all children during reassociation batch process" do
+    # Original oid 2004551
+    before do
+      parent_object_old_three
+      parent_object_2
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      batch_process.file = redirect
+      batch_process.save
+    end
+
+    it "can add redirect_to to parent objects that have all its children reassociated" do
+      co = ChildObject.find(child_object_1.oid)
+      # performed the reassociation
+      expect(co.parent_object).to eq parent_object_2
+
+      po_old_three = ParentObject.find(parent_object_old_three.oid)
+      # created redirect
+      expect(po_old_three.redirect_to).to eq("https://collections.library.yale.edu/catalog/2004550")
+      expect(po_old_three.visibility).to eq("Redirect")
+      expect(po_old_three.bib).to be_nil
+      expect(po_old_three.call_number).to be_nil
+
+      # still has child object
+      po_old_one = ParentObject.find(parent_object_old_one.oid)
+      expect(po_old_one.redirect_to).to be_nil
+    end
+  end
+
+  describe "redirect objects that lose all children during reassociation batch process to different sources" do
+    # Original oid 2004551
+    before do
+      parent_object_old_three
+      parent_object_2
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      batch_process.file = do_not_redirect
+      batch_process.save
+    end
+
+    it "does not create redirect_to from parent objects that have all its children reassociated" do
+      co = ChildObject.find(child_object_1.oid)
+      # performed the reassociation
+      expect(co.parent_object).to eq parent_object_2
+
+      po_old_three = ParentObject.find(parent_object_old_three.oid)
+      # did not create redirect
+      expect(po_old_three.redirect_to).to be_nil
+      expect(po_old_three.visibility).to eq("Private")
+      expect(po_old_three.bib).to eq("34567")
+      expect(po_old_three.call_number).to eq("MSS MS 345")
+
+      # still has child object
+      po_old_one = ParentObject.find(parent_object_old_one.oid)
+      expect(po_old_one.redirect_to).to be_nil
+    end
+  end
+end

--- a/spec/models/batch_process_reassociation_spec.rb
+++ b/spec/models/batch_process_reassociation_spec.rb
@@ -10,14 +10,16 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_small.csv")) }
   let(:child_object_nil_values) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_child_object_counts.csv")) }
   let(:redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_redirect.csv")) }
+  let(:do_not_redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_do_not_redirect.csv")) }
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
   let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2004550", admin_set_id: admin_set.id) }
   let(:parent_object_old_one) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
   let(:parent_object_old_two) { FactoryBot.create(:parent_object, oid: "2004549", admin_set_id: admin_set.id) }
-  let(:parent_object_old_three) { FactoryBot.create(:parent_object, oid: "2004551", admin_set_id: admin_set.id) }
+  let(:parent_object_old_three) { FactoryBot.create(:parent_object, oid: "2004551", admin_set_id: admin_set.id, bib: "34567", call_number: "MSS MS 345") }
   let(:child_object_1) { FactoryBot.create(:child_object, oid: "12345", parent_object: parent_object_old_three) }
   let(:child_object_2) { FactoryBot.create(:child_object, oid: "67890", parent_object: parent_object_old_three) }
-  let(:child_object_3) { FactoryBot.create(:child_object, oid: "12", parent_object: parent_object_2) }
+  let(:child_object_3) { FactoryBot.create(:child_object, oid: "12", parent_object: parent_object_old_one) }
+  let(:child_object_4) { FactoryBot.create(:child_object, oid: "123", parent_object: parent_object_old_one) }
 
   around do |example|
     perform_enqueued_jobs do
@@ -61,6 +63,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
   end
 
   describe "redirect objects that lose all children during reassociation batch process" do
+    # Original oid 2004551
     before do
       parent_object_old_three
       parent_object_2
@@ -71,14 +74,49 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
     end
 
     it "can add redirect_to to parent objects that have all its children reassociated" do
-      # byebug
-      co = ChildObject.find('12345')
+      co = ChildObject.find(child_object_1.oid)
+      # performed the reassociation
       expect(co.parent_object).to eq parent_object_2
-      expect(parent_object_old_one.redirect_to).to be_nil
 
+      po_old_three = ParentObject.find(parent_object_old_three.oid)
+      # created redirect
+      expect(po_old_three.redirect_to).to eq("https://collections.library.yale.edu/catalog/2004550")
+      expect(po_old_three.visibility).to eq("Redirect")
+      expect(po_old_three.bib).to be_nil
+      expect(po_old_three.call_number).to be_nil
       
-      # end goal:
-      # expect(parent_object_old_one.redirect_to).to eq("https://www.collections.library.yale.edu/catalog/2004550")
+      # still has child object
+      po_old_one = ParentObject.find(parent_object_old_one.oid)
+      expect(po_old_one.redirect_to).to be_nil
+    end
+  end
+
+  describe "redirect objects that lose all children during reassociation batch process to different sources" do
+    # Original oid 2004551
+    before do
+      parent_object_old_three
+      parent_object_2
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      batch_process.file = do_not_redirect
+      batch_process.save
+    end
+
+    it "does not create redirect_to from parent objects that have all its children reassociated" do
+      co = ChildObject.find(child_object_1.oid)
+      # performed the reassociation
+      expect(co.parent_object).to eq parent_object_2
+
+      po_old_three = ParentObject.find(parent_object_old_three.oid)
+      # did not create redirect
+      expect(po_old_three.redirect_to).to be_nil
+      expect(po_old_three.visibility).to eq("Private")
+      expect(po_old_three.bib).to eq("34567")
+      expect(po_old_three.call_number).to eq("MSS MS 345")
+      
+      # still has child object
+      po_old_one = ParentObject.find(parent_object_old_one.oid)
+      expect(po_old_one.redirect_to).to be_nil
     end
   end
 

--- a/spec/system/batch_process_reassociation_redirect_spec.rb
+++ b/spec/system/batch_process_reassociation_redirect_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
   # parent object has two child objects
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
   let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2004550", admin_set_id: admin_set.id) }
+  let(:parent_object_redirect) { FactoryBot.create(:parent_object, oid: "2004554", admin_set_id: admin_set.id, redirect_to: "https://collections.library.yale.edu/catalog/#{parent_object_2.oid}") }
+  let(:child_object_1) { FactoryBot.create(:child_object, oid: "12345", parent_object: parent_object_2) }
 
   before do
     stub_metadata_cloud("2005512")
     stub_ptiffs_and_manifests
     parent_object
     parent_object_2
+    child_object_1
   end
 
   around do |example|
@@ -39,6 +42,30 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     it "updates relationships and creates a redirected parent object" do
       po = ParentObject.find(parent_object.oid)
       expect(page).to have_content "Your job is queued for processing in the background"
+      expect(po.redirect_to).to eq "https://collections.library.yale.edu/catalog/#{parent_object_2.oid}"
+      expect(po.visibility).to eq "Redirect"
+      expect(po.call_number).to be_nil
+    end
+  end
+
+  describe "child object reassociation with redirected parent object destination" do
+    before do
+      parent_object_redirect.save
+      login_as user
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      visit batch_processes_path
+      select("Reassociate Child Oids")
+      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/csv/reassociation_example_do_not_reassociate.csv")
+      click_button("Submit")
+    end
+
+    it "does not update relationships and does not change the redirected parent object" do
+      po = ParentObject.find(parent_object_redirect.oid)
+      expect(page).to have_content "Your job is queued for processing in the background"
+      co = ChildObject.find(child_object_1.oid)
+      expect(co.parent_object).to eq parent_object_2
+
       expect(po.redirect_to).to eq "https://collections.library.yale.edu/catalog/#{parent_object_2.oid}"
       expect(po.visibility).to eq "Redirect"
       expect(po.call_number).to be_nil

--- a/spec/system/batch_process_reassociation_redirect_spec.rb
+++ b/spec/system/batch_process_reassociation_redirect_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
+  let(:batch_process) { described_class.new(batch_action: "reassociate child oids") }
+  let(:user) { FactoryBot.create(:user) }
+  let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl', label: 'brbl') }
+  # parent object has two child objects
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
+  let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2004550", admin_set_id: admin_set.id) }
+
+  before do
+    stub_metadata_cloud("2005512")
+    stub_ptiffs_and_manifests
+    parent_object
+    parent_object_2
+  end
+
+  around do |example|
+    perform_enqueued_jobs do
+      original_path_ocr = ENV['OCR_DOWNLOAD_BUCKET']
+      ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
+      example.run
+      ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
+    end
+  end
+
+  describe "child object reassociation with removing all children" do
+    before do
+      login_as user
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      visit batch_processes_path
+      select("Reassociate Child Oids")
+      page.attach_file("batch_process_file", Rails.root + "spec/fixtures/csv/reassociation_example_redirect_system.csv")
+      click_button("Submit")
+    end
+
+    it "updates relationships and creates a redirected parent object" do
+      po = ParentObject.find(parent_object.oid)
+      expect(page).to have_content "Your job is queued for processing in the background"
+      expect(po.redirect_to).to eq "https://collections.library.yale.edu/catalog/#{parent_object_2.oid}"
+      expect(po.visibility).to eq "Redirect"
+      expect(po.call_number).to be_nil
+    end
+  end
+end

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         select("Reassociate Child Oids")
         click_button("Submit")
         expect(page).to have_content("Your job is queued for processing in the background")
-        expect(parent_object.reload.child_object_count).to eq(0)
+        expect(parent_object.reload.child_objects.count).to eq(0)
         expect(parent_object_old_one.reload.child_object_count).to eq(3)
       end
 


### PR DESCRIPTION
# Summary
As part of the reassociation batch process if a parent object has all children redirected to the same destination parent then the source parent will be converted into a redirected parent object directing to the destination parent.  Includes error messaging for user attempting to reassociate child objects to a redirected parent object.

# Related Ticket
[#1784](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1784)

# Screenshots

![image](https://user-images.githubusercontent.com/36549923/149598141-c1ea4d77-5936-470f-a5ca-20719278b858.png)
![image](https://user-images.githubusercontent.com/36549923/149598177-c28be136-3451-4790-be2a-3280c954df7b.png)
![image](https://user-images.githubusercontent.com/36549923/149844819-782785ca-3601-4016-b570-222073be325a.png)
