### PR TITLE
Skip redirect_to objects for update metadata

### DIFF
--- a/app/jobs/update_all_metadata_job.rb
+++ b/app/jobs/update_all_metadata_job.rb
@@ -7,12 +7,11 @@ class UpdateAllMetadataJob < ApplicationJob
     5000
   end
 
-  def perform(start_position = 0, where = '')
+  def perform(start_position = 0, where = 'redirect_to: nil')
     parent_objects = ParentObject.where(where).order(:oid).offset(start_position).limit(UpdateAllMetadataJob.job_limit)
-    selected_parent_objects = parent_objects.select { |po| po.redirect_to.nil? }
-    last_job = selected_parent_objects.count < UpdateAllMetadataJob.job_limit
-    return unless selected_parent_objects.count.positive? # stop if nothing is found
-    selected_parent_objects.each do |po|
+    last_job = parent_objects.count < UpdateAllMetadataJob.job_limit
+    return unless parent_objects.count.positive? # stop if nothing is found
+    parent_objects.each do |po|
       po.metadata_update = true
       po.setup_metadata_job
     end

--- a/app/jobs/update_all_metadata_job.rb
+++ b/app/jobs/update_all_metadata_job.rb
@@ -9,9 +9,10 @@ class UpdateAllMetadataJob < ApplicationJob
 
   def perform(start_position = 0, where = '')
     parent_objects = ParentObject.where(where).order(:oid).offset(start_position).limit(UpdateAllMetadataJob.job_limit)
-    last_job = parent_objects.count < UpdateAllMetadataJob.job_limit
-    return unless parent_objects.count.positive? # stop if nothing is found
-    parent_objects.each do |po|
+    selected_parent_objects = parent_objects.select { |po| po.redirect_to.nil? }
+    last_job = selected_parent_objects.count < UpdateAllMetadataJob.job_limit
+    return unless selected_parent_objects.count.positive? # stop if nothing is found
+    selected_parent_objects.each do |po|
       po.metadata_update = true
       po.setup_metadata_job
     end

--- a/spec/jobs/update_all_metadata_job_spec.rb
+++ b/spec/jobs/update_all_metadata_job_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe UpdateAllMetadataJob, type: :job, prep_metadata_sources: true, so
     end
 
     it 'processes all parents in batches' do
-      expect(ParentObject).to receive(:where).with('').and_return(parent_object_where).exactly(expected_call_count).times
+      expect(ParentObject).to receive(:where).with('redirect_to: nil').and_return(parent_object_where).exactly(expected_call_count).times
       UpdateAllMetadataJob.perform_later
     end
 

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -342,14 +342,14 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
 
     context "redirected parent objects" do
       let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, redirect_to: "https://collections.library.yale.edu/catalog/123") }
-      
+
       before do
         stub_metadata_cloud("2012036", "ladybird")
         parent_object
       end
-      
+
       it "will not update metadata" do
-        time_then = Time.now
+        time_then = Time.current
         parent_object.last_ladybird_update = time_then
         visit parent_objects_path
         click_on("Update Metadata")

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -340,6 +340,23 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       end
     end
 
+    context "redirected parent objects" do
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, redirect_to: "https://collections.library.yale.edu/catalog/123") }
+      
+      before do
+        stub_metadata_cloud("2012036", "ladybird")
+        parent_object
+      end
+      
+      it "will not update metadata" do
+        time_then = Time.now
+        parent_object.last_ladybird_update = time_then
+        visit parent_objects_path
+        click_on("Update Metadata")
+        expect(parent_object.last_ladybird_update).to eq time_then
+      end
+    end
+
     context "with a ParentObject whose authoritative_metadata_source is ArchiveSpace" do
       let(:child_object) { FactoryBot.create(:child_object, oid: 456_789, parent_object: ParentObject.find_by(oid: "2012036")) }
       around do |example|


### PR DESCRIPTION
# Summary  
Redirected objects queued for metadata will not update metadata

# Ticket
[#1943](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1943)