### PR TITLE
Creates batch process with status for synchronize child object button

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -168,8 +168,16 @@ class ParentObjectsController < ApplicationController
 
     def queue_parent_sync_from_preservica
       authorize!(:update, @parent_object)
-      @parent_object.sync_from_preservica
-      @parent_object.setup_metadata_job
+      @batch_process = BatchProcess.new(user: current_user,
+                                        oid: @parent_object.oid,
+                                        batch_action: 'sync from preservica',
+                                        csv: CSV.generate do |csv|
+                                               csv << ['oid']
+                                               csv << [@parent_object.oid.to_s]
+                                             end)
+      @parent_object.current_batch_connection = @batch_process.batch_connections.build(connectable: @parent_object)
+      @batch_process.save!
+      @parent_object.current_batch_process = @batch_process
     end
 
     def valid_admin_set_edit?


### PR DESCRIPTION
# Summary
Triggers a batch process job to be created when the synchronize child objects button is used from the parent object show page. 

# Related Ticket
[#2038](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2038)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/164801312-3759974b-8a99-434c-8f42-31234dbb03a3.png)