### PR TITLE
1854 stream preservica download

### DIFF
--- a/app/lib/preservica_client.rb
+++ b/app/lib/preservica_client.rb
@@ -88,6 +88,18 @@ class PreservicaClient
   end
 
   def get(uri)
+    return get_body(uri) unless block_given?
+    authenticated_get URI("#{@host}#{uri}") do |http, request|
+      http.request request do |response|
+        raise StandardError, "Request error #{response.code} #{response.body}" unless response.is_a? Net::HTTPSuccess
+        response.read_body do |chunk|
+          yield chunk
+        end
+      end
+    end
+  end
+
+  def get_body(uri)
     authenticated_get URI("#{@host}#{uri}") do |http, request|
       response = http.request request
       raise StandardError, "Request error #{response.code} #{response.body}" unless response.is_a? Net::HTTPSuccess

--- a/app/models/preservica/bitstream.rb
+++ b/app/models/preservica/bitstream.rb
@@ -22,20 +22,34 @@ class Preservica::Bitstream
   end
 
   def bits
-    preservica_client.get "/api/entity/content-objects/#{@content_id}/generations/#{@generation_id}/bitstreams/#{@id}/content"
+    preservica_client.get content_uri
   end
 
   def download_to_file(file_name)
-    data = bits
-    sha512 = Digest::SHA512.hexdigest(data)
-    raise StandardError, "Checksum mismatch on file (#{sha512} != #{sha512_checksum})" unless sha512 == sha512_checksum
-    raise StandardError, "File sizes do not match (#{data.length} != #{size})" unless data.length == size
-    File.open(file_name, 'wb') { |file| file.write(data) }
+    data_length = 0
+    sha512 = Digest::SHA512. new
+    File.open(file_name, 'wb') do |file|
+      preservica_client.get(content_uri) do |chunk|
+        data_length += chunk.length
+        file.write(chunk)
+        sha512 << chunk
+      end
+    end
+    data_sha512 = sha512.hexdigest
+    file_size = File.size?(file_name)
+    raise StandardError, "Checksum mismatch (#{data_sha512} != #{sha512_checksum})" unless data_sha512 == sha512_checksum
+    raise StandardError, "Data size did not match (#{data_length} != #{size})" unless data_length == size
+    raise StandardError, "File sizes do not match (#{file_size} != #{size})" unless file_size == size
+    # could also check: Digest::SHA512.file(file_name).hexdigest == sha512_checksum, but probably not necessary
   end
 
   private
 
     def xml
       @xml ||= Nokogiri::XML(preservica_client.content_object_generation_bitstream(@content_id, @generation_id, @id)).remove_namespaces!
+    end
+
+    def content_uri
+      @content_uri ||= "/api/entity/content-objects/#{@content_id}/generations/#{@generation_id}/bitstreams/#{@id}/content"
     end
 end

--- a/spec/models/preservica/preservica_object_spec.rb
+++ b/spec/models/preservica/preservica_object_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Preservica::PreservicaObject, type: :model do
     end
   end
 
+  after do
+    File.delete("tmp/testdownload.file") if File.exist?("tmp/testdownload.file")
+  end
+
   it 'traverses hierarcy' do
     structured_object = Preservica::StructuralObject.where(admin_set_key: 'brbl', id: "7fe35e8c-c21a-444a-a2e2-e3c926b519c4")
     information_objects = structured_object.information_objects
@@ -67,7 +71,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model do
       bitstreams = generations[0].bitstreams
       bitstreams[0].download_to_file "tmp/testdownload.file"
       expect(File.size("tmp/testdownload.file")).to eq(bitstreams[0].size)
-      File.delete("tmp/testdownload.file")
+      expect(Digest::SHA512.file("tmp/testdownload.file").hexdigest).to eq(bitstreams[0].sha512_checksum)
     end
   end
 
@@ -84,7 +88,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model do
       content_objects = representations[0].content_objects
       generations = content_objects[0].active_generations
       bitstreams = generations[0].bitstreams
-      expect { bitstreams[0].download_to_file "tmp/testdownload.file" }.to raise_error
+      expect { bitstreams[0].download_to_file "tmp/testdownload.file" }.to raise_error(/Checksum mismatch/)
     end
   end
 


### PR DESCRIPTION
Downloads bitstream content from preservica API in chunks, so that all the data doesn't need to be loaded into memory.

Allows PreservicaClient.get() to take a block to receive chunks of data.