### PR TITLE
Add redirect_to: nil to where in controller

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -103,7 +103,7 @@ class ParentObjectsController < ApplicationController
   end
 
   def all_metadata_where
-    where = {}
+    where = { redirect_to: nil }
     admin_set_ids = params[:admin_set]
     admin_set_ids&.compact!
     if !admin_set_ids

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -118,7 +118,6 @@ class ParentObjectsController < ApplicationController
     end
     metadata_source_ids = params[:metadata_source_ids]
     where[:authoritative_metadata_source_id] = metadata_source_ids if metadata_source_ids
-    where = '' if where.empty?
     where
   end
 

--- a/spec/jobs/update_all_metadata_job_spec.rb
+++ b/spec/jobs/update_all_metadata_job_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe UpdateAllMetadataJob, type: :job, prep_metadata_sources: true, so
     end
 
     it 'processes parents with where' do
-      expect(ParentObject).to receive(:where).with(admin_set_id: [1, 2, 3], authoritative_metadata_source_id: [2, 3], redirect_to: nil).and_return(parent_object_where).exactly(expected_call_count).times
+      where = { admin_set_id: [1, 2, 3], authoritative_metadata_source_id: [2, 3], redirect_to: nil }
+      expect(ParentObject).to receive(:where).with(where).and_return(parent_object_where).exactly(expected_call_count).times
       UpdateAllMetadataJob.perform_later(0, admin_set_id: [1, 2, 3], authoritative_metadata_source_id: [2, 3], redirect_to: nil)
     end
   end

--- a/spec/jobs/update_all_metadata_job_spec.rb
+++ b/spec/jobs/update_all_metadata_job_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe UpdateAllMetadataJob, type: :job, prep_metadata_sources: true, so
     end
 
     it 'processes parents with where' do
-      expect(ParentObject).to receive(:where).with(admin_set_id: [1, 2, 3], authoritative_metadata_source_id: [2, 3]).and_return(parent_object_where).exactly(expected_call_count).times
-      UpdateAllMetadataJob.perform_later(0, admin_set_id: [1, 2, 3], authoritative_metadata_source_id: [2, 3])
+      expect(ParentObject).to receive(:where).with(admin_set_id: [1, 2, 3], authoritative_metadata_source_id: [2, 3], redirect_to: nil).and_return(parent_object_where).exactly(expected_call_count).times
+      UpdateAllMetadataJob.perform_later(0, admin_set_id: [1, 2, 3], authoritative_metadata_source_id: [2, 3], redirect_to: nil)
     end
   end
 end

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       end
 
       it 'starts job when dialog is submitted' do
-        expect(UpdateAllMetadataJob).to receive(:perform_later).with(0, admin_set_id: ["", admin_set.id.to_s], authoritative_metadata_source_id: ["", metadata_source.id.to_s])
+        expect(UpdateAllMetadataJob).to receive(:perform_later).with(0, admin_set_id: ["", admin_set.id.to_s], redirect_to: nil, authoritative_metadata_source_id: ["", metadata_source.id.to_s])
         expect(page).to have_css('input[value="Update Metadata"]')
         page.find("#metadata_source_ids").set [metadata_source.id.to_s]
         click_on('Update Metadata')

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
           allow(offset).to receive(:limit).and_return([])
           allow(order).to receive(:offset).and_return(offset)
           allow(ParentObject).to receive(:where).with({}).and_return(ParentObject.where({}))
-          expect(ParentObject).to receive(:where).with('').and_return(where)
+          expect(ParentObject).to receive(:where).with(redirect_to: nil).and_return(where)
           expect(where).to receive(:order).and_return(order)
           expect(page.driver.browser.switch_to.alert.text).to eq("Are you sure you want to proceed?  This action will update metadata for the entire contents of the system.")
           page.driver.browser.switch_to.alert.accept


### PR DESCRIPTION
When a user clicks Update All Metadata from the admin set page, `redirect_to: nil` needs to be added to the where clause since it will override the default parameter in the job.
Similarly for the global Update All Metadata.