### PR TITLE
Deletes children from parent if not found in preservica

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -121,6 +121,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # Note - the upsert_all method skips ActiveRecord callbacks, and is entirely
   # database driven. This also makes object creation much faster.
   # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def create_child_records
     if from_mets
       upsert_child_objects(array_of_child_hashes_from_mets)
@@ -128,6 +131,16 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     elsif digital_object_source == "Preservica"
       child_hashes = array_of_child_hashes_from_preservica # only call array_of_child_hashes_from_preservica once since it causes all images to be downloaded
       if child_hashes.present?
+        # if not found locally add the image
+        preservica_co_uris = child_hashes.pluck(:preservica_content_object_uri)
+        preservica_co_uris.each do |uri|
+          # check if exists
+          co = ChildObject.find_by(preservica_content_object_uri: uri)
+          unless co.nil?
+            # if it does remove it from the child hash
+            child_hashes.delete_if { |h| h[:preservica_content_object_uri] == co.preservica_content_object_uri }
+          end
+        end
         upsert_child_objects(child_hashes)
         self.last_preservica_update = Time.current
         save!
@@ -141,6 +154,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.child_object_count = child_objects.size
   end
   # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   def upsert_child_objects(child_objects_hash)
     raise "One or more of the child objects exists, Unable to create children" if ChildObject.where(oid: child_objects_hash.map { |co| co[:oid] }).exists?
@@ -180,8 +196,30 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def sync_from_preservica
-    child_objects.destroy_all
-    create_child_records
+    # get list of child preservica_content_object_uri currently associated with parent
+    local_content_uris = []
+    child_objects.map do |co|
+      local_content_uris << co.preservica_content_object_uri
+    end
+    # get list of content object uris from preservica
+    preservica_content_uris = []
+    PreservicaImageService.new(preservica_uri, admin_set.key).image_list(preservica_representation_name).map do |co|
+      preservica_content_uris << co[:preservica_content_object_uri]
+    end
+    local_content_uris.map do |local|
+      # keep child objects that have a match in preservica
+      next if preservica_content_uris.include?(local)
+
+      # delete child objects that don't have a match in preservica
+      co = ChildObject.find_by(preservica_content_object_uri: local)
+      co.destroy
+    end
+
+    # create only the new child records
+    preservica_content_uris.map do |preservica|
+      next if local_content_uris.include?(preservica)
+      create_child_records
+    end
   end
 
   def array_of_child_hashes_from_mets

--- a/spec/fixtures/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children_sync.xml
+++ b/spec/fixtures/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children_sync.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ChildrenResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Children>
+    <Child title="mss_29_s03_b092_f0019" ref="1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r
+    </Child>
+    <Child title="mss_29_s03_b092_f0019_0002" ref="f44ba97e-af2b-498e-b118-ed1247822f44" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44
+    </Child>
+  </Children>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children
+    </Self>
+  </AdditionalInformation>
+</ChildrenResponse>

