### PR TITLE
Confirm solr visibility handling

### DIFF
--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
     end
   end
 
-  describe "changing the parent to private", solr: true do
+  describe "changing the parent from public to private", solr: true do
     let(:oid) { "2034600" }
     let(:parent_object) { FactoryBot.create(:parent_object, oid: oid, source_name: 'ladybird', visibility: "Public") }
     before do
@@ -120,8 +120,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       solr_document = parent_object.reload.to_solr
       parent_object.save!
       expect(solr_document[:visibility_ssi]).to eq "Private"
-      response = solr.get 'select', params: { q: 'oid_ssi:2034600' }
-      expect(response["response"]["docs"].first["visibility_ssi"]).to eq "Private"
     end
   end
 

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -104,6 +104,27 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
     end
   end
 
+  describe "changing the parent to private", solr: true do
+    let(:oid) { "2034600" }
+    let(:parent_object) { FactoryBot.create(:parent_object, oid: oid, source_name: 'ladybird', visibility: "Public") }
+    before do
+      stub_metadata_cloud(oid)
+      parent_object
+    end
+
+    it "indexes the new visibility" do
+      solr_document = parent_object.reload.to_solr
+      expect(solr_document[:visibility_ssi]).to eq "Public"
+      parent_object.visibility = "Private"
+      parent_object.save!
+      solr_document = parent_object.reload.to_solr
+      parent_object.save!
+      expect(solr_document[:visibility_ssi]).to eq "Private"
+      response = solr.get 'select', params: { q: 'oid_ssi:2034600' }
+      expect(response["response"]["docs"].first["visibility_ssi"]).to eq "Private"
+    end
+  end
+
   context "indexing to Solr from the database with Ladybird ParentObjects", solr: true do
     it "can index the 5 parent objects in the database to Solr and can remove those items", undelayed: true do
       response = solr.get 'select', params: { q: 'type_ssi:parent' }

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -174,6 +174,23 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         expect(page.body).to include "Yale Community Only"
       end
 
+      it "can change the visibility to private via the UI" do
+        click_on("Edit")
+        select("Yale Community Only")
+        click_on(UPDATE_PARENT_OBJECT_BUTTON)
+        expect(page.body).to include "Yale Community Only"
+        click_on("Edit")
+        select("Private")
+        click_on(UPDATE_PARENT_OBJECT_BUTTON)
+        expect(page.body).to include "Private"
+        click_on("Back")
+        click_on("Update Metadata")
+        visit parent_object_path(2_012_036)
+        # counts once on page and once in solr document section
+        expect(page.body).to include("Private").twice
+        expect(page.body).to include "visibility_ssi"
+      end
+
       it "can change the Admin Set via the UI", prep_admin_sets: true do
         visit parent_object_path(2_012_036)
         click_on("Edit")


### PR DESCRIPTION
# Summary
Adds specs to confirm that the correct visibility is indexed to solr.

# Related Ticket
[#1869](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1869)

