### PR TITLE
Allows for index of parents with no children

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -69,7 +69,7 @@ module SolrIndexable
       }
     else
       json_to_index ||= authoritative_json
-      return nil if json_to_index.blank? || !manifest_completed?
+      return nil if json_to_index.blank?
       {
         # example_suffix: json_to_index[""],
         id: oid.to_s,

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -112,14 +112,33 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       parent_object
     end
 
-    it "indexes the new visibility" do
-      solr_document = parent_object.reload.to_solr
-      expect(solr_document[:visibility_ssi]).to eq "Public"
+    it "indexes the new visibility in solr" do
+      solr = SolrService.connection
+
+      parent_object.visibility = "Public"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Public"
+
+      parent_object.visibility = "Yale Community Only"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Yale Community Only"
+
+      # rubocop:disable RSpec/AnyInstance
+      # ParentObject will return false to manifest_complete if there are no children, so simulating no children with:
+      allow_any_instance_of(ParentObject).to receive(:manifest_completed?).and_return(false)
+      # rubocop:enable RSpec/AnyInstance
       parent_object.visibility = "Private"
-      parent_object.save!
-      solr_document = parent_object.reload.to_solr
-      parent_object.save!
-      expect(solr_document[:visibility_ssi]).to eq "Private"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Private"
     end
   end
 


### PR DESCRIPTION
# Summary
After a parent object has had children reassociated it failed the 'no children present' check required to index to solr so updating information in Blacklight for that object became impossible.  This PR removes that check to allow for the indexing of parent objects without children.

# Related Ticket
[#1836](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1836)

# Screenshots
![image](https://user-images.githubusercontent.com/36549923/152439330-28cb279c-f92a-4e6e-b341-6e0cb4584253.png)
![image](https://user-images.githubusercontent.com/36549923/152440765-5e407584-f235-496a-af65-e298c04600b5.png)
![image](https://user-images.githubusercontent.com/36549923/152441375-2dcaf387-179a-45f3-9131-b342d5f3007b.png)


# Videos

### Before

https://user-images.githubusercontent.com/36549923/152440311-207af1fe-8bf0-443c-9e59-e1b57e5f5e1c.mp4

### After

https://user-images.githubusercontent.com/36549923/152440530-58f27aea-72f5-4e70-8750-094dffbf31e5.mp4


