### PR TITLE
Refresh preservica token when it is close to expiration

### DIFF
--- a/app/lib/preservica_client.rb
+++ b/app/lib/preservica_client.rb
@@ -6,6 +6,12 @@
 #
 # rubocop:disable Metrics/ClassLength
 class PreservicaClient
+  # refresh token when there is TOKEN_EXPIRATION_OFFSET remaining on the token
+  TOKEN_EXPIRATION_OFFSET = 5.minutes
+
+  # login on refresh for now, due to Preservica bug with refresh tokens
+  LOGIN_ON_REFRESH = true
+
   def initialize(args)
     @host = args[:base_url] || "https://#{ENV['PRESERVICA_HOST']}"
     if args[:admin_set_key]
@@ -25,8 +31,8 @@ class PreservicaClient
       request.set_form_data('username' => @username, 'password' => @password)
       response = http.request request # Net::HTTPResponse object
       raise StandardError, 'Unable to login' unless response.is_a? Net::HTTPSuccess
-
       @login_info = JSON.parse(response.body)
+      @refresh_by = Time.zone.now + @login_info['validFor'].to_i.minutes
       class << @login_info
         define_method(:inspect, proc { "Login Info" })
       end
@@ -34,13 +40,27 @@ class PreservicaClient
   end
 
   def refresh
-    authenticated_post URI("#{@host}/api/accesstoken/refresh") do |http, request|
-      request.set_form_data('refreshToken' => @login_info['refresh-token'])
-      @login_info = http.request request
-      class << @login_info
-        define_method(:inspect, proc { "Login Info" })
+    if LOGIN_ON_REFRESH
+      login
+    else
+      authenticated_post URI("#{@host}/api/accesstoken/refresh") do |http, request|
+        request.set_form_data('refreshToken' => @login_info['refresh-token'], "includeUserDetails" => "true")
+        response = http.request request
+        if response.is_a? Net::HTTPSuccess
+          @login_info = JSON.parse(response.body)
+          @refresh_by = Time.zone.now + @login_info['validFor'].to_i.minutes
+          class << @login_info
+            define_method(:inspect, proc { "Login Info" })
+          end
+        else
+          login
+        end
       end
     end
+  end
+
+  def check_refresh
+    refresh if Time.zone.now > @refresh_by - TOKEN_EXPIRATION_OFFSET
   end
 
   def content_structural_object_details(id)
@@ -121,6 +141,7 @@ class PreservicaClient
   end
 
   def authenticated_get(uri)
+    check_refresh
     Net::HTTP.start(uri.host, uri.port,
                     use_ssl: uri.scheme == 'https',
                     verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|

--- a/spec/models/preservica/preservica_token_refresh_spec.rb
+++ b/spec/models/preservica/preservica_token_refresh_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Preservica::PreservicaObject, type: :model do
+  around do |example|
+    preservica_host = ENV['PRESERVICA_HOST']
+    preservica_creds = ENV['PRESERVICA_CREDENTIALS']
+    ENV['PRESERVICA_HOST'] = "testpreservica"
+    ENV['PRESERVICA_CREDENTIALS'] = '{"brbl": {"username":"xxxxx", "password":"xxxxx"}}'
+    example.run
+    ENV['PRESERVICA_HOST'] = preservica_host
+    ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
+  end
+
+  before do
+    stub_preservica_login
+    stub_request(:get, "https://testpreservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c4/children").to_return(
+      status: 200, body: File.open(File.join(fixture_path, "preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c4/children.xml"))
+    )
+  end
+
+  context "when there token has expired" do
+    before do
+      Timecop.freeze(Time.zone.today)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "refresh the token" do
+      preservica_client = PreservicaClient.new(admin_set_key: "brbl")
+      preservica_client.login
+      expect(preservica_client).to receive(:refresh).once
+      now = Time.zone.today
+      ActiveJob::Scheduler.start
+      new_time = now + 15.minutes
+      Timecop.travel(new_time)
+      preservica_client.structural_object_children("7fe35e8c-c21a-444a-a2e2-e3c926b519c4")
+    end
+  end
+end

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -229,8 +229,8 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
 
     before do
       stub_preservica_aspace_single
-      stub_request(:post, "https://testpreservica/api/accesstoken/login").to_return(status: 200, body: '{"token":"test"}')
-      stub_request(:post, "https://testpreservica/api/accesstoken/refresh").to_return(status: 200, body: '{"token":"test"}')
+      stub_request(:post, "https://testpreservica/api/accesstoken/login").to_return(status: 200, body: '{"token":"test", "validFor": 15}')
+      stub_request(:post, "https://testpreservica/api/accesstoken/refresh").to_return(status: 200, body: '{"token":"test", "validFor": 15}')
       fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children
                     preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations
                     preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Access-2

--- a/spec/support/stub_requests_helper.rb
+++ b/spec/support/stub_requests_helper.rb
@@ -60,8 +60,8 @@ module StubRequestHelper
   end
 
   def stub_preservica_login
-    stub_request(:post, "https://testpreservica/api/accesstoken/login").to_return(status: 200, body: '{"token":"test"}')
-    stub_request(:post, "https://testpreservica/api/accesstoken/refresh").to_return(status: 200, body: '{"token":"test"}')
+    stub_request(:post, "https://testpreservica/api/accesstoken/login").to_return(status: 200, body: '{"token":"test", "validFor":15}')
+    stub_request(:post, "https://testpreservica/api/accesstoken/refresh").to_return(status: 200, body: '{"token":"test", "validFor":15}')
   end
 
   # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Refreshes preservica token when it is close to expiration.
For now, re-login on refresh instead of using the refresh api call because of a bug in Preservica