### PR TITLE
Change the way the redirect hash is created

### DIFF
--- a/app/models/concerns/deletable.rb
+++ b/app/models/concerns/deletable.rb
@@ -53,7 +53,7 @@ module Deletable
       child_object.destroy
       child_object.parent_object.processing_event("child #{child_object.oid} has been deleted", 'deleted')
     end
-    update_related_parent_objects(parents_needing_update)
+    update_related_parent_objects(parents_needing_update, {})
   end
 
   # CHECKS TO SEE IF USER HAS ABILITY TO DELETE OBJECTS:


### PR DESCRIPTION
Create a redirect hash mapping parent oid to the list of destination oids it's children were moved to.
When processing parents, if it has 0 children, check the list of destination oids to see if all when to 1 parent.