### PR TITLE
Add coordintate display field

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -107,6 +107,7 @@ module SolrIndexable
         contributor_tsim: json_to_index["contributor"],
         contributorDisplay_tsim: json_to_index["contributorDisplay"],
         coordinates_ssim: json_to_index["coordinate"],
+        coordinateDisplay_ssim: json_to_index["coordinateDisplay"].presence || json_to_index["coordinate"],
         copyrightDate_ssim: json_to_index["copyrightDate"],
         creator_ssim: extract_creator(json_to_index),
         creator_tesim: extract_creator(json_to_index),

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -92,14 +92,18 @@ class IiifPresentationV3
     }
   end
 
+  def extract_value(field, hash)
+    if hash[:digital_only] == true
+      @parent_object.send(field.to_s)
+    else
+      @parent_object&.authoritative_json&.[](field.to_s).presence || (hash[:backup_field] && @parent_object&.authoritative_json&.[](hash[:backup_field]).presence)
+    end
+  end
+
   def metadata
     values = []
     METADATA_FIELDS.each do |field, hash|
-      value = if hash[:digital_only] == true
-                @parent_object.send(field.to_s)
-              else
-                @parent_object&.authoritative_json&.[](field.to_s)
-              end
+      value = extract_value(field, hash)
       if value.is_a?(Array)
         value = process_metadata_array value, hash
       else

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -90,6 +90,7 @@ METADATA_FIELDS = {
   },
   coordinateDisplay: {
     label: 'Coordinates',
+    backup_field: 'coordinate', # use coordinate from authoritative_metadata in IIIF presentation if coordinateDisplay is not present
     solr_fields: [
       'coordinateDisplay_ssim'
     ]

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -88,10 +88,10 @@ METADATA_FIELDS = {
       'scale_tesim'
     ]
   },
-  coordinate: {
+  coordinateDisplay: {
     label: 'Coordinates',
     solr_fields: [
-      'coordinates_ssim'
+      'coordinateDisplay_ssim'
     ]
   },
   digital: {

--- a/spec/fixtures/ladybird/16172421.json
+++ b/spec/fixtures/ladybird/16172421.json
@@ -20,7 +20,7 @@
   "extentOfDigitization": [
     "Complete folder digitized."
   ],
-  "coordinateDisplay": [
+  "coordinate": [
     "(N90 E90 S90 W90)"
   ],
   "creationPlace": [

--- a/spec/fixtures/ladybird/16172421.json
+++ b/spec/fixtures/ladybird/16172421.json
@@ -20,6 +20,9 @@
   "extentOfDigitization": [
     "Complete folder digitized."
   ],
+  "coordinateDisplay": [
+    "(N90 E90 S90 W90)"
+  ],
   "creationPlace": [
     "England"
   ],

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -70,4 +70,19 @@ RSpec.describe SolrIndexable, type: :model do
     expect(solr_document[:quicksearchId_ssi]).to be_nil
   end
   # rubocop:enable Lint/ParenthesesAsGroupedExpression
+
+  it "indexes coordinateDisplay" do
+    solr_document = solr_indexable.to_solr("coordinate" => ["do not index"], "coordinateDisplay" => ["(N90, S90, E90, W90)"])
+    expect(solr_document[:coordinateDisplay_ssim]).to eq(["(N90, S90, E90, W90)"])
+  end
+
+  it "indexes coordinate as coordinateDisplay if coordinateDisplay is nil" do
+    solr_document = solr_indexable.to_solr("coordinate" => ["coordinate"], "coordinateDisplay" => nil)
+    expect(solr_document[:coordinateDisplay_ssim]).to eq(["coordinate"])
+  end
+
+  it "indexes coordinate as coordinateDisplay if coordinateDisplay is an empty array" do
+    solr_document = solr_indexable.to_solr("coordinate" => ["coordinate"], "coordinateDisplay" => [])
+    expect(solr_document[:coordinateDisplay_ssim]).to eq(["coordinate"])
+  end
 end

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -162,6 +162,10 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["metadata"].select { |k| true if k["label"]["en"].first == "Container / Volume Information" }).not_to be_empty
     end
 
+    it "has coordinates in metadata" do
+      expect(iiif_presentation.manifest["metadata"].select { |v| v["label"]["en"] == ["Coordinates"] }.first["value"]["none"]).to eq(["(N90 E90 S90 W90)"])
+    end
+
     it "has a ASpace record link in metadata if ASpace record" do
       expect(aspace_iiif_presentation.manifest["metadata"].class).to eq Array
       expect(aspace_iiif_presentation.manifest["metadata"].select { |k| true if k["label"]["en"].first == "Archives at Yale Item Page" }).not_to be_empty


### PR DESCRIPTION
Adds solr field `coordinateDisplay_ssim` populated with `coordinateDisplay` with a fallback to coordinate from metadata cloud
Updates `METADATA_FIELDS` to use `coordinateDisplay` then `coordinate` in `authoritative_metadata` for Coordinates for IIIF metadata.
Adds `backup_field` property to METADATA_FIELDS for use by IIIF manifest when generating metadata.  `backup_field` is used to get values from `authoritative_metadata` is the primary field is not present.