### PR TITLE
Delete instead of destroy children when parent is deleted

### DIFF
--- a/app/jobs/generate_ptiff_job.rb
+++ b/app/jobs/generate_ptiff_job.rb
@@ -8,6 +8,7 @@ class GeneratePtiffJob < ApplicationJob
   end
 
   def perform(child_object, batch_process)
+    return if child_object.nil?
     child_object.current_batch_process = batch_process
     child_object.current_batch_connection = batch_process&.batch_connections&.find_or_create_by(connectable: child_object)
     parent_object = child_object.parent_object

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+#
+# ChildObjects are _deleted_ when parents are destroyed; expect that ChildObjects will be
+# deleted _without_ any destroy hooks called.
+#
+
 # rubocop:disable ClassLength
 class ChildObject < ApplicationRecord
   # rubocop:enable ClassLength
@@ -15,8 +20,6 @@ class ChildObject < ApplicationRecord
   paginates_per 50
   attr_accessor :current_batch_process
   attr_accessor :current_batch_connection
-  after_destroy :delayed_jobs_deletion
-  after_destroy :solr_delete
 
   # Does not get called because we use upsert to create children
   # before_create :check_for_size_and_file

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -42,6 +42,7 @@ module SolrIndexable
   def solr_delete
     solr = SolrService.connection
     solr.delete_by_id(oid.to_s)
+    solr.delete_by_query("parent_ssi:#{oid}")
     solr.commit
   end
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -12,7 +12,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include Delayable
   include DigitalObjectManagement
   has_many :dependent_objects, dependent: :delete_all
-  has_many :child_objects, -> { order('"order" ASC, oid ASC') }, primary_key: 'oid', foreign_key: 'parent_object_oid', dependent: :destroy
+  has_many :child_objects, -> { order('"order" ASC, oid ASC') }, primary_key: 'oid', foreign_key: 'parent_object_oid', dependent: :delete_all
   has_many :batch_connections, as: :connectable
   has_many :batch_processes, through: :batch_connections
   belongs_to :authoritative_metadata_source, class_name: "MetadataSource"


### PR DESCRIPTION
- Changes child object relationship so they are deleted rather than destroyed when parent is destroyed.
- Update solr_delete for parent object to also delete child records based on parent_ssi.
- Update PTIFF job to return if child_object is nil, since children no longer delete pending jobs.