### PR TITLE
Preservica representation name to parent object

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -199,7 +199,7 @@ class ParentObjectsController < ApplicationController
       cur_params = params.require(:parent_object).permit(:oid, :admin_set, :project_identifier, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
                                                          :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
                                                          :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization,
-                                                         :digitization_note, :redirect_to, :preservica_uri, :digital_object_source)
+                                                         :digitization_note, :redirect_to, :preservica_uri, :digital_object_source, :preservica_representation_name)
       cur_params[:admin_set] = AdminSet.find_by(key: cur_params[:admin_set]) if cur_params[:admin_set]
       cur_params
     end

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -121,12 +121,17 @@
   <div class="digital_object_identifiers, form-row">
     <div class="col-med-3">
       <%= form.label :digital_object_source %>
-      <%= form.select(:digital_object_source, ['None', 'Preservica']) %>
+      <%= form.select(:digital_object_source, ['None', 'Preservica'], {}, style: "width:178px;" ) %>
     </div>
 
     <div class="col-med-3">
       <%= form.label :preservica_uri %>
       <%= form.text_field :preservica_uri %>
+    </div>
+
+    <div class="col-med-3">
+      <%= form.label :preservica_representation_name %>
+      <%= form.text_field :preservica_representation_name %>
     </div>
   </div>
   <br>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -75,6 +75,11 @@
 </p>
 
 <p>
+  <strong>Preservica Representation Name:</strong>
+  <%= @parent_object.preservica_representation_name %>
+</p>
+
+<p>
   <strong>Last ladybird update:</strong>
   <%= @parent_object.last_ladybird_update %>
 </p>

--- a/db/migrate/20220208193807_add_preservica_representation_name_to_parent_object.rb
+++ b/db/migrate/20220208193807_add_preservica_representation_name_to_parent_object.rb
@@ -1,0 +1,5 @@
+class AddPreservicaRepresentationNameToParentObject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :parent_objects, :preservica_representation_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_03_005413) do
+ActiveRecord::Schema.define(version: 2022_02_08_193807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_005413) do
     t.text "redirect_to"
     t.text "preservica_uri"
     t.string "digital_object_source", default: "None"
+    t.string "preservica_representation_name"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["aspace_uri"], name: "index_parent_objects_on_aspace_uri"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         expect(page).to have_content("This is the Project ID")
       end
 
+      it "can set the Preservica Representation Name via the UI" do
+        click_on("Create Parent object")
+        click_on("Edit")
+        expect(page).to have_field("Preservica representation name")
+        fill_in("Preservica representation name", with: "Access-1")
+        click_on(UPDATE_PARENT_OBJECT_BUTTON)
+        expect(page).to have_content("Access-1")
+      end
+
       it "can show the representative thumbnail via the UI" do
         click_on("Create Parent object")
         expect(page).to have_content("Children:")


### PR DESCRIPTION
# Summary  
"Preservica Representation Name" is now an editable field on Parent Objects:  
  
Edit:  
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/24666568/153087190-3cd8f6fa-2a10-4171-b85b-ea34e860a743.png">
  
Showpage:  
  
<img width="957" alt="image" src="https://user-images.githubusercontent.com/24666568/153087258-cf1323f5-0111-45d0-b1d7-d5c9eef678df.png">
