### PR TITLE
Adjust table heights to fit on page with Horizontal Scollbar

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -37,10 +37,6 @@ DEFAULT DESKTOP STYLING
   padding: 0;
 }
 
-.expanded {
-  //display: table;
-}
-
 .dataTables_length {
   font-family: $standard_font_family;
   font-size: 17px;
@@ -128,19 +124,10 @@ DEFAULT DESKTOP STYLING
   font-size: 18px;
 }
 
-
 table.dataTable {
   max-height: calc(100vh - 360px);
-  //th {
-  //  white-space: nowrap;
-  //}
 }
 
 table#batch-processes-datatable {
   max-height: calc(100vh - 480px);
-  //white-space: nowrap;
-}
-
-table#parent-objects-datatable, table#reoccurring-job-datatable {
-  //white-space: nowrap;
 }

--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -131,16 +131,16 @@ DEFAULT DESKTOP STYLING
 
 table.dataTable {
   max-height: calc(100vh - 360px);
-  th {
-    white-space: nowrap;
-  }
+  //th {
+  //  white-space: nowrap;
+  //}
 }
 
 table#batch-processes-datatable {
   max-height: calc(100vh - 480px);
-  white-space: nowrap;
+  //white-space: nowrap;
 }
 
 table#parent-objects-datatable, table#reoccurring-job-datatable {
-  white-space: nowrap;
+  //white-space: nowrap;
 }

--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -38,7 +38,7 @@ DEFAULT DESKTOP STYLING
 }
 
 .expanded {
-  display: table;
+  //display: table;
 }
 
 .dataTables_length {
@@ -126,4 +126,21 @@ DEFAULT DESKTOP STYLING
 
 .reoccurring-notice p {
   font-size: 18px;
+}
+
+
+table.dataTable {
+  max-height: calc(100vh - 360px);
+  th {
+    white-space: nowrap;
+  }
+}
+
+table#batch-processes-datatable {
+  max-height: calc(100vh - 480px);
+  white-space: nowrap;
+}
+
+table#parent-objects-datatable, table#reoccurring-job-datatable {
+  white-space: nowrap;
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -226,15 +226,6 @@ $( document ).on('turbolinks:load', function() {
     })
   }
 
-  if (document.getElementsByClassName('is-datatable')[0]) {
-    // Allows all datatables, no matter the amount of columns, to have 100% width
-    const tableWidth = document.getElementsByClassName('is-datatable')[0].clientWidth;
-    const tableHeadWidth = document.getElementsByClassName('table-head')[0].clientWidth;
-    if (tableHeadWidth <= tableWidth) {
-      $('.is-datatable').addClass('expanded')
-    }
-  }
-
   $('.export-all span').hover(
       function() {
         if ($(this).parent("button").attr('disabled')) {


### PR DESCRIPTION
Adjusts the height of the datatables, so that they fit on the page with some room at the bottom for the pagination buttons.