### PR TITLE
Force update of parent during preservica sync

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -124,6 +124,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # Note - the upsert_all method skips ActiveRecord callbacks, and is entirely
   # database driven. This also makes object creation much faster.
   # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength
   def create_child_records
     if from_mets
       upsert_child_objects(array_of_child_hashes_from_mets)
@@ -134,6 +135,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
         valid_child_hashes = validate_child_hashes(child_hashes)
         upsert_child_objects(valid_child_hashes)
         self.last_preservica_update = Time.current
+        self.metadata_update = true
+        setup_metadata_job
         save!
       end
     else
@@ -145,6 +148,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.child_object_count = child_objects.size
   end
   # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable Metrics/LineLength
   def validate_child_hashes(child_hashes)

--- a/spec/models/preservica/preservica_sequential_add_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_add_sync_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     changing_fixtures.each do |fixture|
       stub_request(:get, "https://test#{fixture}").to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
-      ).times(2).then.to_return(
+      ).times(3).then.to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}_add_sync.xml"))
       )
     end

--- a/spec/models/preservica/preservica_sync_spec.rb
+++ b/spec/models/preservica/preservica_sync_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!
       end.to change { ChildObject.count }.from(2).to(3)
+      expect(po_first.iiif_manifest['items'].count).to eq 3
       expect(File.exist?("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif")).to be true
       expect(File.exist?("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif")).to be true
       expect(File.exist?("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif")).to be true

--- a/spec/support/stub_requests_helper.rb
+++ b/spec/support/stub_requests_helper.rb
@@ -96,7 +96,7 @@ module StubRequestHelper
     changing_fixtures.each do |fixture|
       stub_request(:get, "https://test#{fixture}").to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
-      ).times(2).then.to_return(
+      ).times(3).then.to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}_new.xml"))
       )
     end


### PR DESCRIPTION
# Summary
During Preservica sync manifest was not regenerated.  This MR ensures a metadata update is triggered as part of the batch process.

# Related Ticket
[#2105](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2105)
