### PR TITLE
Reduce max attempts of delayed job runs

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -10,7 +10,7 @@ Delayed::Worker.max_run_time = 2.hours
 Delayed::Worker.default_queue_name = :default
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.logger = Rails.logger
-if ENV['RAILS_ENV'] = 'development'
+if ENV['RAILS_ENV'] == 'development'
   Delayed::Worker.max_attempts = 3
 else
   Delayed::Worker.max_attempts = 15

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -10,3 +10,8 @@ Delayed::Worker.max_run_time = 2.hours
 Delayed::Worker.default_queue_name = :default
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.logger = Rails.logger
+if ENV['RAILS_ENV'] = 'development'
+  Delayed::Worker.max_attempts = 3
+else
+  Delayed::Worker.max_attempts = 15
+end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -10,8 +10,8 @@ Delayed::Worker.max_run_time = 2.hours
 Delayed::Worker.default_queue_name = :default
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.logger = Rails.logger
-if ENV['RAILS_ENV'] == 'development'
-  Delayed::Worker.max_attempts = 3
-else
-  Delayed::Worker.max_attempts = 15
-end
+Delayed::Worker.max_attempts = if ENV['RAILS_ENV'] == 'development'
+                                 3
+                               else
+                                 15
+                               end


### PR DESCRIPTION
# Summary
In production delayed job attempts will max out at 15 and in local development the max attempts will be 3.  Reduces from default of 25.

# Related Ticket
[#1938](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1938)