### PR TITLE
1885 Updated parent object table

### DIFF
--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -3,6 +3,11 @@ DEFAULT DESKTOP STYLING
 ********************************************************/
 @import 'theme/colors', 'theme/typography', 'theme/breakpoints';
 
+.table-responsive {
+  overflow-x: -moz-scrollbars-horizontal;
+  overflow-x: scroll;
+}
+
 .delete-item-container,
 .update-item-container {
   display: grid;

--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -4,8 +4,7 @@ DEFAULT DESKTOP STYLING
 @import 'theme/colors', 'theme/typography', 'theme/breakpoints';
 
 .table-responsive {
-  overflow-x: -moz-scrollbars-horizontal;
-  overflow-x: scroll;
+  cursor: all-scroll;
 }
 
 .delete-item-container,


### PR DESCRIPTION
**Story**

The Parent Objects table in the Management App does not make it easy for users (at least on Chrome, Safari, Firefox, and likely in other browsers) to scroll to the right to view additional columns. Suggest adding a bottom scroll bar or another mechanism for easily viewing the table in its entirety.

Note: There is a scrollbar if you manage to get to the bottom of the table.  The solution, for now, is to have the scrollbar appear at the bottom of each breakpoint depending on how zoomed.

**Acceptance**
- [ ] Users in a variety of browsers are able to scroll to view all columns in the table
- [ ] Make a ticket to discuss a more holistic solution to handle what we're seeing in the tables now.