### PR TITLE
Add rakes task to export xml from Preservica

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ yarn-debug.log*
 # Ignore coverage report
 coverage
 *-params.yml
+
+/preservica_export

--- a/app/models/preservica/bitstream.rb
+++ b/app/models/preservica/bitstream.rb
@@ -43,11 +43,11 @@ class Preservica::Bitstream
     # could also check: Digest::SHA512.file(file_name).hexdigest == sha512_checksum, but probably not necessary
   end
 
-  private
+  def xml
+    @xml ||= Nokogiri::XML(preservica_client.content_object_generation_bitstream(@content_id, @generation_id, @id)).remove_namespaces!
+  end
 
-    def xml
-      @xml ||= Nokogiri::XML(preservica_client.content_object_generation_bitstream(@content_id, @generation_id, @id)).remove_namespaces!
-    end
+  private
 
     def content_uri
       @content_uri ||= "/api/entity/content-objects/#{@content_id}/generations/#{@generation_id}/bitstreams/#{@id}/content"

--- a/app/models/preservica/content_object.rb
+++ b/app/models/preservica/content_object.rb
@@ -17,6 +17,10 @@ class Preservica::ContentObject
     @generations ||= load_generations
   end
 
+  def xml
+    @xml ||= @preservica_client.content_object(@id)
+  end
+
   private
 
     def load_generations

--- a/app/models/preservica/generation.rb
+++ b/app/models/preservica/generation.rb
@@ -29,6 +29,10 @@ class Preservica::Generation
     xml.xpath('/GenerationResponse/Bitstreams/Bitstream').text.strip
   end
 
+  def xml
+    @xml ||= Nokogiri::XML(preservica_client.content_object_generation(@content_id, @id)).remove_namespaces!
+  end
+
   private
 
     def load_bitstreams
@@ -44,9 +48,5 @@ class Preservica::Generation
 
     def load_format_group
       xml.xpath('/GenerationResponse/Generation/FormatGroup').map(&:content)
-    end
-
-    def xml
-      @xml ||= Nokogiri::XML(preservica_client.content_object_generation(@content_id, @id)).remove_namespaces!
     end
 end

--- a/app/models/preservica/information_object.rb
+++ b/app/models/preservica/information_object.rb
@@ -29,6 +29,10 @@ class Preservica::InformationObject
     @representation ||= load_representation(preservica_representation_name)
   end
 
+  def xml
+    @xml ||= @preservica_client.information_object(@id)
+  end
+
   private
 
     def load_representation(preservica_representation_name)

--- a/app/models/preservica/representation.rb
+++ b/app/models/preservica/representation.rb
@@ -30,6 +30,10 @@ class Preservica::Representation
     xml.xpath('/RepresentationResponse/ContentObjects/ContentObject').text.strip
   end
 
+  def xml
+    @xml ||= Nokogiri::XML(@preservica_client.information_object_representation(@id, @name)).remove_namespaces!
+  end
+
   private
 
     def load_content_objects
@@ -37,9 +41,5 @@ class Preservica::Representation
         content_object_id = content_object_node.xpath('@ref').text
         Preservica::ContentObject.new(@preservica_client, content_object_id)
       end
-    end
-
-    def xml
-      @xml ||= Nokogiri::XML(@preservica_client.information_object_representation(@id, @name)).remove_namespaces!
     end
 end

--- a/app/models/preservica/structural_object.rb
+++ b/app/models/preservica/structural_object.rb
@@ -17,6 +17,10 @@ class Preservica::StructuralObject
     @information_objects ||= load_information_objects
   end
 
+  def xml
+    @xml ||= @preservica_client.structural_object(@id)
+  end
+
   private
 
     def load_information_objects

