### PR TITLE
Add color space to processing command in PDF json

### DIFF
--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -74,6 +74,8 @@ module PdfRepresentable
       "pages" => children,
       "imageProcessingCommand" => "convert -resize 2000x2000 %s[0] %s"
     }
+    # only add color space with :s3_presigned_url so it does not affect the checksum:
+    json_hash["imageProcessingCommand"] = "convert -resize 2000x2000 %s[0] -colorspace sRGB %s" if child_page_file == :s3_presigned_url
     json_hash.to_json
   end
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -388,7 +388,11 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
 
       it "generates pdf json with the correct preprocessing command" do
-        expect(parent_object.pdf_generator_json).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] %s"')
+        expect(parent_object.pdf_generator_json).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] -colorspace sRGB %s"')
+      end
+
+      it "generates pdf json for checksum with the original preprocessing command" do
+        expect(parent_object.pdf_json("same", :child_modification)).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] %s"')
       end
 
       it "generated pdf json with Extent of Digitization" do


### PR DESCRIPTION
Adds color-space parameter to command used to resize images for PDFs
Does **not** add color-space for PDF checksum json to avoid unnecessary PDF creation.

See https://github.com/yalelibrary/YUL-DC/issues/2032 and https://github.com/yalelibrary/YUL-DC/issues/2022