### PR TITLE
Force solr index when marked Private, only mark Aspace items private

### DIFF
--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -50,7 +50,7 @@ class MetadataSource < ApplicationRecord
       response_text
     when 400...500
       parent_object.processing_event("Metadata Cloud did not return json. Response was #{full_response.status.code} - #{full_response.body}", "failed")
-      check_response(full_response)
+      check_response(full_response) if metadata_cloud_name == 'aspace'
       false
     when 500...600
       parent_object.processing_event("Metadata Cloud did not return json. Response was #{full_response.status.code} - #{full_response.body}", "failed")

--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -63,8 +63,8 @@ class MetadataSource < ApplicationRecord
 
   def check_response(full_response)
     raise MetadataSource::MetadataCloudVersionError if JSON.parse(full_response.body)["ex"].include?("Unable to find retriever")
-    raise MetadataSource::MetadataCloudNotFoundError if JSON.parse(full_response.body)["ex"].include?("Record is not found.") && metadata_cloud_name == 'aspace'
-    raise MetadataSource::MetadataCloudUnpublishedError if JSON.parse(full_response.body)["ex"].include?("You have requested an unpublished object") && metadata_cloud_name == 'aspace'
+    raise MetadataSource::MetadataCloudNotFoundError if JSON.parse(full_response.body)["ex"].include?("Record is not found.")
+    raise MetadataSource::MetadataCloudUnpublishedError if JSON.parse(full_response.body)["ex"].include?("You have requested an unpublished object")
   end
 
   def file_name(parent_object)

--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -50,7 +50,7 @@ class MetadataSource < ApplicationRecord
       response_text
     when 400...500
       parent_object.processing_event("Metadata Cloud did not return json. Response was #{full_response.status.code} - #{full_response.body}", "failed")
-      check_response(full_response) if metadata_cloud_name == 'aspace'
+      check_response(full_response)
       false
     when 500...600
       parent_object.processing_event("Metadata Cloud did not return json. Response was #{full_response.status.code} - #{full_response.body}", "failed")
@@ -63,8 +63,8 @@ class MetadataSource < ApplicationRecord
 
   def check_response(full_response)
     raise MetadataSource::MetadataCloudVersionError if JSON.parse(full_response.body)["ex"].include?("Unable to find retriever")
-    raise MetadataSource::MetadataCloudNotFoundError if JSON.parse(full_response.body)["ex"].include?("Record is not found.")
-    raise MetadataSource::MetadataCloudUnpublishedError if JSON.parse(full_response.body)["ex"].include?("You have requested an unpublished object")
+    raise MetadataSource::MetadataCloudNotFoundError if JSON.parse(full_response.body)["ex"].include?("Record is not found.") && metadata_cloud_name == 'aspace'
+    raise MetadataSource::MetadataCloudUnpublishedError if JSON.parse(full_response.body)["ex"].include?("You have requested an unpublished object") && metadata_cloud_name == 'aspace'
   end
 
   def file_name(parent_object)

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -354,16 +354,12 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
                       begin
                         self.aspace_json = MetadataSource.find_by(metadata_cloud_name: "aspace").fetch_record(self)
                       rescue MetadataSource::MetadataCloudNotFoundError
-                        processing_event("Marking this parent as private because record is not found.", "metadata-fetched")
-                        self.visibility = "Private"
-                        save!
-                        solr_index
+                        processing_event("Marking #{oid} private because Archives Space record is not found.", "metadata-fetched")
+                        force_private
                         false
                       rescue MetadataSource::MetadataCloudUnpublishedError
-                        processing_event("Marking this parent as private because this record is unpublished.", "metadata-fetched")
-                        self.visibility = "Private"
-                        save!
-                        solr_index
+                        processing_event("Marking #{oid} private because Archives Space record is unpublished.", "metadata-fetched")
+                        force_private
                         false
                       end
                     end
@@ -375,6 +371,12 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     fetch_results
   end
   # rubocop:enable Metrics/MethodLength
+
+  def force_private
+    self.visibility = "Private"
+    save!
+    solr_index
+  end
 
   # Currently we run this job if the record is new and ladybird json wasn't passed in from create
   # OR if the authoritative metaadata source changes

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -357,11 +357,13 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
                         processing_event("Marking this parent as private because record is not found.", "metadata-fetched")
                         self.visibility = "Private"
                         save!
+                        solr_index
                         false
                       rescue MetadataSource::MetadataCloudUnpublishedError
                         processing_event("Marking this parent as private because this record is unpublished.", "metadata-fetched")
                         self.visibility = "Private"
                         save!
+                        solr_index
                         false
                       end
                     end

--- a/spec/models/parent_object_aspace_sync_spec.rb
+++ b/spec/models/parent_object_aspace_sync_spec.rb
@@ -43,19 +43,21 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       ENV['VPN'] = original_vpn
     end
 
-    it "marks the parent private if aspace recode is restricted" do
+    it "marks the parent private if aspace record is restricted" do
       stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/clearly_fake_version/aspace/repositories/11/archival_objects/555049")
           .to_return(status: 400, body: File.open(File.join(fixture_path, "metadata_cloud_aspace_restricted.json")))
       allow(MetadataSource).to receive(:metadata_cloud_version).and_return("clearly_fake_version")
+      expect(parent_object).to receive(:solr_index).once
       expect(parent_object.visibility).to eq "Public"
       parent_object.default_fetch
       expect(parent_object.visibility).to eq "Private"
     end
 
-    it "marks the parent private if aspace recode is deleted" do
+    it "marks the parent private if aspace record is deleted" do
       stub_request(:get, "https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/clearly_fake_version/aspace/repositories/11/archival_objects/555049")
           .to_return(status: 400, body: File.open(File.join(fixture_path, "metadata_cloud_aspace_not_found.json")))
       allow(MetadataSource).to receive(:metadata_cloud_version).and_return("clearly_fake_version")
+      expect(parent_object).to receive(:solr_index).once
       expect(parent_object.visibility).to eq "Public"
       parent_object.default_fetch
       expect(parent_object.visibility).to eq "Private"


### PR DESCRIPTION
- Fixes issue where unpublished or missing records are marked Private, but not removed from blacklight because they are not indexed.
- Updates logic so that only aspace items are marked private based on source response
