### PR TITLE
Adds last preservica update to child object

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -192,6 +192,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       child_hash[:oid] = co_oid
       child_hash[:parent_object_oid] = oid
       child_hash[:order] = index
+      child_hash[:last_preservica_update] = Time.current
       child_hash
     end
   end
@@ -227,6 +228,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       co.preservica_content_object_uri = value[:content_uri]
       co.preservica_generation_uri = value[:generation_uri]
       co.preservica_bitstream_uri = value[:bitstream_uri]
+      co.last_preservica_update = Time.current
       replace_preservica_tif(co)
       co.save
     end

--- a/app/views/child_objects/show.html.erb
+++ b/app/views/child_objects/show.html.erb
@@ -56,6 +56,11 @@
 </p>
 
 <p>
+  <strong>Last Update from Preservica:</strong>
+  <%= @child_object.last_preservica_update %>
+</p>
+
+<p>
   <strong>Full text:</strong>
   <%= @child_object.full_text ? "Yes" : "No" %>
 </p>

--- a/db/migrate/20220706214806_add_last_update_preservica_to_child_object.rb
+++ b/db/migrate/20220706214806_add_last_update_preservica_to_child_object.rb
@@ -1,0 +1,5 @@
+class AddLastUpdatePreservicaToChildObject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :child_objects, :last_preservica_update, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_18_174221) do
+ActiveRecord::Schema.define(version: 2022_07_06_214806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2022_05_18_174221) do
     t.text "preservica_generation_uri"
     t.text "preservica_bitstream_uri"
     t.string "sha512_checksum"
+    t.datetime "last_preservica_update"
     t.index ["caption"], name: "index_child_objects_on_caption"
     t.index ["label"], name: "index_child_objects_on_label"
     t.index ["oid"], name: "index_child_objects_on_oid", unique: true

--- a/spec/models/preservica/preservica_sequential_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_sync_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(co_first.order).to eq 1
       expect(co_first.preservica_content_object_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486"
       expect(co_first.ptiff_conversion_at.present?).to be_truthy
+      expect(co_first.last_preservica_update).not_to be nil
       expect(po_first.child_objects.count).to eq 4
 
       sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)


### PR DESCRIPTION
# Summary
Adds timestamp to child object for preservica updates.

# Related Ticket 
[#2144](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2144)