### PR TITLE
Add navPlace support for IIIF Manifests

### DIFF
--- a/app/lib/geojson.rb
+++ b/app/lib/geojson.rb
@@ -26,9 +26,9 @@ class Geojson
     p.each_with_index do |v, i|
       if v.class.equal?(String)
         if v.starts_with?('N', 'S', 'E', 'W')
-          p[i] = Float(v[1..3] + '.' + v[4..-1])
+          p[i] = Float(v[1..3] + '.' + v[4..-1], exception: false)
         elsif v =~ /[0-9]+[.]?[0-9]*/
-          p[i] = Float(v)
+          p[i] = Float(v, exception: false)
         end
       end
     end

--- a/app/lib/geojson.rb
+++ b/app/lib/geojson.rb
@@ -4,8 +4,8 @@ class Geojson
   attr_reader :valid, :coords, :type
 
   def initialize(n, e, s, w)
-    p1 = convert_point([n, e])
-    p2 = convert_point([s, w])
+    p1 = convert_point([e, n])
+    p2 = convert_point([w, s])
 
     if valid_point?(p1)
       @valid = true
@@ -38,7 +38,7 @@ class Geojson
     p.each do |c|
       return false unless value_is_numeric(c)
     end
-    return false if (p[0] > 90) || (p[0] < -90) || (p[1] > 180) || (p[1] < -180) || p.length != 2
+    return false if (p[1] > 90) || (p[1] < -90) || (p[0] > 180) || (p[0] < -180) || p.length != 2
     true
   end
 

--- a/app/lib/geojson.rb
+++ b/app/lib/geojson.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 class Geojson
   attr_reader :valid, :coords, :type
 
   def initialize(n, e, s, w)
-    p1 = convert_point([n,e])
-    p2 = convert_point([s,w])
+    p1 = convert_point([n, e])
+    p2 = convert_point([s, w])
 
     if valid_point?(p1)
       @valid = true
-      if !valid_point?(p2) or (p1 == p2)
+      if !valid_point?(p2) || (p1 == p2)
         @type = "Point"
         @coords = p1
       else
@@ -21,11 +23,11 @@ class Geojson
   end
 
   def convert_point(p)
-    p.each_with_index do |v,i|
+    p.each_with_index do |v, i|
       if v.class.equal?(String)
-        if v.starts_with?('N','S','E','W')
+        if v.starts_with?('N', 'S', 'E', 'W')
           p[i] = Float(v[1..3] + '.' + v[4..-1])
-        elsif v.match(/[0-9]+[.]?[0-9]*/)
+        elsif v =~ /[0-9]+[.]?[0-9]*/
           p[i] = Float(v)
         end
       end
@@ -33,13 +35,15 @@ class Geojson
   end
 
   def valid_point?(p)
-    return false unless p.length == 2
     p.each do |c|
-      return false unless c and (c.class.equal?(Float) or c.class.equal?(Integer))
+      return false unless value_is_numeric(c)
     end
-    return false if p[0] > 90 or p[0] < -90
-    return false if p[1] > 180 or p[1] < -180
+    return false if (p[0] > 90) || (p[0] < -90) || (p[1] > 180) || (p[1] < -180) || p.length != 2
     true
+  end
+
+  def value_is_numeric(v)
+    v && (v.class.equal?(Float) || v.class.equal?(Integer))
   end
 
   def to_polygon(c1, c2)
@@ -68,5 +72,4 @@ class Geojson
       ]
     }
   end
-
 end