--- a/spec/models/preservica/preservica_sequential_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_sync_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  subject(:batch_process) { BatchProcess.new }
+  let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl') }
+  let(:admin_set_sml) { FactoryBot.create(:admin_set, key: 'sml') }
+  let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:preservica_parent_with_children) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent_with_children.csv")) }
+  let(:preservica_sync) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_sync.csv")) }
+
+  around do |example|
+    preservica_host = ENV['PRESERVICA_HOST']
+    preservica_creds = ENV['PRESERVICA_CREDENTIALS']
+    ENV['PRESERVICA_HOST'] = "testpreservica"
+    ENV['PRESERVICA_CREDENTIALS'] = '{"brbl": {"username":"xxxxx", "password":"xxxxx"}}'
+    access_host = ENV['ACCESS_MASTER_MOUNT']
+    ENV['ACCESS_MASTER_MOUNT'] = File.join("spec", "fixtures", "images", "access_masters")
+    perform_enqueued_jobs do
+      example.run
+    end
+    ENV['PRESERVICA_HOST'] = preservica_host
+    ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
+    ENV['ACCESS_MASTER_MOUNT'] = access_host
+  end
+
+  before do
+    login_as(:user)
+    batch_process.user_id = user.id
+    stub_metadata_cloud("AS-200000000", "aspace")
+    stub_request(:post, "https://testpreservica/api/accesstoken/login").to_return(status: 200, body: '{"token":"test"}')
+    stub_request(:post, "https://testpreservica/api/accesstoken/refresh").to_return(status: 200, body: '{"token":"test"}')
+    fixtures = %w[preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Access-2
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Preservation-1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Access-2
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Preservation-1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1]
+
+    temporary_fixtures = %w[preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations
+                            preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Access-2
+                            preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Preservation-1
+                            preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations
+                            preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1
+                            preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1]
+
+    changing_fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children]
+
+    fixtures.each do |fixture|
+      stub_request(:get, "https://test#{fixture}").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
+      )
+    end
+    temporary_fixtures.each do |fixture|
+      stub_request(:get, "https://test#{fixture}").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
+      ).times(2).then.to_return(status: 404, body: 'text')
+    end
+    changing_fixtures.each do |fixture|
+      stub_request(:get, "https://test#{fixture}").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
+      ).times(2).then.to_return(
+        status: 200, body: File.open(File.join(fixture_path, "#{fixture}_sync.xml"))
+      )
+    end
+
+    stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1/content").to_return(
+      status: 200, body: File.open(File.join(fixture_path, "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1/content.tif"), 'rb')
+    )
+    stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1/content").to_return(
+      status: 200, body: File.open(File.join(fixture_path, "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1/content.tif"), 'rb')
+    )
+    stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1/content").to_return(
+      status: 200, body: File.open(File.join(fixture_path, "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1/content.tif"), 'rb')
+    ).times(2).then.to_return(status: 404, body: 'text')
+  end
+
+  context 'user with permission' do
+    before do
+      user.add_role(:editor, admin_set)
+      login_as(:user)
+    end
+
+    it 'can recognize when child is removed from preservica' do
+      File.delete("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif") if File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")
+      File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
+      File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
+      File.delete("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif") if File.exist?("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif")
+      File.delete("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif") if File.exist?("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif")
+      File.delete("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif") if File.exist?("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif")
+
+      allow(S3Service).to receive(:s3_exists?).and_return(false)
+      expect(File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")).to be false
+      expect(File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")).to be false
+      expect(File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")).to be false
+      expect(File.exist?("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif")).to be false
+      expect(File.exist?("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif")).to be false
+      expect(File.exist?("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif")).to be false
+      expect do
+        batch_process.file = preservica_parent_with_children
+        batch_process.save
+      end.to change { ChildObject.count }.from(0).to(3)
+      po_first = ParentObject.first
+      co_first = ChildObject.first
+      expect(po_first.last_preservica_update).not_to be nil
+      expect(co_first.preservica_content_object_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486"
+      expect(File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")).to be true
+      expect(File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")).to be true
+      expect(File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")).to be true
+      expect(co_first.ptiff_conversion_at.present?).to be_truthy
+      File.delete("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif") if File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")
+      File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
+      File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
+      expect(po_first.child_objects.count).to eq 3
+
+      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      expect do
+        sync_batch_process.file = preservica_sync
+        sync_batch_process.save!
+      end.to change { ChildObject.count }.from(3).to(2)
+    end
+  end
+end

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
     }
   end
 
+  let(:valid_preservica_attributes) do
+    {
+      oid: "200000000",
+      authoritative_metadata_source_id: 1,
+      admin_set: AdminSet.find_by_key('brbl'),
+      bib: "123",
+      preservica_uri: '/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5',
+      preservica_representation_name: 'Preservation-1'
+    }
+  end
+
   describe "GET /index" do
     it "renders a successful response" do
       ParentObject.create! valid_attributes
@@ -201,8 +212,64 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
   end
 
   describe '#sync_from_preservica' do
+    around do |example|
+      preservica_host = ENV['PRESERVICA_HOST']
+      preservica_creds = ENV['PRESERVICA_CREDENTIALS']
+      ENV['PRESERVICA_HOST'] = "testpreservica"
+      ENV['PRESERVICA_CREDENTIALS'] = '{"brbl": {"username":"xxxxx", "password":"xxxxx"}}'
+      access_host = ENV['ACCESS_MASTER_MOUNT']
+      ENV['ACCESS_MASTER_MOUNT'] = File.join("spec", "fixtures", "images", "access_masters")
+      perform_enqueued_jobs do
+        example.run
+      end
+      ENV['PRESERVICA_HOST'] = preservica_host
+      ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
+      ENV['ACCESS_MASTER_MOUNT'] = access_host
+    end
+
+    before do
+      stub_metadata_cloud("AS-200000000", "aspace")
+      stub_request(:post, "https://testpreservica/api/accesstoken/login").to_return(status: 200, body: '{"token":"test"}')
+      stub_request(:post, "https://testpreservica/api/accesstoken/refresh").to_return(status: 200, body: '{"token":"test"}')
+      fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children
+                    preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations
+                    preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Access-2
+                    preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Preservation-1
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1
+                    preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations
+                    preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Access-2
+                    preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Preservation-1
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1
+                    preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations
+                    preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Access-2
+                    preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Preservation-1
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1
+                    preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1]
+
+      fixtures.each do |fixture|
+        stub_request(:get, "https://test#{fixture}").to_return(
+          status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
+        )
+      end
+      stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1/content").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1/content.tif"), 'rb')
+      )
+      stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1/content").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1/content.tif"), 'rb')
+      )
+      stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1/content").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1/content.tif"), 'rb')
+      )
+    end
+
     it 'redirects to the parent_objects list' do
-      parent_object = ParentObject.create! valid_attributes
+      parent_object = ParentObject.create! valid_preservica_attributes
+      expect(parent_object.child_objects.count).to eq 0
       post sync_from_preservica_parent_object_url(parent_object)
       expect(response).to redirect_to(parent_object_url(parent_object))
       expect(flash[:notice]).to eq('This object has been queued for synchronization of child objects from Preservica.')


### PR DESCRIPTION
# Summary
When syncing a parent object in Preservica the process will now remove a child from the parent if it is no longer part of the record in Preservica.

# Related Ticket
[#2024](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2024)