### PR TITLE
Lookup documents in solr by id, write to solr in setup metadata job for redirects

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -154,7 +154,7 @@ class ParentObjectsController < ApplicationController
     authorize!(:read, @parent_object)
     solr = SolrService.connection
     oid = params[:id].to_i
-    response = solr.get 'select', params: { q: "oid_ssi:#{oid}" }
+    response = solr.get 'select', params: { q: "id:#{oid}" }
     render json: response["response"]
   end
 


### PR DESCRIPTION
- Write to solr in setup metadata job for redirects to bypass any metadata fetchs, etc that may fail on redirects.
- Lookups documents in solr by id so that redirects are found.  (Redirects do not have an oid_ssi in the document).