### PR TITLE
Fixes Sonarcloud HTML bugs

### DIFF
--- a/app/views/admin_sets/_roles_tables.html.erb
+++ b/app/views/admin_sets/_roles_tables.html.erb
@@ -1,4 +1,4 @@
-<table class='table table-striped admin-set-show-table'>
+<table class='table table-striped admin-set-show-table' aria-label='Viewers Admin Set'>
   <thead class='thead-dark'>
     <tr>
       <th scope='col'> Viewers </th>
@@ -13,7 +13,7 @@
   </tbody>
 </table>
 
-<table class='table table-striped admin-set-show-table'>
+<table class='table table-striped admin-set-show-table' aria-label='Editors Admin Set'>
   <thead class='thead-dark'>
     <tr>
       <th scope='col'> Editors </th>

--- a/app/views/admin_sets/index.html.erb
+++ b/app/views/admin_sets/index.html.erb
@@ -13,7 +13,7 @@
 
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='batch-processes-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= admin_sets_path(format: :json) %>'>
+    <table id='batch-processes-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Admin Sets' data-source='<%= admin_sets_path(format: :json) %>'>
       <thead class='table-head'>
       <tr>
         <th scope='col'> Key </th>

--- a/app/views/batch_processes/index.html.erb
+++ b/app/views/batch_processes/index.html.erb
@@ -13,7 +13,7 @@
 
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='batch-processes-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= batch_processes_path(format: :json) %>' data-refresh="true" >
+    <table id='batch-processes-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Batch Processes' data-source='<%= batch_processes_path(format: :json) %>' data-refresh="true" >
       <thead class='table-head'>
         <tr>
           <th scope='col'>Process ID</th>

--- a/app/views/batch_processes/show.html.erb
+++ b/app/views/batch_processes/show.html.erb
@@ -52,7 +52,7 @@
       <h1>Batch Messages:</h1>
     </div>
   </div>
-  <table class='table table-bordered table-responsive table-striped'>
+  <table class='table table-bordered table-responsive table-striped' aria-label='Batch Messages'>
     <thead class='table-head'>
       <tr>
         <th scope='col'> Time </th>
@@ -75,7 +75,7 @@
         <h1>Batch Parent Objects:</h1>
       </div>
     </div>
-    <table id='batch-process-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= batch_process_path(format: :json) %>'>
+    <table id='batch-process-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Batch Parent Objects' data-source='<%= batch_process_path(format: :json) %>'>
       <thead class='table-head'>
         <tr>
           <th scope='col'> Parent OID </th>

--- a/app/views/batch_processes/show_child.html.erb
+++ b/app/views/batch_processes/show_child.html.erb
@@ -30,7 +30,7 @@
   </p>
 </div>
 
-<table class='table table-responsive table-bordered table-striped detail-table'>
+<table class='table table-responsive table-bordered table-striped detail-table' aria-label='Child Batch Process Success'>
 <% if @batch_process.batch_action == "update fulltext status"  %>
   <p>
     <strong>Current Full Text Status:</strong> <%= @child_object.full_text ? "Available" : "Not Found" %>
@@ -71,7 +71,7 @@
 <% end %>
 
 <% if @failure %>
-  <table class='table table-responsive table-bordered table-striped'>
+  <table class='table table-responsive table-bordered table-striped' aria-label='Child Batch Process Failure'>
     <thead class='table-head'>
       <tr>
         <th scope='col'>Message</th>

--- a/app/views/batch_processes/show_parent.html.erb
+++ b/app/views/batch_processes/show_parent.html.erb
@@ -28,7 +28,7 @@
 
 <div class='row batch-process-subheading'>
   <div class='col'>
-    <table class='table table-responsive table-bordered table-striped detail-table'>
+    <table class='table table-responsive table-bordered table-striped detail-table' aria-label='Parent Batch Process Detail'>
       <thead class='table-head'>
         <tr>
           <th scope='col'>Ingest step</th>
@@ -106,7 +106,7 @@
 </div>
 
 <% if @latest_failure %>
-<table class='table table-responsive table-bordered table-striped'>
+<table class='table table-responsive table-bordered table-striped' aria-label='Parent Batch Process Failure'>
   <thead class='table-head'>
     <tr>
       <th scope='col'>Last Failure Message</th>
@@ -124,7 +124,7 @@
 
 <div class='row batch-process-subheading'>
   <div class='col'>
-    <table id='parent-batch-process-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= show_parent_batch_process_path(format: :json) %>'>
+    <table id='parent-batch-process-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Parent Batch Process Status' data-source='<%= show_parent_batch_process_path(format: :json) %>'>
       <thead class='table-head'>
         <tr>
           <th scope='col'>Child OID</th>

--- a/app/views/child_objects/index.html.erb
+++ b/app/views/child_objects/index.html.erb
@@ -12,7 +12,7 @@
 
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='child-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= child_objects_path(format: :json) %>'>
+    <table id='child-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Child Objects' data-source='<%= child_objects_path(format: :json) %>'>
       <thead class='table-head'>
         <tr>
           <th scope='col'>OID</th>

--- a/app/views/delayed_job_dashboard/index.html.erb
+++ b/app/views/delayed_job_dashboard/index.html.erb
@@ -6,7 +6,7 @@
   <h3>Total Jobs: <%= @all_jobs_count %></h3>
 </div>
 
-<table class="table table-bordered table-responsive table-striped">
+<table class="table table-bordered table-responsive table-striped" aria-label="Job Status">
   <thead class="thead-dark">
   <tr>
     <th scope="col"> Job Type </th>

