### PR TITLE
Child object link

### DIFF
--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -243,7 +243,7 @@ class IiifPresentationV3
     metadata_values <<  metadata_pair('Image ID', child.oid.to_s) if child.oid
     metadata_values <<  metadata_pair('Image Label', child.label) if child.label
     metadata_values <<  metadata_pair('Image Caption', child.caption) if child.caption
-    metadata_values <<  metadata_pair('Image Link', "https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}") if child.oid
+    metadata_values <<  metadata_pair('Link to this image', "https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}") if child.oid
     canvas['metadata'] = metadata_values
     canvas
   end

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -153,7 +153,7 @@ class IiifPresentationV3
   def homepage
     [
       {
-        "id" => "https://collections.library.yale.edu/catalog/#{@oid}/test",
+        "id" => "https://collections.library.yale.edu/catalog/#{@oid}",
         "type" => "Text",
         "format" => "text/html",
         "label" => { "en" => ["Yale Digital Collections page"] }
@@ -243,7 +243,7 @@ class IiifPresentationV3
     metadata_values <<  metadata_pair('Image ID', child.oid.to_s) if child.oid
     metadata_values <<  metadata_pair('Image Label', child.label) if child.label
     metadata_values <<  metadata_pair('Image Caption', child.caption) if child.caption
-    metadata_values <<  metadata_pair('Link to this image', "https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}") if child.oid
+    metadata_values <<  metadata_pair('Link to this Image', "https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}") if child.oid
     canvas['metadata'] = metadata_values
     canvas
   end

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -153,7 +153,7 @@ class IiifPresentationV3
   def homepage
     [
       {
-        "id" => "https://collections.library.yale.edu/catalog/#{@oid}",
+        "id" => "https://collections.library.yale.edu/catalog/#{@oid}/test",
         "type" => "Text",
         "format" => "text/html",
         "label" => { "en" => ["Yale Digital Collections page"] }
@@ -243,6 +243,7 @@ class IiifPresentationV3
     metadata_values <<  metadata_pair('Image ID', child.oid.to_s) if child.oid
     metadata_values <<  metadata_pair('Image Label', child.label) if child.label
     metadata_values <<  metadata_pair('Image Caption', child.caption) if child.caption
+    metadata_values <<  metadata_pair('Image Link', "https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}") if child.oid
     canvas['metadata'] = metadata_values
     canvas
   end


### PR DESCRIPTION
## Summary  
Image link is now provided in the UV "More Information" panel:  
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/24666568/162025088-cdf6a79e-46c4-4f38-957c-012efc16fd46.png">