--- a/app/lib/geojson.rb
+++ b/app/lib/geojson.rb
@@ -1,0 +1,72 @@
+class Geojson
+  attr_reader :valid, :coords, :type
+
+  def initialize(n, e, s, w)
+    p1 = convert_point([n,e])
+    p2 = convert_point([s,w])
+
+    if valid_point?(p1)
+      @valid = true
+      if !valid_point?(p2) or (p1 == p2)
+        @type = "Point"
+        @coords = p1
+      else
+        @type = "Polygon"
+        @coords = to_polygon(p1, p2)
+      end
+    else
+      @valid = false
+      @coords = []
+    end
+  end
+
+  def convert_point(p)
+    p.each_with_index do |v,i|
+      if v.class.equal?(String)
+        if v.starts_with?('N','S','E','W')
+          p[i] = Float(v[1..3] + '.' + v[4..-1])
+        elsif v.match(/[0-9]+[.]?[0-9]*/)
+          p[i] = Float(v)
+        end
+      end
+    end
+  end
+
+  def valid_point?(p)
+    return false unless p.length == 2
+    p.each do |c|
+      return false unless c and (c.class.equal?(Float) or c.class.equal?(Integer))
+    end
+    return false if p[0] > 90 or p[0] < -90
+    return false if p[1] > 180 or p[1] < -180
+    true
+  end
+
+  def to_polygon(c1, c2)
+    poly = []
+    poly << [c1[0], c1[1]]
+    poly << [c2[0], c1[1]]
+    poly << [c2[0], c2[1]]
+    poly << [c1[0], c2[1]]
+    poly << [c1[0], c1[1]]
+    [poly]
+  end
+
+  def as_featurecollection
+    return [] unless @valid
+    {
+      'type' => 'FeatureCollection',
+      'features' => [
+        {
+          'type' => 'Feature',
+          'properties' => {},
+          'geometry' => {
+            'type' => @type,
+            'coordinates' => @coords
+          }
+        }
+      ]
+    }
+  end
+
+end

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -74,17 +74,14 @@ class IiifPresentationV3
 
   def manifest_navplace
     authoritative_metadata = @parent_object&.authoritative_json
-    if 'ils' == authoritative_metadata&.[]('source')
-      geo = Geojson.new(
-        authoritative_metadata['coordinateNorth'],
-        authoritative_metadata['coordinateEast'],
-        authoritative_metadata['coordinateSouth'],
-        authoritative_metadata['coordinateWest']
-      )
-      if geo.valid
-        @manifest['navPlace'] = geo.as_featurecollection
-      end
-    end
+    return unless 'ils' == authoritative_metadata&.[]('source')
+    geo = Geojson.new(
+      authoritative_metadata['coordinateNorth'],
+      authoritative_metadata['coordinateEast'],
+      authoritative_metadata['coordinateSouth'],
+      authoritative_metadata['coordinateWest']
+    )
+    @manifest['navPlace'] = geo.as_featurecollection if geo.valid
   end
 
   def required_statement

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -43,7 +43,7 @@ class IiifPresentationV3
   def manifest
     return @manifest if @manifest
     @manifest = {}
