### PR TITLE
WIP: Demonstrate issue with Solr save with no children

### DIFF
--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -112,14 +112,33 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       parent_object
     end
 
-    it "indexes the new visibility" do
-      solr_document = parent_object.reload.to_solr
-      expect(solr_document[:visibility_ssi]).to eq "Public"
+    it "indexes the new visibility in solr" do
+      solr = SolrService.connection
+
+      parent_object.visibility = "Public"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Public"
+
+      parent_object.visibility = "Yale Community Only"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Yale Community Only"
+
+      # rubocop:disable RSpec/AnyInstance
+      # ParentObject will return false to manifest_complete if there are no children, so simulating no children with:
+      allow_any_instance_of(ParentObject).to receive(:manifest_completed?).and_return(false)
+      # rubocop:enable RSpec/AnyInstance
       parent_object.visibility = "Private"
-      parent_object.save!
-      solr_document = parent_object.reload.to_solr
-      parent_object.save!
-      expect(solr_document[:visibility_ssi]).to eq "Private"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Private"
     end
   end
 


### PR DESCRIPTION
This is just to demonstrate the issue with parents not updating solr if they have no children.

This can be demonstrated using the UI by following these steps:
- Choose a test parent that is public, indexed, and searchable in SOLR.
- In Management, reassociate all the children for that parent to some other parent(s). (It's easiest to re-associate with multiple parents so it doesn't end up being redirected.) (At this point, it will no longer be able to update solr).
- In Management, set the parent to "Private" and save.
- Check the Solr record and blacklight: Record will still be in solr from before it was set to private and children were removed.  (Blacklight thinks it's public, so it will serve it up and the IIIF and manifest, etc.)