### PR TITLE
Sort nulls last

### DIFF
--- a/config/initializers/ajax_datatables_rails.rb
+++ b/config/initializers/ajax_datatables_rails.rb
@@ -3,4 +3,5 @@
 AjaxDatatablesRails.configure do |config|
   # available options for db_adapter are: :pg, :mysql, :mysql2, :sqlite, :sqlite3
   config.db_adapter = :pg
+  config.nulls_last = true
 end


### PR DESCRIPTION
# Summary
Standard datatable sorting would put nulls first.  This configuration change will push all null values to the end of the list.

# Related Ticket
[#2027](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2027)

# Video

https://user-images.githubusercontent.com/36549923/168170217-d852bcbf-7db6-416b-869c-3534a0f9f59d.mp4


