### PR TITLE
Change name of "Sync from Preservica" batch job to "Resync with Preservica"

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -170,7 +170,7 @@ class ParentObjectsController < ApplicationController
       authorize!(:update, @parent_object)
       @batch_process = BatchProcess.new(user: current_user,
                                         oid: @parent_object.oid,
-                                        batch_action: 'sync from preservica',
+                                        batch_action: 'resync with preservica',
                                         csv: CSV.generate do |csv|
                                                csv << ['oid']
                                                csv << [@parent_object.oid.to_s]

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -26,7 +26,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # LISTS AVAILABLE BATCH ACTIONS
   def self.batch_actions
     ['create parent objects', 'update parent objects', 'delete parent objects', 'delete child objects', 'export all parent objects by admin set',
-     'export child oids', 'reassociate child oids', 'recreate child oid ptiffs', 'update fulltext status', 'sync from preservica']
+     'export child oids', 'reassociate child oids', 'recreate child oid ptiffs', 'update fulltext status', 'resync with preservica']
   end
 
   # LOGS BATCH PROCESSING MESSAGES AND SETS STATUSES
@@ -157,7 +157,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         RecreateChildOidPtiffsJob.perform_later(self)
       when 'update fulltext status'
         UpdateFulltextStatusJob.perform_later(self)
-      when 'sync from preservica'
+      when 'resync with preservica'
         SyncFromPreservicaJob.perform_later(self)
       end
     elsif mets_xml.present?

--- a/spec/models/preservica/preservica_sequential_add_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_add_sync_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(co_first.ptiff_conversion_at.present?).to be_truthy
       expect(po_first.child_objects.count).to eq 3
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!

--- a/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(co_first.ptiff_conversion_at.present?).to be_truthy
       expect(po_first.child_objects.count).to eq 3
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!

--- a/spec/models/preservica/preservica_sequential_subtract_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_subtract_sync_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
       expect(po_first.child_objects.count).to eq 3
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!

--- a/spec/models/preservica/preservica_sequential_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_sync_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(co_first.ptiff_conversion_at.present?).to be_truthy
       expect(po_first.child_objects.count).to eq 4
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!

--- a/spec/models/preservica/preservica_sync_spec.rb
+++ b/spec/models/preservica/preservica_sync_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       co.delete
       expect(ChildObject.count).to be 2
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!
@@ -140,7 +140,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
       File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!
@@ -170,7 +170,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       co.sha512_checksum = "123"
       co.save
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!
@@ -202,7 +202,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
       File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync_invalid
         sync_batch_process.save!
@@ -216,7 +216,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('brbl'), redirect_to: "https://collections.library.yale.edu/catalog/123")
       parent_object.save
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync_invalid
         sync_batch_process.save!
@@ -230,7 +230,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('brbl'))
       parent_object.save
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync_invalid
         sync_batch_process.save!
@@ -244,7 +244,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('brbl'), preservica_uri: "/")
       parent_object.save
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync_invalid
         sync_batch_process.save!
@@ -258,7 +258,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('brbl'), preservica_uri: "/", digital_object_source: "Preservica")
       parent_object.save
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync_invalid
         sync_batch_process.save!
@@ -272,7 +272,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('sml'), preservica_uri: "/", digital_object_source: "Preservica", preservica_representation_name: "Preservation-1")
       parent_object.save
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync_invalid
         sync_batch_process.save!
@@ -293,7 +293,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('brbl'), preservica_uri: "/", digital_object_source: "Preservica", preservica_representation_name: "Preservation-1")
       parent_object.save
 
-      sync_batch_process = BatchProcess.new(batch_action: 'sync from preservica', user: user)
+      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do
         sync_batch_process.file = preservica_sync_invalid
         sync_batch_process.save!


### PR DESCRIPTION
## Summary
Change name of "Sync from Preservica" batch job to "Resync with Preservica".

## Related Ticket
[2078](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2078)

## Screenshot
![Screen Shot 2022-05-17 at 3 39 19 PM](https://user-images.githubusercontent.com/39319859/168928204-2f945559-f888-4128-a654-f795e71d4af6.JPG)

