### PR TITLE
Delete dependent objects when parent is redirected

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -53,6 +53,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
         self[key.to_sym] = nil unless minimal_attr.include? key
       end
     end
+
+    # clear dependent objects
+    DependentObject.delete(dependent_objects)
   end
 
   def self.visibilities

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -330,6 +330,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       expect(parent_object.dependent_objects.first.dependent_uri).to eq '/ladybird/oid/2005512'
     end
 
+    it "deletes DependentObjects when redirected" do
+      expect(parent_object.reload.dependent_objects.count).to eq 1
+      parent_object.redirect_to = "https://collections.library.yale.edu/catalog/5555"
+      parent_object.save
+      expect(parent_object.dependent_objects.count).to eq 0
+    end
+
     context "a newly created ParentObject with just the oid and default authoritative_metadata_source (Ladybird for now)" do
       let(:parent_object) { described_class.create(oid: "2005512", admin_set: FactoryBot.create(:admin_set)) }
       before do


### PR DESCRIPTION
Delete DependentObjects for a parent when it it redirected.
Removing the dependent objects will cause the activity stream sync to ignore redirected parents.