### PR TITLE
Representations by name bug fix

### DIFF
--- a/app/models/preservica/information_object.rb
+++ b/app/models/preservica/information_object.rb
@@ -38,7 +38,7 @@ class Preservica::InformationObject
   private
 
     def load_representation(preservica_representation_name)
-      load_representations.select { |representation| representation.name.include?(preservica_representation_name) }
+      representations.select { |representation| representation.name.include?(preservica_representation_name) }
     end
 
     def load_representations

--- a/app/models/preservica/information_object.rb
+++ b/app/models/preservica/information_object.rb
@@ -26,6 +26,7 @@ class Preservica::InformationObject
     @preservation_representations ||= load_preservation_reps
   end
 
+  # returns all representations with a name containing preservica_representation_name
   def fetch_by_representation_name(preservica_representation_name)
     @representation_hash[preservica_representation_name] ||= load_representation(preservica_representation_name)
   end

--- a/app/models/preservica/information_object.rb
+++ b/app/models/preservica/information_object.rb
@@ -11,6 +11,7 @@ class Preservica::InformationObject
   def initialize(preservica_client, id)
     @preservica_client = preservica_client
     @id = id
+    @representation_hash = {}
   end
 
   def representations
@@ -26,7 +27,7 @@ class Preservica::InformationObject
   end
 
   def fetch_by_representation_name(preservica_representation_name)
-    @representation ||= load_representation(preservica_representation_name)
+    @representation_hash[preservica_representation_name] ||= load_representation(preservica_representation_name)
   end
 
   def xml

--- a/app/models/preservica/information_object.rb
+++ b/app/models/preservica/information_object.rb
@@ -37,10 +37,7 @@ class Preservica::InformationObject
   private
 
     def load_representation(preservica_representation_name)
-      xml = Nokogiri::XML(@preservica_client.information_object_representations(@id)).remove_namespaces!
-      xml.xpath('//Representation/@name').map(&:text).select { |name| name.include?(preservica_representation_name) }.map do |name|
-        Preservica::Representation.new(@preservica_client, @id, name)
-      end
+      load_representations.select { |representation| representation.name.include?(preservica_representation_name) }
     end
 
     def load_representations
@@ -51,16 +48,10 @@ class Preservica::InformationObject
     end
 
     def load_access_reps
-      xml = Nokogiri::XML(@preservica_client.information_object_representations(@id)).remove_namespaces!
-      xml.xpath('//Representation/@name').map(&:text).select { |name| name.include?("Access") }.map do |name|
-        Preservica::Representation.new(@preservica_client, @id, name)
-      end
+      load_representation("Access")
     end
 
     def load_preservation_reps
-      xml = Nokogiri::XML(@preservica_client.information_object_representations(@id)).remove_namespaces!
-      xml.xpath('//Representation/@name').map(&:text).select { |name| name.include?("Preservation") }.map do |name|
-        Preservica::Representation.new(@preservica_client, @id, name)
-      end
+      load_representation("Preservation")
     end
 end

--- a/app/models/preservica/information_object.rb
+++ b/app/models/preservica/information_object.rb
@@ -19,11 +19,11 @@ class Preservica::InformationObject
   end
 
   def access_representations
-    @access_representations ||= load_access_reps
+    @access_representations ||= load_representation("Access")
   end
 
   def preservation_representations
-    @preservation_representations ||= load_preservation_reps
+    @preservation_representations ||= load_representation("Preservation")
   end
 
   # returns all representations with a name containing preservica_representation_name
@@ -46,13 +46,5 @@ class Preservica::InformationObject
       xml.xpath('//Representation/@name').map(&:text).map do |name|
         Preservica::Representation.new(@preservica_client, @id, name)
       end
-    end
-
-    def load_access_reps
-      load_representation("Access")
-    end
-
-    def load_preservation_reps
-      load_representation("Preservation")
     end
 end

--- a/spec/models/preservica/preservica_object_spec.rb
+++ b/spec/models/preservica/preservica_object_spec.rb
@@ -135,6 +135,13 @@ RSpec.describe Preservica::PreservicaObject, type: :model do
     expect(preservation_representations[0].type).to eq "Preservation"
   end
 
+  it 'retrieves correct representations with fetch' do
+    structured_object = Preservica::StructuralObject.where(admin_set_key: 'brbl', id: "7fe35e8c-c21a-444a-a2e2-e3c926b519c4")
+    information_objects = structured_object.information_objects
+    expect(information_objects[0].fetch_by_representation_name('Access-2')[0].name).to eq("Access-2")
+    expect(information_objects[0].fetch_by_representation_name('Preservation-1')[0].name).to eq("Preservation-1")
+  end
+
   it 'retrieves generation based on active true' do
     structured_object = Preservica::StructuralObject.where(admin_set_key: 'brbl', id: "7fe35e8c-c21a-444a-a2e2-e3c926b519c4")
     information_objects = structured_object.information_objects

--- a/spec/models/preservica/preservica_object_spec.rb
+++ b/spec/models/preservica/preservica_object_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe Preservica::PreservicaObject, type: :model do
   it 'retrieves correct representations with fetch' do
     structured_object = Preservica::StructuralObject.where(admin_set_key: 'brbl', id: "7fe35e8c-c21a-444a-a2e2-e3c926b519c4")
     information_objects = structured_object.information_objects
-    expect(information_objects[0].fetch_by_representation_name('Access-2')[0].name).to eq("Access-2")
-    expect(information_objects[0].fetch_by_representation_name('Preservation-1')[0].name).to eq("Preservation-1")
+    expect(information_objects[0].fetch_by_representation_name('Access')[0].name).to eq("Access-2")
+    expect(information_objects[0].fetch_by_representation_name('Preservation')[0].name).to eq("Preservation-1")
   end
 
   it 'retrieves generation based on active true' do


### PR DESCRIPTION
Fix bug in fetch_by_representation_name.
Calling it with different names on the same information_object instance works as expected.

(Also consolidates some methods that had duplicate code.)