### PR TITLE
Adds navDate to manifest

### DIFF
--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -56,6 +56,7 @@ class IiifPresentationV3
       @manifest["service"] ||= []
       @manifest["service"] << search_service
     end
+    manifest_navdate
     manifest_navplace
     @manifest
   end
@@ -71,6 +72,20 @@ class IiifPresentationV3
     @manifest["seeAlso"] = see_also
     @manifest["metadata"] = metadata
   end
+
+  # rubocop:disable Rails/TimeZone
+  def manifest_navdate
+    date = @parent_object.authoritative_json['dateStructured'] if @parent_object&.authoritative_json
+    if date.nil?
+      @manifest['navDate'] = nil
+    elsif date&.first&.include?('/')
+      first_year = date.first.split('/').first
+      @manifest['navDate'] = DateTime.new(first_year.to_i)
+    else
+      @manifest['navDate'] = DateTime.new(date.first.to_i)
+    end
+  end
+  # rubocop:enable Rails/TimeZone
 
   def manifest_navplace
     authoritative_metadata = @parent_object&.authoritative_json

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -75,9 +75,8 @@ class IiifPresentationV3
 
   def manifest_navdate
     date = @parent_object.authoritative_json['dateStructured'] if @parent_object&.authoritative_json
-    if date.nil?
-      @manifest['navDate'] = nil
-    elsif date&.first&.include?('/')
+    return unless date
+    if date&.first&.include?('/')
       first_year = date.first.split('/').first
       @manifest['navDate'] = DateTime.new(first_year.to_i).utc.iso8601
     else

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -73,19 +73,17 @@ class IiifPresentationV3
     @manifest["metadata"] = metadata
   end
 
-  # rubocop:disable Rails/TimeZone
   def manifest_navdate
     date = @parent_object.authoritative_json['dateStructured'] if @parent_object&.authoritative_json
     if date.nil?
       @manifest['navDate'] = nil
     elsif date&.first&.include?('/')
       first_year = date.first.split('/').first
-      @manifest['navDate'] = DateTime.new(first_year.to_i)
+      @manifest['navDate'] = DateTime.new(first_year.to_i).utc.iso8601
     else
-      @manifest['navDate'] = DateTime.new(date.first.to_i)
+      @manifest['navDate'] = DateTime.new(date.first.to_i).utc.iso8601
     end
   end
-  # rubocop:enable Rails/TimeZone
 
   def manifest_navplace
     authoritative_metadata = @parent_object&.authoritative_json

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -376,4 +376,39 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       expect(nav_place).to be_nil
     end
   end
+
+  describe 'IIIF navDate ' do
+    let(:single_date_oid) { oid }
+    let(:parent_object_single_date) { parent_object }
+    let(:split_date_oid) { 16_685_691 }
+    let(:parent_object_split_date) { FactoryBot.create(:parent_object, oid: split_date_oid) }
+    let(:empty_date_oid) { oid_no_labels }
+    let(:parent_object_empty_date) { parent_object_no_labels }
+
+    before do
+      stub_metadata_cloud(single_date_oid)
+      stub_metadata_cloud(split_date_oid)
+      parent_object_single_date
+      parent_object_split_date
+      parent_object_empty_date
+      allow(parent_object_single_date).to receive(:authoritative_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ladybird", "#{single_date_oid}.json"))))
+      allow(parent_object_split_date).to receive(:authoritative_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ladybird", "#{split_date_oid}.json"))))
+      allow(parent_object_empty_date).to receive(:authoritative_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ladybird", "#{empty_date_oid}.json"))))
+    end
+
+    it 'has navDate in the manifest for a single date' do
+      iiif_presentation_single_date = described_class.new(parent_object_single_date)
+      expect(iiif_presentation_single_date.manifest['navDate']).to eq '1883-01-01T00:00:00Z'
+    end
+
+    it 'has navDate in the manifest for a split date' do
+      iiif_presentation_split_date = described_class.new(parent_object_split_date)
+      expect(iiif_presentation_split_date.manifest['navDate']).to eq '1914-01-01T00:00:00Z'
+    end
+
+    it 'does not have navDate when empty date' do
+      iiif_presentation_empty_date = described_class.new(parent_object_empty_date)
+      expect(iiif_presentation_empty_date.manifest['navDate']).to be_nil
+    end
+  end
 end

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -408,7 +408,7 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
 
     it 'does not have navDate when empty date' do
       iiif_presentation_empty_date = described_class.new(parent_object_empty_date)
-      expect(iiif_presentation_empty_date.manifest['navDate']).to be_nil
+      expect(iiif_presentation_empty_date.manifest.key?('navDate')).to eq false
     end
   end
 end


### PR DESCRIPTION
# Summary
Adds a navDate to the manifest when value is present in dateStructured

# Related Ticket
[#2086](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2086)