### PR TITLE
Adds index to dependent uri on dependent objects table

### DIFF
--- a/db/migrate/20220401163246_add_index_to_dependent_object.rb
+++ b/db/migrate/20220401163246_add_index_to_dependent_object.rb
@@ -1,0 +1,5 @@
+class AddIndexToDependentObject < ActiveRecord::Migration[6.0]
+  def change
+    add_index  :dependent_objects, :dependent_uri unless index_exists?(:dependent_objects, :dependent_uri)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_02_184235) do
+ActiveRecord::Schema.define(version: 2022_04_01_163246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 2022_03_02_184235) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "metadata_source"
+    t.index ["dependent_uri"], name: "index_dependent_objects_on_dependent_uri"
     t.index ["parent_object_id"], name: "index_dependent_objects_on_parent_object_id"
   end
 


### PR DESCRIPTION
# Summary
Adds an index to the dependent objects table in order to help speed up the nightly metadata refresh.

# Related Ticket
[#1992](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1992)