-    @manifest["@context"] = ["http://iiif.io/api/search/1/context.json", "http://iiif.io/api/presentation/3/context.json"]
+    @manifest["@context"] = %w[http://iiif.io/api/search/1/context.json http://iiif.io/api/extension/navplace/context.json http://iiif.io/api/presentation/3/context.json]
     @manifest['id'] = File.join((ENV['IIIF_MANIFESTS_BASE_URL']).to_s, oid.to_s)
     @manifest['type'] = "Manifest"
     manifest_descriptive_properties
@@ -56,6 +56,7 @@ class IiifPresentationV3
       @manifest["service"] ||= []
       @manifest["service"] << search_service
     end
+    manifest_navplace
     @manifest
   end
   # rubocop:enable Metrics/AbcSize
@@ -69,6 +70,21 @@ class IiifPresentationV3
     @manifest["rendering"] = rendering
     @manifest["seeAlso"] = see_also
     @manifest["metadata"] = metadata
+  end
+
+  def manifest_navplace
+    authoritative_metadata = @parent_object&.authoritative_json
+    if 'ils' == authoritative_metadata&.[]('source')
+      geo = Geojson.new(
+        authoritative_metadata['coordinateNorth'],
+        authoritative_metadata['coordinateEast'],
+        authoritative_metadata['coordinateSouth'],
+        authoritative_metadata['coordinateWest']
+      )
+      if geo.valid
+        @manifest['navPlace'] = geo.as_featurecollection
+      end
+    end
   end
 
   def required_statement

--- a/spec/models/geojson_spec.rb
+++ b/spec/models/geojson_spec.rb
@@ -3,64 +3,63 @@
 require 'rails_helper'
 
 RSpec.describe Geojson do
-
   describe "Initializing Geojson " do
     it "fails with null data in first point" do
-      g = Geojson.new(nil, nil, 1, 2)
+      g = described_class.new(nil, nil, 1, 2)
       expect(g.valid).to be_falsey
     end
 
     it "fails with string data in first point" do
-      g = Geojson.new("foo", "bar", 1, 2)
+      g = described_class.new("foo", "bar", 1, 2)
       expect(g.valid).to be_falsey
     end
 
     it "fails with high latitude value in first point" do
-      g = Geojson.new(91, 1, 1, 2)
+      g = described_class.new(91, 1, 1, 2)
       expect(g.valid).to be_falsey
     end
 
     it "fails with low latitude value in first point" do
-      g = Geojson.new(-90.001, 1, 1, 2)
+      g = described_class.new(-90.001, 1, 1, 2)
       expect(g.valid).to be_falsey
     end
 
     it "fails with high longitude value in first point" do
-      g = Geojson.new(91, 1, 1, 2)
+      g = described_class.new(1, 180.1, 1, 2)
       expect(g.valid).to be_falsey
     end
 
     it "fails with low longitude value in first point" do
-      g = Geojson.new(-90.001, 1, 1, 2)
+      g = described_class.new(1, -180.1, 1, 2)
       expect(g.valid).to be_falsey
     end
 
     it "returns type Point with null data in second point" do
-      g = Geojson.new(1, 2, nil, nil)
+      g = described_class.new(1, 2, nil, nil)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'
     end
 
     it "returns type Point with string representation of coordinates" do
-      g = Geojson.new("N0550000", "E0260000", nil, nil)
+      g = described_class.new("N0550000", "E0260000", nil, nil)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'
     end
 
     it "returns type Point with string data in second point" do
-      g = Geojson.new( 1, 2, "foo", "bar")
+      g = described_class.new(1, 2, "foo", "bar")
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'
     end
 
     it "returns type Point when points match" do
-      g = Geojson.new( 1.0, 2.0, 1.0, 2.0)
+      g = described_class.new(1.0, 2.0, 1.0, 2.0)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'
     end
 
     it "returns type Polygon when points do not match" do
-      g = Geojson.new( 1.0, 2.0, 5.0, 8.0)
+      g = described_class.new(1.0, 2.0, 5.0, 8.0)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Polygon'
     end
@@ -68,8 +67,8 @@ RSpec.describe Geojson do
 
   describe "Geojson coordinates" do
     it "returns the correct coordinates for a Polygon" do
-      expected_coords = [[[7.1915,49.4037],[6.2819,49.4037],[6.2819,49.0756],[7.1915,49.0756],[7.1915,49.4037]]]
-      g = Geojson.new( 7.1915,49.4037, 6.2819, 49.0756)
+      expected_coords = [[[7.1915, 49.4037], [6.2819, 49.4037], [6.2819, 49.0756], [7.1915, 49.0756], [7.1915, 49.4037]]]
+      g = described_class.new(7.1915, 49.4037, 6.2819, 49.0756)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Polygon'
       expect(g.coords).to eq expected_coords
@@ -77,7 +76,7 @@ RSpec.describe Geojson do
 
     it "returns the correct coordinates for a Point" do
       expected_coords = [12.4663, 41.9031]
-      g = Geojson.new(12.4663, 41.9031, nil, nil)
+      g = described_class.new(12.4663, 41.9031, nil, nil)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'
       expect(g.coords).to eq expected_coords
@@ -85,11 +84,10 @@ RSpec.describe Geojson do
 
     it "returns correct coordinates with string representation of coordinates" do
       expected_coords = [55.0, 26.002]
-      g = Geojson.new("N0550000", "E0260020", nil, nil)
+      g = described_class.new("N0550000", "E0260020", nil, nil)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'
       expect(g.coords).to eq expected_coords
     end
   end
-
 end

--- a/spec/models/geojson_spec.rb
+++ b/spec/models/geojson_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Geojson do
       expect(g.valid).to be_truthy
     end
 
+    it "is valid with zero values" do
+      g = described_class.new(0, "0", 1, 2)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Polygon'
+    end
+
     it "returns type Point with null data in second point" do
       g = described_class.new(1, 2, nil, nil)
       expect(g.valid).to be_truthy

--- a/spec/models/geojson_spec.rb
+++ b/spec/models/geojson_spec.rb
@@ -34,6 +34,21 @@ RSpec.describe Geojson do
       expect(g.valid).to be_falsey
     end
 
+    it "fails with incorrect NSEW string value" do
+      g = described_class.new(1, "N18FASDF", 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "is fails with float-like string value" do
+      g = described_class.new(1, "12.34JUNK", 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "is valid with float-like string value" do
+      g = described_class.new(1, "12.34576", 1, 2)
+      expect(g.valid).to be_truthy
+    end
+
     it "returns type Point with null data in second point" do
       g = described_class.new(1, 2, nil, nil)
       expect(g.valid).to be_truthy

--- a/spec/models/geojson_spec.rb
+++ b/spec/models/geojson_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Geojson do
 
   describe "Geojson coordinates" do
     it "returns the correct coordinates for a Polygon" do
-      expected_coords = [[[7.1915, 49.4037], [6.2819, 49.4037], [6.2819, 49.0756], [7.1915, 49.0756], [7.1915, 49.4037]]]
+      expected_coords = [[[49.4037, 7.1915], [49.0756, 7.1915], [49.0756, 6.2819], [49.4037, 6.2819], [49.4037, 7.1915]]]
       g = described_class.new(7.1915, 49.4037, 6.2819, 49.0756)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Polygon'
@@ -96,7 +96,7 @@ RSpec.describe Geojson do
     end
 
     it "returns the correct coordinates for a Point" do
-      expected_coords = [12.4663, 41.9031]
+      expected_coords = [41.9031, 12.4663]
       g = described_class.new(12.4663, 41.9031, nil, nil)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'
@@ -104,7 +104,7 @@ RSpec.describe Geojson do
     end
 
     it "returns correct coordinates with string representation of coordinates" do
-      expected_coords = [55.0, 26.002]
+      expected_coords = [26.002, 55.0]
       g = described_class.new("N0550000", "E0260020", nil, nil)
       expect(g.valid).to be_truthy
       expect(g.type).to eq 'Point'

--- a/spec/models/geojson_spec.rb
+++ b/spec/models/geojson_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Geojson do
+
+  describe "Initializing Geojson " do
+    it "fails with null data in first point" do
+      g = Geojson.new(nil, nil, 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "fails with string data in first point" do
+      g = Geojson.new("foo", "bar", 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "fails with high latitude value in first point" do
+      g = Geojson.new(91, 1, 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "fails with low latitude value in first point" do
+      g = Geojson.new(-90.001, 1, 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "fails with high longitude value in first point" do
+      g = Geojson.new(91, 1, 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "fails with low longitude value in first point" do
+      g = Geojson.new(-90.001, 1, 1, 2)
+      expect(g.valid).to be_falsey
+    end
+
+    it "returns type Point with null data in second point" do
+      g = Geojson.new(1, 2, nil, nil)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Point'
+    end
+
+    it "returns type Point with string representation of coordinates" do
+      g = Geojson.new("N0550000", "E0260000", nil, nil)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Point'
+    end
+
+    it "returns type Point with string data in second point" do
+      g = Geojson.new( 1, 2, "foo", "bar")
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Point'
+    end
+
+    it "returns type Point when points match" do
+      g = Geojson.new( 1.0, 2.0, 1.0, 2.0)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Point'
+    end
+
+    it "returns type Polygon when points do not match" do
+      g = Geojson.new( 1.0, 2.0, 5.0, 8.0)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Polygon'
+    end
+  end
+
+  describe "Geojson coordinates" do
+    it "returns the correct coordinates for a Polygon" do
+      expected_coords = [[[7.1915,49.4037],[6.2819,49.4037],[6.2819,49.0756],[7.1915,49.0756],[7.1915,49.4037]]]
+      g = Geojson.new( 7.1915,49.4037, 6.2819, 49.0756)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Polygon'
+      expect(g.coords).to eq expected_coords
+    end
+
+    it "returns the correct coordinates for a Point" do
+      expected_coords = [12.4663, 41.9031]
+      g = Geojson.new(12.4663, 41.9031, nil, nil)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Point'
+      expect(g.coords).to eq expected_coords
+    end
+
+    it "returns correct coordinates with string representation of coordinates" do
+      expected_coords = [55.0, 26.002]
+      g = Geojson.new("N0550000", "E0260020", nil, nil)
+      expect(g.valid).to be_truthy
+      expect(g.type).to eq 'Point'
+      expect(g.coords).to eq expected_coords
+    end
+  end
+
+end

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -348,4 +348,39 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       end
     end
   end
+
+  describe 'IIIF navPlace ' do
+    let(:oid_geojson) { 15_234_629 }
+    let(:parent_object_geojson) { FactoryBot.create(:parent_object, oid: oid_geojson, viewing_direction: "left-to-right", display_layout: "individuals", bib: "12834515") }
+
+    before do
+      stub_metadata_cloud(15_234_629)
+      stub_ptiffs
+      stub_pdfs
+      parent_object_geojson
+      allow(parent_object_geojson).to receive(:authoritative_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ils", "V-#{oid_geojson}.json"))))
+    end
+
+    it 'is produced when an ILS item has coordinates' do
+      iiif_presentation_geojson = described_class.new(parent_object_geojson)
+      nav_place = iiif_presentation_geojson.manifest['navPlace']
+      expect(nav_place).not_to be_nil
+      expect(nav_place['type']).to eq 'FeatureCollection'
+      coords = nav_place['features'][0]['geometry']['coordinates']
+      expect(coords).to eq([[
+                             [90.0, 180.0],
+                             [-90.0,180.0],
+                             [-90.0,-180.0],
+                             [90.0,-180.0],
+                             [90.0,180.0]
+                           ]])
+    end
+
+    it 'is not produced for an ASpace item' do
+      iiif_presentation_no_geojson = described_class.new(aspace_parent_object)
+      nav_place = iiif_presentation_no_geojson.manifest['navPlace']
+      expect(nav_place).to be_nil
+    end
+
+  end
 end

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -367,13 +367,7 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       expect(nav_place).not_to be_nil
       expect(nav_place['type']).to eq 'FeatureCollection'
       coords = nav_place['features'][0]['geometry']['coordinates']
-      expect(coords).to eq([[
-                             [90.0, 180.0],
-                             [-90.0, 180.0],
-                             [-90.0, -180.0],
-                             [90.0, -180.0],
-                             [90.0, 180.0]
-                           ]])
+      expect(coords).to eq([[[180.0, 90.0], [-180.0, 90.0], [-180.0, -90.0], [180.0, -90.0], [180.0, 90.0]]])
     end
 
     it 'is not produced for an ASpace item' do

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -369,10 +369,10 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       coords = nav_place['features'][0]['geometry']['coordinates']
       expect(coords).to eq([[
                              [90.0, 180.0],
-                             [-90.0,180.0],
-                             [-90.0,-180.0],
-                             [90.0,-180.0],
-                             [90.0,180.0]
+                             [-90.0, 180.0],
+                             [-90.0, -180.0],
+                             [90.0, -180.0],
+                             [90.0, 180.0]
                            ]])
     end
 
@@ -381,6 +381,5 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       nav_place = iiif_presentation_no_geojson.manifest['navPlace']
       expect(nav_place).to be_nil
     end
-
   end
 end


### PR DESCRIPTION
Add support for `navPlace` in IIIF Manifests.  Create transformer to produce GeoJSON from N/S/E/W coordinate data in the ILS.