--- a/app/views/delayed_job_dashboard/jobs.html.erb
+++ b/app/views/delayed_job_dashboard/jobs.html.erb
@@ -2,7 +2,7 @@
   <%= @job_types %> Jobs
 </h1>
 <%= paginate @jobs %>
-<table border=1>
+<table border=1 aria-label='Job Status'>
   <tr>
     <th>Id</th>
     <th>Attempts</th>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang='EN' xml:lang='en'>
 <head>
   <title>YulDcManagement</title>
   <%= csrf_meta_tags %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="EN" xml:lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Mailer</title>
     <style>
       /* Email styles need to be inline */
     </style>

--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -1,7 +1,7 @@
 
 <div class="container">
   <h3> Containers </h3>
-  <table class="table table-bordered table-responsive table-striped">
+  <table class="table table-bordered table-responsive table-striped" aria-label="Containers">
     <thead class="thead-dark">
       <tr>
         <th scope="col"> Service </th>
@@ -30,7 +30,7 @@
       </tr>
   </table>
   <h3> Base URLs</h3>
-    <table class="table table-bordered table-responsive table-striped">
+    <table class="table table-bordered table-responsive table-striped" aria-label="Base URLs">
       <thead class="thead-dark">
       <tr>
         <th scope="col"> Service </th>
@@ -59,7 +59,7 @@
       </tr>
   </table>
     <h3> Storage </h3>
-    <table class="table table-bordered table-responsive table-striped">
+    <table class="table table-bordered table-responsive table-striped" aria-label="Storage">
       <thead class="thead-dark">
       <tr>
         <th scope="col"> Service </th>

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -22,7 +22,7 @@
 </div>
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='parent-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= parent_objects_path(format: :json) %>'>
+    <table id='parent-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Parent Objects' data-source='<%= parent_objects_path(format: :json) %>'>
       <thead class='table-head'>
         <tr>
           <th scope='col'>OID</th>

--- a/app/views/preservica_ingests/index.html.erb
+++ b/app/views/preservica_ingests/index.html.erb
@@ -6,7 +6,7 @@
 </div>
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='preservica-ingests-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= preservica_ingests_path(format: :json) %>'>
+    <table id='preservica-ingests-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Preservica Ingests' data-source='<%= preservica_ingests_path(format: :json) %>'>
       <thead class='table-head'>
         <tr>
           <th scope='col'>Parent OID</th>

--- a/app/views/redirected_parent_objects/index.html.erb
+++ b/app/views/redirected_parent_objects/index.html.erb
@@ -7,7 +7,7 @@
 
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='redirected-parent-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= redirected_parent_objects_path(format: :json) %>'>
+    <table id='redirected-parent-objects-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Redirected Parent Objects' data-source='<%= redirected_parent_objects_path(format: :json) %>'>
       <thead class='table-head'>
         <tr>
           <th scope='col'>OID</th>

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -29,7 +29,7 @@
 </div><br />
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id='reoccurring-job-datatable' class='is-datatable table table-responsive table-bordered table-striped' data-source='<%= reoccurring_jobs_path(format: :json) %>' data-refresh="true" >
+    <table id='reoccurring-job-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Reoccurring Jobs' data-source='<%= reoccurring_jobs_path(format: :json) %>' data-refresh="true" >
       <thead class='table-head'>
         <tr>
           <th scope='col'>Process ID</th>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
 </div>
 <div class='row datatable'>
   <div class='col overflow-auto'>
-    <table id="users-datatable" class='is-datatable table table-responsive table-bordered table-striped' data-source="<%= users_path(format: :json) %>">
+    <table id="users-datatable" class='is-datatable table table-responsive table-bordered table-striped' aria-label='Users' data-source="<%= users_path(format: :json) %>">
     <thead class='table-head'>
       <tr>
         <th scope='col'>NetID</th>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,7 +26,7 @@
   <%= @user.deactivated %>
 </p>
 
-<table class='table table-striped user-roles-table table-bordered'>
+<table class='table table-striped user-roles-table table-bordered' aria-label='User Details'>
   <thead class='thead-dark'>
     <tr>
       <th scope='col'> Admin Set </th>

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="EN">
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/public/422.html
+++ b/public/422.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="EN">
 <head>
   <title>The change you wanted was rejected (422)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/public/500.html
+++ b/public/500.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="EN">
 <head>
   <title>We're sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
## Summary
Fixes Sonarcloud HTML bugs

## Related Ticket
[2057](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2057)

## Note
1. For the "Add a description to this table." issues: It's suggested to use `aria-describedby` if there is an element on the page you can use as the `aria-label`. Using `aria-describedby` requires passing an id for the element being referenced. I decided to use `aria-label` for simplicity and not cluttering the code with ids.  It's my understanding that this work is being done to appease Sonarcloud. If you would like me to refactor to use `aria-describedby`, please let me know.

2. For the "Surround this `<li>` item tag by a `<ul>` or `<ol>` container one." issues - These `li` elements are wrapped in a `ul` element in the app/views/kaminari/_paginator.html.erb file. Can we override these issues in Sonarcloud?

![image](https://user-images.githubusercontent.com/39319859/167004776-43449623-c318-43f1-8759-6cdbc6a910e8.png)

3. For the "Add "lang" and/or "xml:lang" attributes to this "<html>" element" issues - I added both `lang='EN' xml:lang='en'` to most of the files as coverall. 