### PR TITLE
Removes double parent in batch process detail for preservica resync

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -137,12 +137,10 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
         valid_child_hashes = validate_child_hashes(child_hashes)
         invalid_child_hashes = child_hashes - valid_child_hashes
         cleanup_child_artifacts(invalid_child_hashes)
-        unless valid_child_hashes.empty?
-          upsert_child_objects(valid_child_hashes)
-          self.last_preservica_update = Time.current
-          self.metadata_update = true
-          save!
-        end
+        upsert_child_objects(valid_child_hashes) unless valid_child_hashes.empty?
+        self.last_preservica_update = Time.current
+        self.metadata_update = true
+        save!
       end
     else
       return unless ladybird_json
@@ -232,9 +230,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       replace_preservica_tif(co)
       co.save
     end
-    # save changes to parent
-    self.metadata_update = true
-    save!
 
     # create child records for any new items in preservica
     create_child_records

--- a/spec/system/batch_process_preservica_spec.rb
+++ b/spec/system/batch_process_preservica_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       po_first = ParentObject.first
       visit "/batch_processes/#{sync_batch_process.id}/parent_objects/#{po_first.oid}"
       expect(page).not_to have_content('Pending').twice
-      expect(page).not_to have_content("#{po_first.oid}").twice
+      expect(page).not_to have_content(po_first.oid.to_s).twice
       co_first = po_first.child_objects.first
       expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1_new"
       expect(co_first.preservica_bitstream_uri).to eq "/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"

--- a/spec/system/batch_process_preservica_spec.rb
+++ b/spec/system/batch_process_preservica_spec.rb
@@ -89,6 +89,9 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       expect(po_first.iiif_manifest['items'][2]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000003"
 
       po_first = ParentObject.first
+      visit "/batch_processes/#{sync_batch_process.id}/parent_objects/#{po_first.oid}"
+      expect(page).not_to have_content('Pending').twice
+      expect(page).not_to have_content("#{po_first.oid}").twice
       co_first = po_first.child_objects.first
       expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1_new"
       expect(co_first.preservica_bitstream_uri).to eq "/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"


### PR DESCRIPTION
# Summary
An additional trigger was added and that caused two parents to appear in the batch process detail parent datatable for preservica resync process.  This MR changes the logic for the resync to remove that trigger and still complete the batch process.

# Related Ticket
[#2166](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2166)