### PR TITLE
Add should_index? to ParentObject, delete from solr if false

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -8,22 +8,27 @@ module SolrIndexable
     end
   end
 
+  # rubocop:disable Metrics/PerceivedComplexity
   def solr_index
     begin
-      if self&.redirect_to.present?
-        indexable = to_solr
+      if self&.should_index?
+        if self&.redirect_to.present?
+          indexable = to_solr
+        else
+          indexable, child_solr_documents = to_solr_full_text
+        end
+        return unless indexable.present?
+        solr = SolrService.connection
+        solr.add([indexable])
+        solr.add(child_solr_documents) unless child_solr_documents.nil?
+        result = solr.commit
+        if (result&.[]("responseHeader")&.[]("status"))&.zero?
+          processing_event("Solr index updated", "solr-indexed")
+        else
+          processing_event("Solr index after manifest generation failed", "failed")
+        end
       else
-        indexable, child_solr_documents = to_solr_full_text
-      end
-      return unless indexable.present?
-      solr = SolrService.connection
-      solr.add([indexable])
-      solr.add(child_solr_documents) unless child_solr_documents.nil?
-      result = solr.commit
-      if (result&.[]("responseHeader")&.[]("status"))&.zero?
-        processing_event("Solr index updated", "solr-indexed")
-      else
-        processing_event("Solr index after manifest generation failed", "failed")
+        result = solr_delete
       end
     rescue => e
       processing_event("Solr indexing failed due to #{e.message}", "failed")
@@ -31,6 +36,7 @@ module SolrIndexable
     end
     result
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def solr_delete
     solr = SolrService.connection

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -29,6 +29,7 @@ module SolrIndexable
         end
       else
         result = solr_delete
+        processing_event("Solr record deleted", "solr-indexed")
       end
     rescue => e
       processing_event("Solr indexing failed due to #{e.message}", "failed")

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -475,4 +475,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       child_object.processing_event("Child #{child_object.oid} has been updated: #{child_object.full_text ? 'YES' : 'NO'}", 'update-complete')
     end
   end
+
+  def should_index?
+    return false if child_object_count&.zero? || child_objects.empty?
+    ['Public', 'Redirect', 'Yale Community Only'].include?(visibility) || redirect_to.present?
+  end
 end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -477,7 +477,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def should_index?
-    return false if child_object_count&.zero? || child_objects.empty?
+    return false if redirect_to.blank? && (child_object_count&.zero? || child_objects.empty?)
     ['Public', 'Redirect', 'Yale Community Only'].include?(visibility) || redirect_to.present?
   end
 end

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       expect(solr_docs.length).to eq 0
     end
   end
-  
+
   context "indexing to Solr from the database with Ladybird ParentObjects", solr: true do
     it "can index the 5 parent objects in the database to Solr and can remove those items", undelayed: true do
       response = solr.get 'select', params: { q: 'type_ssi:parent' }

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -112,17 +112,36 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
       parent_object
     end
 
-    it "indexes the new visibility" do
-      solr_document = parent_object.reload.to_solr
-      expect(solr_document[:visibility_ssi]).to eq "Public"
+    it "indexes the new visibility in solr" do
+      solr = SolrService.connection
+
+      parent_object.visibility = "Public"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Public"
+
+      parent_object.visibility = "Yale Community Only"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_document = response['response']['docs'][0]
+      expect(solr_document['visibility_ssi']).to eq "Yale Community Only"
+
+      # rubocop:disable RSpec/AnyInstance
+      # ParentObject will return false to manifest_complete if there are no children, so simulating no children with:
+      allow_any_instance_of(ParentObject).to receive(:manifest_completed?).and_return(false)
+      # rubocop:enable RSpec/AnyInstance
       parent_object.visibility = "Private"
-      parent_object.save!
-      solr_document = parent_object.reload.to_solr
-      parent_object.save!
-      expect(solr_document[:visibility_ssi]).to eq "Private"
+      parent_object.save
+      parent_object.solr_index_job
+      response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
+      solr_docs = response['response']['docs']
+      expect(solr_docs.length).to eq 0
     end
   end
-
+  
   context "indexing to Solr from the database with Ladybird ParentObjects", solr: true do
     it "can index the 5 parent objects in the database to Solr and can remove those items", undelayed: true do
       response = solr.get 'select', params: { q: 'type_ssi:parent' }

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
     end
 
     context "with a ParentObject whose authoritative_metadata_source is Voyager" do
-      let(:child_object) { FactoryBot.create(:child_object, oid: 456_789, parent_object: po) }
+      let(:child_object) { FactoryBot.create(:child_object, oid: 456_789, parent_object: ParentObject.find_by(oid: "2012036")) }
 
       before do
         stub_metadata_cloud("2012036", "ladybird")

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -283,6 +283,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
     end
 
     context "with a ParentObject whose authoritative_metadata_source is Voyager" do
+      let(:child_object) { FactoryBot.create(:child_object, oid: 456_789, parent_object: po) }
+
       before do
         stub_metadata_cloud("2012036", "ladybird")
         stub_metadata_cloud("V-2012036", "ils")
@@ -320,6 +322,10 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
 
       it 'has functioning Solr Document link' do
         po = ParentObject.find_by(oid: "2012036")
+        po.child_object_count = 1
+        po.visibility = "Public"
+        po.save
+        child_object
         po.solr_index_job
         expect(page).to have_link("Solr Document", href: solr_document_parent_object_path("2012036"))
         click_on("Solr Document")
@@ -365,15 +371,15 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
 
       it 'has functioning Solr Document link' do
         po = ParentObject.find_by(oid: "2012036")
+        po.child_object_count = 1
+        po.visibility = "Public"
+        po.save
         po.solr_index_job
         expect(page).to have_link("Solr Document", href: solr_document_parent_object_path("2012036"))
         click_on("Solr Document")
         solr_data = JSON.parse(page.body)
-        expect(solr_data['numFound']).to eq 1
-        expect(solr_data["docs"].count).to eq 1
-        document = solr_data["docs"].first
-        expect(document["id"]).to eq "2012036"
-        expect(document["localRecordNumber_ssim"]).to include "YCAL MSS 202"
+        expect(solr_data['numFound']).to eq 0
+        expect(solr_data["docs"].count).to eq 0
       end
     end
 


### PR DESCRIPTION
Added a "should_index?" method to parent.  If it's false, a delete (by oid) is sent to SOLR during index.  If it's true, indexing continues as it typically does.

should_index? will be true for parents which may still be processing their images, but have children and a non-Private visibility.  So, if a previously indexed parent has new children added, it will not be deleted while the images are being processed.

should_index? is always true for all redirected parents, regardless of the status of children.

If a parent has no children or is Private, it will be deleted from solr next solr_index, regardless of the status of the children, etc.