### PR TITLE
Prevent queueing PDF Job and Generating Manifest for Redirects

### DIFF
--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -10,10 +10,12 @@ class GenerateManifestJob < ApplicationJob
   def perform(parent_object, current_batch_process, current_batch_connection = parent_object.current_batch_connection)
     parent_object.current_batch_process = current_batch_process
     parent_object.current_batch_connection = current_batch_connection
-    generate_manifest(parent_object)
-    parent_object.save
+    if parent_object.should_create_manifest_and_pdf?
+      generate_manifest(parent_object)
+      parent_object.save
+    end
     parent_object.solr_index_job
-    GeneratePdfJob.perform_later(parent_object, current_batch_process, current_batch_connection)
+    GeneratePdfJob.perform_later(parent_object, current_batch_process, current_batch_connection) if parent_object.should_create_manifest_and_pdf?
   end
 
   def generate_manifest(parent_object)

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -8,6 +8,7 @@ class GeneratePdfJob < ApplicationJob
   end
 
   def perform(parent_object, current_batch_process = parent_object.current_batch_process, current_batch_connection = parent_object.current_batch_connection)
+    return unless parent_object.should_create_manifest_and_pdf?
     parent_object.current_batch_process = current_batch_process
     parent_object.current_batch_connection = current_batch_connection
     parent_object.generate_pdf

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -23,7 +23,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   attr_accessor :current_batch_connection
   self.primary_key = 'oid'
   after_save :setup_metadata_job
-  after_update :check_for_redirect
+  before_update :check_for_redirect
   after_update :digital_object_check
   # after_update :solr_index_job # we index from the fetch job on create
   after_destroy :solr_delete
@@ -53,7 +53,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
         self[key.to_sym] = nil unless minimal_attr.include? key
       end
     end
-    solr_index
   end
 
   def self.visibilities
@@ -527,5 +526,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def should_index?
     return false if redirect_to.blank? && (child_object_count&.zero? || child_objects.empty?)
     ['Public', 'Redirect', 'Yale Community Only'].include?(visibility) || redirect_to.present?
+  end
+
+  def should_create_manifest_and_pdf?
+    !redirect_to.present?
   end
 end

--- a/spec/models/batch_process_redirect_jobs_spec.rb
+++ b/spec/models/batch_process_redirect_jobs_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Putting this in a separate test file so expect / receive work correctly
+RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
+  subject(:batch_process) { described_class.new(batch_action: "reassociate child oids") }
+  around do |example|
+    perform_enqueued_jobs do
+      example.run
+    end
+  end
+
+  let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:role) { FactoryBot.create(:role, name: editor) }
+  let(:redirect) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "reassociation_example_redirect.csv")) }
+  let(:parent_to_receive_children) { FactoryBot.create(:parent_object, oid: "2004550", admin_set_id: admin_set.id) }
+  let(:parent_to_redirect) { FactoryBot.create(:parent_object, oid: "2004551", admin_set_id: admin_set.id, bib: "34567", call_number: "MSS MS 345") }
+  let(:child_one) { FactoryBot.create(:child_object, oid: "12345", parent_object: parent_to_redirect) }
+  let(:child_two) { FactoryBot.create(:child_object, oid: "67890", parent_object: parent_to_redirect) }
+
+  describe "redirected parent" do
+    before do
+      stub_ptiffs_and_manifests
+      login_as(:user)
+      parent_to_receive_children
+      parent_to_redirect
+      child_one
+      child_two
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+      batch_process.file = redirect
+    end
+
+    it "does not create manifest or pdfs" do
+      # both parents are indexed
+      expect(SolrIndexJob).to receive(:perform_later).exactly(2).times
+      # only the one non-redirected parent generates the manifest
+      # rubocop:disable RSpec/AnyInstance
+      expect_any_instance_of(GenerateManifestJob).to receive(:generate_manifest).exactly(1).times
+      # rubocop:enable RSpec/AnyInstance
+      # only the one non-redirected parent generates the pdf
+      expect(GeneratePdfJob).to receive(:perform_later).exactly(1).times
+
+      # run the reassociate batch
+      batch_process.save
+      po_old_three = ParentObject.find(2_004_551)
+      # created redirect
+      expect(po_old_three.redirect_to).to eq("https://collections.library.yale.edu/catalog/2004550")
+      expect(po_old_three.visibility).to eq("Redirect")
+    end
+  end
+end


### PR DESCRIPTION
- Prevent queueing the PDF job for ParentObjects which are redirects
- Update properties for redirects before update rather than after and remove solr_index in the Active Record callback
- Prevent manifest generation for redirects, but still solr index in that job.
- Exit PDF job for redirects defensively and for PDF Jobs that were previously queued
- After reassociate, skip Manifest job and go to Solr Index for redirects