### PR TITLE
Revert "Removes double parent in batch process detail for preservica resync"

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -136,10 +136,12 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
         valid_child_hashes = validate_child_hashes(child_hashes)
         invalid_child_hashes = child_hashes - valid_child_hashes
         cleanup_child_artifacts(invalid_child_hashes)
-        upsert_child_objects(valid_child_hashes) unless valid_child_hashes.empty?
-        self.last_preservica_update = Time.current
-        self.metadata_update = true
-        save!
+        unless valid_child_hashes.empty?
+          upsert_child_objects(valid_child_hashes)
+          self.last_preservica_update = Time.current
+          self.metadata_update = true
+          save!
+        end
       end
     else
       return unless ladybird_json
@@ -229,6 +231,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       replace_preservica_tif(co)
       co.save
     end
+    # save changes to parent
+    self.metadata_update = true
+    save!
 
     # create child records for any new items in preservica
     create_child_records

--- a/spec/system/batch_process_preservica_spec.rb
+++ b/spec/system/batch_process_preservica_spec.rb
@@ -89,9 +89,6 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       expect(po_first.iiif_manifest['items'][2]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000003"
 
       po_first = ParentObject.first
-      visit "/batch_processes/#{sync_batch_process.id}/parent_objects/#{po_first.oid}"
-      expect(page).not_to have_content('Pending').twice
-      expect(page).not_to have_content(po_first.oid.to_s).twice
       co_first = po_first.child_objects.first
       expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1_new"
       expect(co_first.preservica_bitstream_uri).to eq "/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"


### PR DESCRIPTION
Reverts yalelibrary/yul-dc-management#1049