### PR TITLE
added preservica fields to child objects

### DIFF
--- a/app/controllers/child_objects_controller.rb
+++ b/app/controllers/child_objects_controller.rb
@@ -80,6 +80,7 @@ class ChildObjectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def child_object_params
-      params.require(:child_object).permit(:oid, :caption, :label, :width, :height, :order, :viewing_hint, :parent_object_oid)
+      params.require(:child_object).permit(:oid, :caption, :label, :width, :height, :order, :viewing_hint,
+                                           :parent_object_oid, :preservica_content_object_uri, :preservica_generation_uri, :preservica_bitstream_uri)
     end
 end

--- a/app/views/child_objects/show.html.erb
+++ b/app/views/child_objects/show.html.erb
@@ -41,6 +41,21 @@
 </p>
 
 <p>
+  <strong>Preservica Content Object URI:</strong>
+  <%= @child_object.preservica_content_object_uri %>
+</p>
+
+<p>
+  <strong>Preservica Generation URI:</strong>
+  <%= @child_object.preservica_content_object_uri %>
+</p>
+
+<p>
+  <strong>Preservica Bitstream URI:</strong>
+  <%= @child_object.preservica_bitstream_uri %>
+</p>
+
+<p>
   <strong>Full text:</strong>
   <%= @child_object.full_text ? "Yes" : "No" %>
 </p>

--- a/db/migrate/20220131212240_add_preservica_to_child_object.rb
+++ b/db/migrate/20220131212240_add_preservica_to_child_object.rb
@@ -1,0 +1,10 @@
+class AddPreservicaToChildObject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :child_objects, :preservica_content_object_uri, :string
+    add_column :child_objects, :preservica_generation_uri, :string
+    add_column :child_objects, :preservica_bitstream_uri, :string
+    add_index  :child_objects, :preservica_content_object_uri unless index_exists?(:child_objects, :preservica_content_object_uri)
+    add_index  :child_objects, :preservica_generation_uri unless index_exists?(:child_objects, :preservica_generation_uri)
+    add_index  :child_objects, :preservica_bitstream_uri unless index_exists?(:child_objects, :preservica_bitstream_uri)
+  end
+end

--- a/db/migrate/20220131212240_add_preservica_to_child_object.rb
+++ b/db/migrate/20220131212240_add_preservica_to_child_object.rb
@@ -1,8 +1,8 @@
 class AddPreservicaToChildObject < ActiveRecord::Migration[6.0]
   def change
-    add_column :child_objects, :preservica_content_object_uri, :string
-    add_column :child_objects, :preservica_generation_uri, :string
-    add_column :child_objects, :preservica_bitstream_uri, :string
+    add_column :child_objects, :preservica_content_object_uri, :text
+    add_column :child_objects, :preservica_generation_uri, :text
+    add_column :child_objects, :preservica_bitstream_uri, :text
     add_index  :child_objects, :preservica_content_object_uri unless index_exists?(:child_objects, :preservica_content_object_uri)
     add_index  :child_objects, :preservica_generation_uri unless index_exists?(:child_objects, :preservica_generation_uri)
     add_index  :child_objects, :preservica_bitstream_uri unless index_exists?(:child_objects, :preservica_bitstream_uri)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,9 +75,9 @@ ActiveRecord::Schema.define(version: 2022_01_31_212240) do
     t.string "mets_access_master_path"
     t.boolean "full_text", default: false
     t.integer "original_oid"
-    t.string "preservica_content_object_uri"
-    t.string "preservica_generation_uri"
-    t.string "preservica_bitstream_uri"
+    t.text "preservica_content_object_uri"
+    t.text "preservica_generation_uri"
+    t.text "preservica_bitstream_uri"
     t.index ["caption"], name: "index_child_objects_on_caption"
     t.index ["label"], name: "index_child_objects_on_label"
     t.index ["oid"], name: "index_child_objects_on_oid", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_002832) do
+ActiveRecord::Schema.define(version: 2022_01_31_212240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,12 +75,18 @@ ActiveRecord::Schema.define(version: 2022_01_19_002832) do
     t.string "mets_access_master_path"
     t.boolean "full_text", default: false
     t.integer "original_oid"
+    t.string "preservica_content_object_uri"
+    t.string "preservica_generation_uri"
+    t.string "preservica_bitstream_uri"
     t.index ["caption"], name: "index_child_objects_on_caption"
     t.index ["label"], name: "index_child_objects_on_label"
     t.index ["oid"], name: "index_child_objects_on_oid", unique: true
     t.index ["order"], name: "index_child_objects_on_order"
     t.index ["original_oid"], name: "index_child_objects_on_original_oid"
     t.index ["parent_object_oid"], name: "index_child_objects_on_parent_object_oid"
+    t.index ["preservica_bitstream_uri"], name: "index_child_objects_on_preservica_bitstream_uri"
+    t.index ["preservica_content_object_uri"], name: "index_child_objects_on_preservica_content_object_uri"
+    t.index ["preservica_generation_uri"], name: "index_child_objects_on_preservica_generation_uri"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|


### PR DESCRIPTION
# Summary
Child Objects now have Preservica Content Object URI, Preservica Generation URI, and Preservica Bitstream URI.  These fields are not editable:  
<img width="890" alt="image" src="https://user-images.githubusercontent.com/24666568/151885968-58ae56d7-6022-4a61-956c-8371465cef1b.png">

  