### PR TITLE
Generate digital object json for private parents

### DIFF
--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -6,8 +6,9 @@ module DigitalObjectManagement
   def digital_object_json_available?
     return false unless child_object_count&.positive?
     return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
-    return false unless ['Public', 'Yale Community Only'].include? visibility
+    return false unless ['Public', 'Yale Community Only', 'Private'].include? visibility
     return false unless digital_object_title
+    return false if redirect_to.present?
     true
   end
 


### PR DESCRIPTION
Generate digital object JSON and pass to metadata cloud for Private parents.

Metadata cloud will create/update the digital object in AAY to be publish="false" for private parents.