### PR TITLE
Remove colorspace parameter from imageProcessingCommand

### DIFF
--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -78,8 +78,9 @@ module PdfRepresentable
       "pages" => children,
       "imageProcessingCommand" => "convert -resize 2000x2000 %s[0] %s"
     }
-    # only add color space with :s3_presigned_url so it does not affect the checksum:
-    json_hash["imageProcessingCommand"] = "convert -resize 2000x2000 %s[0] -colorspace sRGB %s" if child_page_file == :s3_presigned_url
+    # Don't adjust the processing command to add color space because it was causing problems.  Adjust and uncomment if
+    # there is a command change for preprocessing needed:
+    #  json_hash["imageProcessingCommand"] = "convert -resize 2000x2000 %s[0] -colorspace sRGB %s" if child_page_file == :s3_presigned_url
     json_hash.to_json
   end
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
 
       it "generates pdf json with the correct preprocessing command" do
-        expect(parent_object.pdf_generator_json).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] -colorspace sRGB %s"')
+        expect(parent_object.pdf_generator_json).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] %s"')
       end
 
       it "generates pdf json for checksum with the original preprocessing command" do


### PR DESCRIPTION
Removes ` -colorspace sRGB` parameter from preprocessing command for PTIFFs going into the PDF because it was distorting colors.

See https://github.com/yalelibrary/YUL-DC/issues/2075