### PR TITLE
Adds preservica fields to export

### DIFF
--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -6,7 +6,8 @@ module CsvExportable
 
   def parent_headers
     ['oid', 'admin_set', 'authoritative_source', 'child_object_count', 'call_number',
-     'container_grouping', 'bib', 'holding', 'item', 'barcode', 'aspace_uri', 'last_ladybird_update',
+     'container_grouping', 'bib', 'holding', 'item', 'barcode', 'aspace_uri',
+     'digital_object_source', 'preservica_uri', 'last_ladybird_update',
      'last_voyager_update', 'last_aspace_update', 'last_id_update', 'visibility',
      'extent_of_digitization', 'digitization_note', 'project_identifier']
   end
@@ -20,7 +21,8 @@ module CsvExportable
         next csv << po if po.is_a?(Array)
         row = [po.oid, po.admin_set.label, po.source_name,
                po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
-               po.barcode, po.aspace_uri, po.last_ladybird_update, po.last_voyager_update,
+               po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
+               po.last_ladybird_update, po.last_voyager_update,
                po.last_aspace_update, po.last_id_update, po.visibility, po.extent_of_digitization,
                po.digitization_note, po.project_identifier]
         csv << row

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     context "outputting csv" do
       let(:brbl) { AdminSet.find_by_key("brbl") }
       let(:other_admin_set) { FactoryBot.create(:admin_set) }
-      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_034_600, admin_set: brbl) }
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_034_600, admin_set: brbl, digital_object_source: "Preservica", preservica_uri: "/preservica_uri") }
       let(:parent_object2) { FactoryBot.create(:parent_object, oid: 2_005_512, admin_set: other_admin_set) }
       let(:user) { FactoryBot.create(:user) }
 
@@ -184,6 +184,8 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.file_name).to eq "export_parent_oids.csv"
         expect(BatchProcess.last.batch_action).to eq "export all parent objects by admin set"
         expect(BatchProcess.last.parent_output_csv).to include "2034600"
+        expect(BatchProcess.last.parent_output_csv).to include "Preservica"
+        expect(BatchProcess.last.parent_output_csv).to include "/preservica_uri"
         expect(BatchProcess.last.parent_output_csv).not_to include "2005512"
       end
 


### PR DESCRIPTION
# Summary
Adds 'preservica_uri' and 'digital_object_source' to the csv exported by the Export All Parents By Admin Set batch process.

# Related Ticket
[#1824](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1824)

# Screenshot
<img width="697" alt="image" src="https://user-images.githubusercontent.com/36549923/150188621-c04aba83-57c0-4536-8ccc-3de746ad7feb.png">
