### PR TITLE
Remove redundant setup metadata job

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -139,7 +139,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
           upsert_child_objects(valid_child_hashes)
           self.last_preservica_update = Time.current
           self.metadata_update = true
-          setup_metadata_job
           save!
         end
       end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -214,6 +214,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       co.preservica_content_object_uri = value[:content_uri]
       co.preservica_generation_uri = value[:generation_uri]
       co.preservica_bitstream_uri = value[:bitstream_uri]
+      replace_preservica_tif(co)
       co.save
     end
     # create child records for any new items in preservica
@@ -223,6 +224,12 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def found_in_preservica(local_preservica_content_object_uri, preservica_children_hash)
     preservica_children_hash.any? do |_, value|
       value[:content_uri] == local_preservica_content_object_uri
+    end
+  end
+
+  def replace_preservica_tif(co)
+    PreservicaImageService.new(preservica_uri, admin_set.key).image_list(preservica_representation_type).map.with_index(1) do |child_hash, _index|
+      preservica_copy_to_access(child_hash, co.oid) if co.preservica_content_object_uri == child_hash[:preservica_content_object_uri]
     end
   end
 

--- a/spec/models/preservica/preservica_sequential_add_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_add_sync_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     changing_fixtures.each do |fixture|
       stub_request(:get, "https://test#{fixture}").to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
-      ).times(3).then.to_return(
+      ).times(2).then.to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}_add_sync.xml"))
       )
     end
@@ -121,10 +121,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!
       end.to change { ChildObject.count }.from(3).to(4)
-      # TODO: it should not create all new ones, only one new one
-      expect(File.exist?("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif")).to be true
-      expect(File.exist?("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif")).to be true
-      expect(File.exist?("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif")).to be true
       expect(File.exist?("spec/fixtures/images/access_masters/00/07/20/00/00/00/200000007.tif")).to be true
       co_first = po_first.child_objects.first
       expect(co_first.order).to eq 1

--- a/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
@@ -11,9 +11,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   let(:first_tif) { "spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif" }
   let(:second_tif) { "spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif" }
   let(:third_tif) { "spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif" }
-  let(:fourth_tif) { "spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif" }
-  let(:fifth_tif) { "spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif" }
-  let(:sixth_tif) { "spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif" }
 
   around do |example|
     preservica_host = ENV['PRESERVICA_HOST']
@@ -49,17 +46,11 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       File.delete(first_tif) if File.exist?(first_tif)
       File.delete(second_tif) if File.exist?(second_tif)
       File.delete(third_tif) if File.exist?(third_tif)
-      File.delete(fourth_tif) if File.exist?(fourth_tif)
-      File.delete(fifth_tif) if File.exist?(fifth_tif)
-      File.delete(sixth_tif) if File.exist?(sixth_tif)
 
       allow(S3Service).to receive(:s3_exists?).and_return(false)
       expect(File.exist?(first_tif)).to be false
       expect(File.exist?(second_tif)).to be false
       expect(File.exist?(third_tif)).to be false
-      expect(File.exist?(fourth_tif)).to be false
-      expect(File.exist?(fifth_tif)).to be false
-      expect(File.exist?(sixth_tif)).to be false
       expect do
         batch_process.file = preservica_parent_with_children
         batch_process.save
@@ -82,21 +73,19 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         sync_batch_process.save!
       end.not_to change { ChildObject.count }
       # downloads new tif to pairtree
-      expect(File.exist?(fourth_tif)).to be true
-      expect(File.exist?(fifth_tif)).to be true
-      expect(File.exist?(sixth_tif)).to be true
+      expect(po_first.iiif_manifest['items'].count).to eq 3
+      expect(po_first.iiif_manifest['items'][0]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000001"
+      expect(po_first.iiif_manifest['items'][1]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000002"
+      expect(po_first.iiif_manifest['items'][2]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000003"
 
       po_first = ParentObject.first
       co_first = po_first.child_objects.first
       expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1_new"
       expect(co_first.preservica_bitstream_uri).to eq "/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"
-
+      # get it to stop creating ptifs when it doesn't need to
       File.delete(first_tif) if File.exist?(first_tif)
       File.delete(second_tif) if File.exist?(second_tif)
       File.delete(third_tif) if File.exist?(third_tif)
-      File.delete(fourth_tif) if File.exist?(fourth_tif)
-      File.delete(fifth_tif) if File.exist?(fifth_tif)
-      File.delete(sixth_tif) if File.exist?(sixth_tif)
     end
   end
 end

--- a/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       co_first = po_first.child_objects.first
       expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1_new"
       expect(co_first.preservica_bitstream_uri).to eq "/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"
-      # get it to stop creating ptifs when it doesn't need to
       File.delete(first_tif) if File.exist?(first_tif)
       File.delete(second_tif) if File.exist?(second_tif)
       File.delete(third_tif) if File.exist?(third_tif)

--- a/spec/models/preservica/preservica_sync_spec.rb
+++ b/spec/models/preservica/preservica_sync_spec.rb
@@ -113,8 +113,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(po_first.iiif_manifest['items'][0]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000001"
       expect(po_first.iiif_manifest['items'][1]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000002"
       expect(po_first.iiif_manifest['items'][2]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000006"
-      expect(File.exist?("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif")).to be true
-      expect(File.exist?("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif")).to be true
       expect(File.exist?("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif")).to be true
       File.delete("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif") if File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")
       File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")

--- a/spec/models/preservica/preservica_sync_spec.rb
+++ b/spec/models/preservica/preservica_sync_spec.rb
@@ -100,9 +100,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")).to be true
       expect(File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")).to be true
       expect(co_first.ptiff_conversion_at.present?).to be_truthy
-      File.delete("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif") if File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")
-      File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
-      File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
       co = ChildObject.last
       co.delete
       expect(ChildObject.count).to be 2
@@ -113,9 +110,15 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         sync_batch_process.save!
       end.to change { ChildObject.count }.from(2).to(3)
       expect(po_first.iiif_manifest['items'].count).to eq 3
+      expect(po_first.iiif_manifest['items'][0]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000001"
+      expect(po_first.iiif_manifest['items'][1]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000002"
+      expect(po_first.iiif_manifest['items'][2]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000006"
       expect(File.exist?("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif")).to be true
       expect(File.exist?("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif")).to be true
       expect(File.exist?("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif")).to be true
+      File.delete("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif") if File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")
+      File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
+      File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
       File.delete("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif") if File.exist?("spec/fixtures/images/access_masters/00/04/20/00/00/00/200000004.tif")
       File.delete("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif") if File.exist?("spec/fixtures/images/access_masters/00/05/20/00/00/00/200000005.tif")
       File.delete("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif") if File.exist?("spec/fixtures/images/access_masters/00/06/20/00/00/00/200000006.tif")

--- a/spec/support/stub_requests_helper.rb
+++ b/spec/support/stub_requests_helper.rb
@@ -96,7 +96,7 @@ module StubRequestHelper
     changing_fixtures.each do |fixture|
       stub_request(:get, "https://test#{fixture}").to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
-      ).times(3).then.to_return(
+      ).times(2).then.to_return(
         status: 200, body: File.open(File.join(fixture_path, "#{fixture}_new.xml"))
       )
     end


### PR DESCRIPTION
# Summary
Resolve resync from preservica not running after save setup metadata job.

# Related Ticket
[#2105](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2105)