### PR TITLE
Index bibs starting with b to 'quicksearchId_ssi', others to 'orbisBibId_ssi'

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -136,7 +136,7 @@ module SolrIndexable
         number_of_pages_ss: json_to_index["numberOfPages"],
         oid_ssi: oid,
         orbisBarcode_ssi: barcode,
-        orbisBibId_ssi: generate_orbis_id(json_to_index["orbisBibId"]),
+        orbisBibId_ssi: generate_orbis_id(bib),
         partOf_tesim: json_to_index["partOf"],
         preferredCitation_tesim: json_to_index["preferredCitation"],
         project_identifier_tesi: generate_pid(json_to_index["project_identifier"]),
@@ -144,7 +144,7 @@ module SolrIndexable
         public_bsi: true, # TEMPORARY, makes everything public
         publisher_tesim: json_to_index["publisher"],
         publisher_ssim: json_to_index["publisher"],
-        quicksearchId_ssi: generate_quicksearch_id(json_to_index["orbisBibId"]),
+        quicksearchId_ssi: generate_quicksearch_id(bib),
         recordType_ssi: json_to_index["recordType"],
         relatedResourceOnline_ssim: json_to_index["relatedResourceOnline"],
         repository_ssi: self&.admin_set&.label,
@@ -277,12 +277,12 @@ module SolrIndexable
     ancestor_title.presence || [self&.admin_set&.label] || nil
   end
 
-  def generate_orbis_id(orbis_id)
-    (orbis_id.to_i.positive? && orbis_id.presence) || nil
+  def generate_orbis_id(bib)
+    (bib.to_i.positive? && bib.presence) || nil
   end
 
-  def generate_quicksearch_id(orbis_id)
-    (orbis_id.present? && orbis_id.start_with?("b") && orbis_id) || nil
+  def generate_quicksearch_id(bib)
+    (bib.present? && bib.start_with?("b") && bib) || nil
   end
 
   def series_sort(json_to_index)

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -136,7 +136,7 @@ module SolrIndexable
         number_of_pages_ss: json_to_index["numberOfPages"],
         oid_ssi: oid,
         orbisBarcode_ssi: barcode,
-        orbisBibId_ssi: bib, # may change to orbisBibId
+        orbisBibId_ssi: generate_orbis_id(json_to_index["orbisBibId"]),
         partOf_tesim: json_to_index["partOf"],
         preferredCitation_tesim: json_to_index["preferredCitation"],
         project_identifier_tesi: generate_pid(json_to_index["project_identifier"]),
@@ -144,6 +144,7 @@ module SolrIndexable
         public_bsi: true, # TEMPORARY, makes everything public
         publisher_tesim: json_to_index["publisher"],
         publisher_ssim: json_to_index["publisher"],
+        quicksearchId_ssi: generate_quicksearch_id(json_to_index["orbisBibId"]),
         recordType_ssi: json_to_index["recordType"],
         relatedResourceOnline_ssim: json_to_index["relatedResourceOnline"],
         repository_ssi: self&.admin_set&.label,
@@ -274,6 +275,14 @@ module SolrIndexable
   # not ASpace records will use the repository value
   def generate_ancestor_title(ancestor_title)
     ancestor_title.presence || [self&.admin_set&.label] || nil
+  end
+
+  def generate_orbis_id(orbis_id)
+    (orbis_id.to_i.positive? && orbis_id.presence) || nil
+  end
+
+  def generate_quicksearch_id(orbis_id)
+    (orbis_id.present? && orbis_id.start_with?("b") && orbis_id) || nil
   end
 
   def series_sort(json_to_index)

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -53,15 +53,18 @@ RSpec.describe SolrIndexable, type: :model do
   end
 
   it "distinguishes actual orbis ids from quicksearch ids" do
-    solr_document = solr_indexable.to_solr ({ 'orbisBibId' => "557744" })
+    solr_indexable.bib = "557744"
+    solr_document = solr_indexable.to_solr ({ "notblank" => "value" })
     expect(solr_document[:orbisBibId_ssi]).to eq('557744')
     expect(solr_document[:quicksearchId_ssi]).to be_nil
-    solr_document = solr_indexable.to_solr ({ 'orbisBibId' => "b557744" })
+    solr_indexable.bib = "b557744"
+    solr_document = solr_indexable.to_solr ({ "notblank" => "value" })
     expect(solr_document[:orbisBibId_ssi]).to be_nil
     expect(solr_document[:quicksearchId_ssi]).to eq("b557744")
   end
 
   it "handles nil orbis ids" do
+    solr_indexable.bib = nil
     solr_document = solr_indexable.to_solr ({ "notblank" => "value" })
     expect(solr_document[:orbisBibId_ssi]).to be_nil
     expect(solr_document[:quicksearchId_ssi]).to be_nil

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -51,5 +51,20 @@ RSpec.describe SolrIndexable, type: :model do
     expect(solr_document[:creator_ssim]).to eq(['creator', 'creators', 'creatorx', 'ancestor creator king', 'ancestor creator'])
     expect(solr_document[:collectionCreators_ssim]).to eq(['ancestor creator'])
   end
+
+  it "distinguishes actual orbis ids from quicksearch ids" do
+    solr_document = solr_indexable.to_solr ({ 'orbisBibId' => "557744" })
+    expect(solr_document[:orbisBibId_ssi]).to eq('557744')
+    expect(solr_document[:quicksearchId_ssi]).to be_nil
+    solr_document = solr_indexable.to_solr ({ 'orbisBibId' => "b557744" })
+    expect(solr_document[:orbisBibId_ssi]).to be_nil
+    expect(solr_document[:quicksearchId_ssi]).to eq("b557744")
+  end
+
+  it "handles nil orbis ids" do
+    solr_document = solr_indexable.to_solr ({ "notblank" => "value" })
+    expect(solr_document[:orbisBibId_ssi]).to be_nil
+    expect(solr_document[:quicksearchId_ssi]).to be_nil
+  end
   # rubocop:enable Lint/ParenthesesAsGroupedExpression
 end


### PR DESCRIPTION
Changes ParentObject to solr mapping:
- Maps bib to `orbisBibId_ssi` if it's an integer (or starts with an integer)
- Maps bib to `quicksearchId_ssi` if it starts with `b`