### PR TITLE
Remove period (.) in message string match

### DIFF
--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -64,7 +64,7 @@ class MetadataSource < ApplicationRecord
   def check_response(full_response)
     raise MetadataSource::MetadataCloudVersionError if JSON.parse(full_response.body)["ex"].include?("Unable to find retriever")
     raise MetadataSource::MetadataCloudNotFoundError if JSON.parse(full_response.body)["ex"].include?("Record is not found.")
-    raise MetadataSource::MetadataCloudUnpublishedError if JSON.parse(full_response.body)["ex"].include?("You have requested an unpublished object.")
+    raise MetadataSource::MetadataCloudUnpublishedError if JSON.parse(full_response.body)["ex"].include?("You have requested an unpublished object")
   end
 
   def file_name(parent_object)

--- a/spec/fixtures/metadata_cloud_aspace_restricted.json
+++ b/spec/fixtures/metadata_cloud_aspace_restricted.json
@@ -1,4 +1,4 @@
 {
   "url": "http://metadata-api-test.library.yale.edu/metadatacloud/api/1.0.1/aspace/repositories/12/archival_objects/2004559",
-  "ex": "Unable to get aspace record repositories/12/archival_objects/2004559 , You have requested an unpublished object."
+  "ex": "Unable to get aspace record repositories/12/archival_objects/2004559 , You have requested an unpublished object"
 }


### PR DESCRIPTION
- Removes period in string matching for error message from metadata cloud.
- Updates fixture.