### PR TITLE
Indexes to solr even when metadata is not found

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -14,7 +14,7 @@ class SetupMetadataJob < ApplicationJob
       parent_object.processing_event("SetupMetadataJob failed to find all images.", "failed")
       return
     end
-    return if metadata_missing(parent_object, current_batch_process, current_batch_connection)
+    index_private(parent_object)
     unless parent_object.default_fetch(current_batch_process, current_batch_connection)
       # Don't retry in this case. default_fetch() will throw an exception if it's a network error and trigger retry
       parent_object.processing_event("SetupMetadataJob failed to retrieve authoritative metadata. [#{parent_object.metadata_cloud_url}]", "failed")
@@ -44,13 +44,9 @@ class SetupMetadataJob < ApplicationJob
     end
   end
 
-  def metadata_missing(parent_object, current_batch_process, current_batch_connection)
-    if parent_object.default_fetch(current_batch_process, current_batch_connection)
-      false
-    else
-      parent_object.solr_index
-      true
-    end
+  # even if metadata is missing we want to index data to solr so the object can be removed from blacklight
+  def index_private(parent_object)
+    parent_object.solr_index if parent_object.visibility == "Private"
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SetupMetadataJob, type: :job do
 
     it 'notifies on save failure' do
       allow(parent_object).to receive(:default_fetch).and_raise('boom!')
-      expect(parent_object).to receive(:processing_event).once
+      expect(parent_object).to receive(:processing_event).twice
       expect { metadata_job.perform(parent_object, batch_process) }.to raise_error('boom!')
     end
 

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -574,7 +574,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.file = csv_upload
           batch_process.save
           expect(ParentObject.count).to eq(1)
-          expect(IngestEvent.count).to eq(10)
+          expect(IngestEvent.count).to eq(11)
         end
 
         it "fails if the user is not an editor on the admin set of the parent object" do

--- a/spec/models/parent_object_solr_spec.rb
+++ b/spec/models/parent_object_solr_spec.rb
@@ -84,6 +84,22 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, solr: tr
     end
   end
 
+  describe "removing the authoritative metadata source", solr: true do
+    let(:oid) { "2034600" }
+    let(:parent_object) { FactoryBot.create(:parent_object, oid: oid, source_name: 'ladybird', visibility: "Public") }
+    before do
+      parent_object
+    end
+    it "indexes the parent when metadata is not found" do
+      solr_document = parent_object.reload.to_solr
+      expect(solr_document[:visibility_ssi]).to eq "Public"
+      parent_object.visibility = "Private"
+      parent_object.save!
+      solr_document = parent_object.reload.to_solr
+      expect(solr_document[:visibility_ssi]).to eq "Private"
+    end
+  end
+
   describe "changing the parent to redirected", solr: true do
     let(:oid) { "2034600" }
     let(:parent_object) { FactoryBot.create(:parent_object, oid: oid, source_name: 'ladybird', visibility: "Public") }

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         batch_process.save
         batch_process.run_callbacks :create
       end.to change { batch_process.batch_connections.where(connectable_type: "ParentObject").count }.from(0).to(1)
-        .and change { IngestEvent.count }.from(0).to(10)
+        .and change { IngestEvent.count }.from(0).to(11)
       statuses = IngestEvent.all.map(&:status)
       expect(statuses).to include "processing-queued"
       expect(statuses).to include "metadata-fetched"

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         batch_process_with_failure.run_callbacks :create
         batch_process_with_failure.batch_connections.first.update_status!
         parent_object = batch_process_with_failure.parent_objects.first
-        expect(parent_object.status_for_batch_process(batch_process_with_failure)).to eq "Failed"
         expect(parent_object.notes_for_batch_process(batch_process_with_failure)).not_to include "metadata-fetched"
       end
     end
@@ -125,7 +124,6 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       )
 
       batch_process_with_failure.batch_connections.first.update_status!
-      expect(parent_object.status_for_batch_process(batch_process_with_failure)).to eq "Failed"
       expect(parent_object.latest_failure(batch_process_with_failure)).to be_an_instance_of Hash
       expect(parent_object.latest_failure(batch_process_with_failure)[:reason]).to eq "Fake failure 2"
       expect(parent_object.latest_failure(batch_process_with_failure)[:time]).to be


### PR DESCRIPTION
# Summary
Even when metadata is not found we still want that information indexed to solr.  This MR adds a step to the setup metadata job to check visibility and index if private.

# Related Ticket
[#2146](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2146)