### PR TITLE
Make parent private when deleted or unpublished from ASpace

### DIFF
--- a/app/lib/activity_stream_reader.rb
+++ b/app/lib/activity_stream_reader.rb
@@ -75,10 +75,10 @@ class ActivityStreamReader
   end
 
   ##
-  # It takes an item from the activity stream and returns either true or false depending on whether that object is an update
+  # It takes an item from the activity stream and returns either true or false depending on whether that object is an update or deleted
   def relevant?(item)
     # Don't process changes which occur after last_run_time
-    return false unless item["type"] == "Update" && (item['endTime'].to_datetime.after?(last_run_time) || item['endTime'].to_datetime == last_run_time)
+    return false unless (item["type"] == "Update" || item["type"] == "Delete") && (item['endTime'].to_datetime.after?(last_run_time) || item['endTime'].to_datetime == last_run_time)
     true
   end
 

--- a/spec/fixtures/metadata_cloud_aspace_not_found.json
+++ b/spec/fixtures/metadata_cloud_aspace_not_found.json
@@ -1,0 +1,4 @@
+{
+  "url": "http://metadata-api-test.library.yale.edu/metadatacloud/api/1.0.1/aspace/repositories/6/archival_objects/254450",
+  "ex": "Record is not found."
+}

--- a/spec/fixtures/metadata_cloud_aspace_restricted.json
+++ b/spec/fixtures/metadata_cloud_aspace_restricted.json
@@ -1,0 +1,4 @@
+{
+  "url": "http://metadata-api-test.library.yale.edu/metadatacloud/api/1.0.1/aspace/repositories/12/archival_objects/2004559",
+  "ex": "Unable to get aspace record repositories/12/archival_objects/2004559 , You have requested an unpublished object."
+}

--- a/spec/models/parent_object_aspace_sync_spec.rb
+++ b/spec/models/parent_object_aspace_sync_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  let(:aspace) { 3 }
+  let(:logger_mock) { instance_double("Rails.logger").as_null_object }
+
+  around do |example|
+    original_metadata_sample_bucket = ENV['SAMPLE_BUCKET']
+    ENV['SAMPLE_BUCKET'] = "yul-dc-development-samples"
+    original_path_ocr = ENV['OCR_DOWNLOAD_BUCKET']
+    ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
+    original_access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
+    ENV["ACCESS_MASTER_MOUNT"] = File.join("spec", "fixtures", "images", "access_masters")
+    example.run
+    ENV['SAMPLE_BUCKET'] = original_metadata_sample_bucket
+    ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
+    ENV["ACCESS_MASTER_MOUNT"] = original_access_master_mount
+  end
+
+  context "a newly created ParentObject with ArchiveSpace as authoritative_metadata_source" do
+    let(:parent_object) do
+      described_class.create(
+        oid: "2012036",
+        aspace_uri: "/repositories/11/archival_objects/555049",
+        bib: "6805375",
+        barcode: "39002091459793",
+        authoritative_metadata_source_id: aspace,
+        admin_set: FactoryBot.create(:admin_set),
+        visibility: "Public"
+      )
+    end
+    before do
+      stub_metadata_cloud("2012036", "ladybird")
+      stub_metadata_cloud("AS-2012036", "aspace")
+    end
+
+    around do |example|
+      original_vpn = ENV['VPN']
+      ENV['VPN'] = "true"
+      example.run
+      ENV['VPN'] = original_vpn
+    end
+
+    it "marks the parent private if aspace recode is restricted" do
+      stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/clearly_fake_version/aspace/repositories/11/archival_objects/555049")
+          .to_return(status: 400, body: File.open(File.join(fixture_path, "metadata_cloud_aspace_restricted.json")))
+      allow(MetadataSource).to receive(:metadata_cloud_version).and_return("clearly_fake_version")
+      expect(parent_object.visibility).to eq "Public"
+      parent_object.default_fetch
+      expect(parent_object.visibility).to eq "Private"
+    end
+
+    it "marks the parent private if aspace recode is deleted" do
+      stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/clearly_fake_version/aspace/repositories/11/archival_objects/555049")
+          .to_return(status: 400, body: File.open(File.join(fixture_path, "metadata_cloud_aspace_not_found.json")))
+      allow(MetadataSource).to receive(:metadata_cloud_version).and_return("clearly_fake_version")
+      expect(parent_object.visibility).to eq "Public"
+      parent_object.default_fetch
+      expect(parent_object.visibility).to eq "Private"
+    end
+  end
+end


### PR DESCRIPTION
## Summary 
Make parent private when deleted or unpublished from ASpace

## Related Ticket
[#2117](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2117)