--- a/lib/tasks/preservica_export.rake
+++ b/lib/tasks/preservica_export.rake
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Example:  rake preservica:export_tree[structural_object/d1dc8009-e39e-44bc-bee9-f46637981e08,Preservation-1,brbl]
+# rubocop:disable  Metrics/BlockLength
+namespace :preservica do
+  desc "Export tree of preservica objects"
+  task :export_tree, [:uri, :representation_name, :admin_set_key] => :environment do |_task, args|
+    Rails.logger = Logger.new(STDOUT)
+    root_object_id = (args[:uri].split('/')[-1]).to_s
+    if args[:uri].include?("structural_object")
+      pattern = :pattern_one
+      destination = "preservica_export/StructuralObject-#{root_object_id}"
+      structural_object = Preservica::StructuralObject.where(admin_set_key: args[:admin_set_key], id: root_object_id)
+      information_objects = structural_object.information_objects
+    elsif args[:uri].include?("information_object")
+      pattern = :pattern_two
+      destination = "preservica_export/InformationObject-#{root_object_id}"
+      information_objects = [Preservica::InformationObject.where(admin_set_key: args[:admin_set_key], id: root_object_id)]
+    else
+      raise StandardError, "Invalid URI: #{args[:uri]}"
+    end
+    exporter = PreservicaExporter.new(destination)
+    FileUtils.mkdir_p destination.to_s
+    Rails.logger.info("Writing XML files to #{destination}")
+    time = Benchmark.measure do
+      exporter.write_object_to_file(structural_object, "0000") if pattern == :pattern_one
+      exporter.write_information_objects(information_objects, args[:representation_name], pattern)
+    end
+    Rails.logger.info("#{exporter.file_count} files written.")
+    Rails.logger.info("Completed in #{time.real} seconds.")
+  end
+
+  class PreservicaExporter
+    attr_reader :file_count
+    attr_reader :destination
+
+    def initialize(destination)
+      @destination = destination
+      @file_count = 0
+    end
+
+    def write_information_objects(information_objects, representation_name, pattern)
+      information_objects.each_with_index do |information_object, index1|
+        index = index1.to_s.rjust(4, '0').to_s
+        write_object_to_file(information_object, index)
+        representation = information_object.fetch_by_representation_name(representation_name)[0]
+        write_object_to_file(representation, index)
+        content_objects = representation.content_objects
+        Rails.logger.info("Warning!! Multiple content objects found for pattern one for InformationObject #{information_object.id}") if pattern == :pattern_one && content_objects.count > 1
+        write_content_objects(content_objects, index)
+      end
+    end
+
+    def write_content_objects(content_objects, index_prefix)
+      content_objects.each_with_index do |content_object, index1|
+        index = "#{index_prefix}-#{index1.to_s.rjust(4, '0')}"
+        write_object_to_file(content_object, index)
+        generations = content_object.active_generations
+        Rails.logger.info("\n\nWarning!! Multiple active generations for content object: #{content_object.id}\n") if generations.count > 1
+        write_generations(content_object, generations, index)
+      end
+    end
+
+    def write_generations(content_object, generations, index_prefix)
+      generations.each_with_index do |generation, index1|
+        index = "#{index_prefix}-#{index1.to_s.rjust(4, '0')}"
+        write_object_to_file(generation, index)
+        bitstreams = generation.bitstreams
+        Rails.logger.info("\n\nWarning!! Multiple bitstreams for content_object: #{content_object.id} with generation #{generation.id} at index #{index3}\n") if bitstreams.count > 1
+        write_bitstreams(bitstreams, index)
+      end
+    end
+
+    def write_bitstreams(bitstreams, index_prefix)
+      bitstreams.each_with_index do |bitstream, index1|
+        index = "#{index_prefix}-#{index1.to_s.rjust(4, '0')}"
+        write_object_to_file(bitstream, index)
+      end
+    end
+
+    def write_object_to_file(object, index)
+      filename = "#{destination}/#{object.class.name.gsub('Preservica::', '')}_#{index}_#{object.id}.xml"
+      Rails.logger.debug("Writing to file #{filename}")
+      File.open(filename, "w") { |f| f.write object.xml }
+      @file_count += 1
+    end
+  end
+end
+# rubocop:enable  Metrics/BlockLength


### PR DESCRIPTION
**Add rakes task to export xml from Preservica**

- Add rake task
- Add non-private xml method to all Preservica models
- Add export directory to gitignore

Example:
`rake preservica:export_tree[structural_object/d1dc8009-e39e-44bc-bee9-f46637981e08,Preservation-1,brbl]`

Files are written using the id, and some index context since some object types use the index as the id.

Sample (partial) file list:
```
preservica_export/StructuralObject-d1dc8009-e39e-44bc-bee9-f46637981e08/Bitstream_0000-0000-0000-0000_1.xml
preservica_export/StructuralObject-d1dc8009-e39e-44bc-bee9-f46637981e08/ContentObject_0000-0000_d72ec820-9877-4ea5-9d23-adb1412ae0ae.xml
preservica_export/StructuralObject-d1dc8009-e39e-44bc-bee9-f46637981e08/Generation_0000-0000-0000_1.xml
preservica_export/StructuralObject-d1dc8009-e39e-44bc-bee9-f46637981e08/InformationObject_0000_1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d.xml
preservica_export/StructuralObject-d1dc8009-e39e-44bc-bee9-f46637981e08/Representation_0000_1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d.xml
preservica_export/StructuralObject-d1dc8009-e39e-44bc-bee9-f46637981e08/StructuralObject_0000_d1dc8009-e39e-44bc-bee9-f46637981e08.xml
```

Warnings are output when there is something unexpected in the structure. (e.g. multiple content objects in pattern one, multiple bitstreams for one content object, etc.) 