### PR TITLE
Allow users to check status of recurring job and queue it

### DIFF
--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -2,6 +2,11 @@
 
 class ReoccurringJobsController < ApplicationController
   def index
+    if params['check_status']
+      @check_status = true
+      @scheduled_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamJob%').exists?
+      @manual_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamManualJob%').exists?
+    end
     @reoccurring_jobs = ActivityStreamLog.all
     respond_to do |format|
       format.html
@@ -10,8 +15,19 @@ class ReoccurringJobsController < ApplicationController
   end
 
   # POST ActivityStreamReader
+  def create_recurring
+    ActivityStreamJob.perform_later unless Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamJob%').exists?
+    respond_to do |format|
+      format.html { redirect_to reoccurring_jobs_url, notice: 'The recurring job has been queued.' }
+      format.json { head :no_content }
+    end
+  end
+
+  # POST ActivityStreamReader
   def create
-    if ActivityStreamLog.where(status: "Running").exists?
+    if params['queue_recurring']
+      create_recurring
+    elsif ActivityStreamLog.where(status: "Running").exists?
       respond_to do |format|
         format.html { redirect_to reoccurring_jobs_url, notice: 'An update is already in progress.' }
         format.json { head :no_content }
@@ -19,7 +35,7 @@ class ReoccurringJobsController < ApplicationController
     else
       ActivityStreamManualJob.perform_later
       respond_to do |format|
-        format.html { redirect_to reoccurring_jobs_url, notice: 'Metadata update queued.' }
+        format.html { redirect_to reoccurring_jobs_url, notice: 'The manual job has been queued.' }
         format.json { head :no_content }
       end
     end

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -6,11 +6,26 @@
   <div class='col'>
     <div class='float-right button-list'>
       <%= button_to 'Trigger Job Manually', reoccurring_jobs_path, method: 'post', class: 'btn button secondary-button', data: {confirm: 'Are you sure you start a manual update outside of the regular schedule?'} %>
+      <%  if @check_status %>
+        <% if !@scheduled_job_exists %>
+          <%= button_to 'Queue the Recurring Job', reoccurring_jobs_path(queue_recurring: 'true'), method: 'post', class: 'btn button secondary-button' %>
+        <% end %>
+      <% else %>
+        <%= link_to 'Check status of the Recurring Job', reoccurring_jobs_path(check_status:'true'), method: 'get', class: 'btn button secondary-button' %>
+      <% end %>
     </div>
   </div>
 </div>
 <div class='reoccurring-notice'>
-  <p>A reoccurring job is set to update metadata from Aspace and Voyager at 1:00am EST</p>
+  <%  if @check_status %>
+    <p>
+      <% if @scheduled_job_exists %>
+        A reoccurring job is set to update metadata from Aspace and Voyager at 1:00am EST
+      <% else %>
+        <p>The recurring job is <strong>NOT</strong> queued</p>
+      <% end %>
+    </p>
+  <%  end %>
 </div><br />
 <div class='row datatable'>
   <div class='col overflow-auto'>

--- a/spec/system/recurring_job_status_spec.rb
+++ b/spec/system/recurring_job_status_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+UPDATE_PARENT_OBJECT_BUTTON = 'Save Parent Object And Update Metadata'
+
+RSpec.describe "Recurring Jobs", type: :system, prep_metadata_sources: true, prep_admin_sets: true do
+  let(:user) { FactoryBot.create(:sysadmin_user) }
+
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::DelayedJobAdapter.new
+  end
+
+  before do
+    login_as user
+  end
+
+  context "Reoccuring Job page" do
+    before do
+      visit reoccurring_jobs_path
+    end
+
+    it "has a button to check the status" do
+      expect(page).to have_link('Check status of the Recurring Job')
+    end
+
+    it "clicking check the status button, displays status" do
+      click_link('Check status of the Recurring Job')
+      expect(page).to have_content('The recurring job is NOT queued')
+    end
+
+    it "clicking queue recurring job, queues the recurring job" do
+      click_link('Check status of the Recurring Job')
+      click_on('Queue the Recurring Job')
+      click_link('Check status of the Recurring Job')
+      expect(page).to have_content('A reoccurring job is set to update metadata from Aspace and Voyager at 1:00am EST')
+    end
+  end
+end


### PR DESCRIPTION
Adds a link on the reoccurring jobs page to allow users to check the status of the activity stream job.
If the job is not queued, there is a button that allows the user to queue the job.

Camerata can be updated so that the job is not queued during startup.

![RecurringJob.gif](https://images.zenhubusercontent.com/5e5e9bbd38fda217bdabbde0/fdc654c5-e43d-4b23-b6f7-e7ea9490ea73)