### PR TITLE
Update Parent Job will not retry after failure

### DIFF
--- a/app/jobs/update_parent_objects_job.rb
+++ b/app/jobs/update_parent_objects_job.rb
@@ -3,6 +3,8 @@
 class UpdateParentObjectsJob < ApplicationJob
   queue_as :default
 
+  discard_on StandardError, Net::OpenTimeout
+
   def default_priority
     50
   end


### PR DESCRIPTION
# Summary
After an invalid vocabulary, timeout, or any other error occurs the Update Parent Object Job will not retry.

# Related Ticket
[#1964](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1964)

# Screenshots
![image](https://user-images.githubusercontent.com/36549923/160715367-c4935d22-443b-4713-b869-4934f53f39b9.png)

