### PR TITLE
Changed the image size in the sitemap and og

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -128,7 +128,7 @@ class ChildObject < ApplicationRecord
   end
 
   def thumbnail_url
-    "#{IiifPresentationV3.new(parent_object).image_service_url(oid)}/full/!200,200/0/default.jpg"
+    "#{IiifPresentationV3.new(parent_object).image_service_url(oid)}/full/!1200x630/0/default.jpg"
   end
 
   def width_and_height(size)

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -128,7 +128,7 @@ class ChildObject < ApplicationRecord
   end
 
   def thumbnail_url
-    "#{IiifPresentationV3.new(parent_object).image_service_url(oid)}/full/!1200x630/0/default.jpg"
+    "#{IiifPresentationV3.new(parent_object).image_service_url(oid)}/full/!1200,630/0/default.jpg"
   end
 
   def width_and_height(size)

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -21,7 +21,7 @@ class IiifPresentationV3
   end
 
   def image_url(oid)
-    "#{image_service_url(oid)}/full/!1200x630/0/default.jpg"
+    "#{image_service_url(oid)}/full/!1200,630/0/default.jpg"
   end
 
   def initialize(parent_object)

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -21,7 +21,7 @@ class IiifPresentationV3
   end
 
   def image_url(oid)
-    "#{image_service_url(oid)}/full/!200,200/0/default.jpg"
+    "#{image_service_url(oid)}/full/!1200x630/0/default.jpg"
   end
 
   def initialize(parent_object)

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
 
     it "has a valid thumbnail url" do
       first_child_object = parent_object.child_objects.first
-      expect(first_child_object.thumbnail_url).to eq "#{(ENV['IIIF_IMAGE_BASE_URL'])}/2/456789/full/!1200x630/0/default.jpg"
+      expect(first_child_object.thumbnail_url).to eq "#{(ENV['IIIF_IMAGE_BASE_URL'])}/2/456789/full/!1200,630/0/default.jpg"
     end
 
     it "has a valid height and width after conversion" do

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
 
     it "has a valid thumbnail url" do
       first_child_object = parent_object.child_objects.first
-      expect(first_child_object.thumbnail_url).to eq "#{(ENV['IIIF_IMAGE_BASE_URL'])}/2/456789/full/!200,200/0/default.jpg"
+      expect(first_child_object.thumbnail_url).to eq "#{(ENV['IIIF_IMAGE_BASE_URL'])}/2/456789/full/!1200x630/0/default.jpg"
     end
 
     it "has a valid height and width after conversion" do

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
 
     it "can index a thumbnail path to Solr" do
       solr_document = parent_object.reload.to_solr
-      expect(solr_document[:thumbnail_path_ss]).to eq "http://localhost:8182/iiif/2/1126257/full/!1200x630/0/default.jpg"
+      expect(solr_document[:thumbnail_path_ss]).to eq "http://localhost:8182/iiif/2/1126257/full/!1200,630/0/default.jpg"
     end
 
     it "can index project identifier" do

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
 
     it "can index a thumbnail path to Solr" do
       solr_document = parent_object.reload.to_solr
-      expect(solr_document[:thumbnail_path_ss]).to eq "http://localhost:8182/iiif/2/1126257/full/!200,200/0/default.jpg"
+      expect(solr_document[:thumbnail_path_ss]).to eq "http://localhost:8182/iiif/2/1126257/full/!1200x630/0/default.jpg"
     end
 
     it "can index project identifier" do


### PR DESCRIPTION
Co-authored-by: Kait Sewell <kait@notch8.com>
Co-authored-by: Amanda Frost <amanda@scientist.com>
Co-authored-by: JP Engstrom <jp@notch8.com>


**Story**

Our sitemap files link to the thumbnail image and the size is `!200,200`.   We should update this to match the image size we going to use for OpenGraph.  See #1249.

**Acceptance**
- [ ] Change sitemap XML image references to `!1200x630`

Ticket 1249
**Acceptance**
- [ ] Change `!200x200` to  `!1200x630` size in the IIIF thumbnail URL