### PR TITLE
Update Batch Process messages

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -391,7 +391,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # COUNTS CURRENT STATUSES
   def status_hash
     @status_hash ||= {
-      complete: connected_statuses.count("Complete"),
+      complete: connected_statuses.count("Complete") + connected_statuses.count("Parent object deleted successfully"),
       in_progress: connected_statuses.count("In progress - no failures"),
       failed: connected_statuses.count("Failed"),
       unknown: connected_statuses.count("Unknown"),


### PR DESCRIPTION
A batch process that has completed without failures will now say "Batch Complete". Batch Processes that have failed will have "View Messages":  
  
<img width="1758" alt="image" src="https://user-images.githubusercontent.com/24666568/157131182-09a5ab9b-280a-4f3c-8471-9479000ece3f.png">
 