### PR TITLE
Fix mapping of child['title'] since it's an array

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -166,7 +166,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
           # Ladybird has only one field for both order label (7v, etc.), and descriptive captions ("Mozart at the Keyboard")
           # For the first iteration we will map this field to label
           label: child_record["caption"],
-          caption: child_record["title"],
+          caption: child_record["title"]&.first,
           order: index,
           parent_object_oid: oid
         }

--- a/spec/fixtures/ladybird/2004628.json
+++ b/spec/fixtures/ladybird/2004628.json
@@ -59,7 +59,7 @@
         "/ladybird/oid/1042003"
       ],
       "caption": "LB Caption FDID 74",
-      "title": "LB Title FDID 70",
+      "title": ["LB Title FDID 70"],
       "oid": 1042003,
       "width": 10,
       "height": 10,


### PR DESCRIPTION
Titles from metadata cloud are arrays.
This PR updates the fixture so that it's correct, and updates the code to take the first element from the array.