### PR TITLE
Update parent show page so it will display even when metadata cloud URL can't be generated

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -272,7 +272,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.container_grouping = authoritative_json["containerGrouping"].is_a?(Array) ? authoritative_json["containerGrouping"].first : authoritative_json["containerGrouping"]
   end
 
-  def add_media_type url
+  def add_media_type(url)
     return "#{url}&mediaType=json" if url.include?("?")
     "#{url}?mediaType=json"
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -272,14 +272,19 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.container_grouping = authoritative_json["containerGrouping"].is_a?(Array) ? authoritative_json["containerGrouping"].first : authoritative_json["containerGrouping"]
   end
 
+  def add_media_type url
+    return "#{url}&mediaType=json" if url.include?("?")
+    "#{url}?mediaType=json"
+  end
+
   def metadata_cloud_url
     case source_name
     when "ladybird"
-      ladybird_cloud_url
+      add_media_type ladybird_cloud_url
     when "ils"
-      voyager_cloud_url
+      add_media_type voyager_cloud_url
     when "aspace"
-      aspace_cloud_url
+      add_media_type aspace_cloud_url
     else
       raise StandardError, "Unexpected metadata cloud name: #{authoritative_metadata_source.metadata_cloud_name}"
     end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -283,6 +283,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     else
       raise StandardError, "Unexpected metadata cloud name: #{authoritative_metadata_source.metadata_cloud_name}"
     end
+  rescue
+    nil
   end
 
   def json_for(source_name)

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -25,7 +25,6 @@
 <% if @parent_object&.metadata_cloud_url.present? %>
 <p>
   <strong>MetadataCloud url:</strong><br>
-  <small>Note: add "&mediaType=json" or "?mediaType=json" to open in your browser</small><br>
   <%= link_to "#{@parent_object.metadata_cloud_url}", "#{@parent_object.metadata_cloud_url}" %>
 </p>
 <% end %>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -22,11 +22,13 @@
   </p>
 <% end %>
 
+<% if @parent_object&.metadata_cloud_url.present? %>
 <p>
   <strong>MetadataCloud url:</strong><br>
   <small>Note: add "&mediaType=json" or "?mediaType=json" to open in your browser</small><br>
   <%= link_to "#{@parent_object.metadata_cloud_url}", "#{@parent_object.metadata_cloud_url}" %>
 </p>
+<% end %>
 
 <p>
   <strong>Call Number:</strong>

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -83,7 +83,9 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       batch_process.save!
       po = ParentObject.find(30_000_557)
       expect(po.aspace_uri).to eq "/repositories/11/archival_objects/329771"
-      expect(po.metadata_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/aspace/repositories/11/archival_objects/329771?mediaType=json"
+      expect(po.metadata_cloud_url).to eq(
+        "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/aspace/repositories/11/archival_objects/329771?mediaType=json"
+      )
     end
 
     it "creates a parent object with admin set from the METs document" do

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(po.viewing_direction).to eq "left-to-right"
       expect(po.display_layout).to eq "individuals"
       expect(po.representative_child_oid).to eq 30_000_403
-      expect(po.metadata_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/ils/holding/1330141?bib=1188135"
+      expect(po.metadata_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/ils/holding/1330141?bib=1188135&mediaType=json"
     end
 
     it "creates a parent object with extent of digitization empty" do
@@ -83,7 +83,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       batch_process.save!
       po = ParentObject.find(30_000_557)
       expect(po.aspace_uri).to eq "/repositories/11/archival_objects/329771"
-      expect(po.metadata_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/aspace/repositories/11/archival_objects/329771"
+      expect(po.metadata_cloud_url).to eq "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/#{MetadataSource.metadata_cloud_version}/aspace/repositories/11/archival_objects/329771?mediaType=json"
     end
 
     it "creates a parent object with admin set from the METs document" do

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -224,6 +224,15 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
       expect(parent_object.redirect_to).to eq 'https://collections.library.yale.edu/catalog/123'
     end
 
+    it 'can display redirected non-ladybird parents' do
+      parent_object = ParentObject.create! valid_attributes
+      expect(parent_object.bib).to eq("123")
+      patch parent_object_url(parent_object), params: { parent_object: redirect_attributes.merge(authoritative_metadata_source_id: 2) }
+      parent_object.reload
+      get parent_object_url(parent_object)
+      expect(response).to be_successful
+    end
+
     it 'redirects to the parent show page' do
       parent_object = ParentObject.create! valid_attributes
       patch parent_object_url(parent_object), params: { parent_object: redirect_attributes }


### PR DESCRIPTION
Allow parent show page to display in management without an error even if the metadata cloud URL can not be generated.
There are cases where the metadata cloud URL can't be generated, but the show page for a parent should not error out.

This fixes the bug where redirected aspace/voyager parents' show pages would error out.

This also updates the URL displayed on the parent show page to already include the mediaType=json  parameter so it can be clicked more easily from the parent object show page.