### PR TITLE
Adds function to disable button over record threshold

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -334,7 +334,7 @@ $( document ).on('turbolinks:load', function() {
   table.clear()
   table.ajax.url($('.is-datatable').data('source')).load(function() {
 
-    var info = $('#child-objects-datatable_info').text().split(' ')
+    var info = $('#child-objects-datatable_info, #parent-objects-datatable_info, #redirected-parent-objects-datatable_info, #batch-processes-datatable_info, #preservica-ingests-datatable_info').text().split(' ')
     var entries = info[5]
     if ( entries > 12000 ) {
       // Disable the button

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -191,9 +191,6 @@ $( document ).on('turbolinks:load', function() {
           action: newExportAction,
           text: "All Matching Entries",
           className: "export-all"
-          // customize: function (csv) {
-          //   return check_csv(csv)
-          // }
         }
       ],
       // pagingType is optional, if you want full pagination controls.

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -190,9 +190,10 @@ $( document ).on('turbolinks:load', function() {
           extend: 'csvHtml5',
           action: newExportAction,
           text: "All Matching Entries",
-          customize: function(){
-            alert("Export of all matching entries is in progress.")
-          }
+          className: "export-all"
+          // customize: function (csv) {
+          //   return check_csv(csv)
+          // }
         }
       ],
       // pagingType is optional, if you want full pagination controls.
@@ -325,6 +326,32 @@ $( document ).on('turbolinks:load', function() {
   $('.parent-edit').on('submit', function() {
     if ( $("#parent_object_redirect_to").val() !== '' && $("#parent_object_redirect_to").length ) {
       return confirm('Adding Redirect To information will remove that object from public view.  Do you wish to continue?');
+    }
+  })
+})
+
+// This will disable the export all button when there are more than 12K records
+$( document ).on('turbolinks:load', function() {
+  // Get count of records
+  var table = $('.is-datatable').DataTable();
+  table.clear()
+  table.ajax.url($('.is-datatable').data('source')).load(function() {
+
+    var info = $('#child-objects-datatable_info').text().split(' ')
+    var entries = info[5]
+    if ( entries > 12000 ) {
+      // Disable the button
+      $('.export-all').attr('disabled', true)
+      // Tell the user why
+      $('.export-all').hover(
+        function() {
+          $( this ).find( "span" ).last().remove();
+          $( this ).append( $( "<span>Cannot export over 12K records</span>" ) );
+        }, function() {
+          $( this ).find( "span" ).last().remove();
+          $( this ).append( $( "<span>All Matching Entries</span>" ) );
+        }
+      )
     }
   })
 })

--- a/app/views/redirected_parent_objects/index.html.erb
+++ b/app/views/redirected_parent_objects/index.html.erb
@@ -7,7 +7,7 @@
 
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='parent-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= redirected_parent_objects_path(format: :json) %>'>
+    <table id='redirected-parent-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= redirected_parent_objects_path(format: :json) %>'>
       <thead class='table-head'>
         <tr>
           <th scope='col'>OID</th>
@@ -23,6 +23,6 @@
   </div>
 </div>
 
-<div id='parent-objects-data' class='d-none datatable-data'>
+<div id='redirected-parent-objects-data' class='d-none datatable-data'>
   <%= RedirectedParentObjectDatatable.new(nil).view_columns.map {|key, value| {data: key, orderable: value[:orderable], searchable: value[:searchable], options: value[:options]} }.to_json %>
 </div>


### PR DESCRIPTION
# Summary
If the datatable has over 12,000 records the 'Export Matching Entries' will be disabled and will display a user message on hover.  This PR also removes a custom alert that has broken the export in production.

# Related Ticket
[#1800](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1800)

# Screenshots
### Disabled
![Screen Shot 2022-01-20 at 1 49 20 PM](https://user-images.githubusercontent.com/36549923/150430090-b7d156bc-2ea3-4fe8-a839-06bc110e1732.png)

### User Messaging - On Hover
![Screen Shot 2022-01-20 at 1 49 04 PM](https://user-images.githubusercontent.com/36549923/150430129-6fd143e3-e4fb-4b6f-b421-fef152650437.png)

