### PR TITLE
Adds admin set to batch process table

### DIFF
--- a/app/datatables/batch_process_datatable.rb
+++ b/app/datatables/batch_process_datatable.rb
@@ -15,6 +15,7 @@ class BatchProcessDatatable < AjaxDatatablesRails::ActiveRecord
     # or in aliased_join_table.column_name format
     @view_columns ||= {
       process_id: { source: "BatchProcess.id", cond: :eq, searchable: true, orderable: true },
+      admin_set: { source: "BatchProcess.admin_set", cond: :start_with, searchable: true, orderable: true },
       user: { source: "User.uid", cond: :start_with, searchable: true, orderable: true },
       time: { source: "BatchProcess.created_at", cond: :like, orderable: true },
       size: { source: "BatchProcess.oid", searchable: false, orderable: false },
@@ -29,6 +30,7 @@ class BatchProcessDatatable < AjaxDatatablesRails::ActiveRecord
     records.map do |batch_process|
       {
         process_id: link_to(batch_process.id, batch_process_path(batch_process)),
+        admin_set: batch_process.admin_set,
         user: batch_process.user.uid,
         time: batch_process.created_at,
         size: batch_process.oids&.count,

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -313,7 +313,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
       end
       next unless child_object
 
-      sets << ', ' + AdminSet.find(child_object.parent_object.authoritative_metadata_source_id).key
+      sets << ', ' + child_object.parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -108,7 +108,7 @@ module CsvExportable
     sets = admin_set
     child_objects_array.each do |co|
       parent_title = lookup_parent_title(co, parent_title_hash)
-      sets << ', ' + AdminSet.find(co.parent_object.authoritative_metadata_source_id).key
+      sets << ', ' + co.parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save

--- a/app/models/concerns/deletable.rb
+++ b/app/models/concerns/deletable.rb
@@ -17,7 +17,7 @@ module Deletable
       next unless action == 'delete'
       parent_object = deletable_parent_object(oid, index)
       next unless parent_object
-      sets << ', ' + AdminSet.find(parent_object.authoritative_metadata_source_id).key
+      sets << ', ' + parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save
@@ -58,7 +58,7 @@ module Deletable
       next unless action == 'delete'
       child_object = deletable_child_object(oid, index)
       next unless child_object
-      sets << ', ' + AdminSet.find(child_object.parent_object.authoritative_metadata_source_id).key
+      sets << ', ' + child_object.parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -29,7 +29,7 @@ module Reassociatable
       po = load_parent(index, row["parent_oid"].to_i)
       next unless co.present? && po.present?
 
-      sets << ', ' + AdminSet.find(po.authoritative_metadata_source_id).key
+      sets << ', ' + po.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -13,9 +13,12 @@ module Reassociatable
     update_related_parent_objects(parents_needing_update, parent_destination_map)
   end
 
-  # rubocop:disable Metrics/AbcSize
   # finds which parents are needed to update
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def update_child_objects
+    self.admin_set = ''
+    sets = admin_set
     return unless batch_action == "reassociate child oids"
     parents_needing_update = []
 
@@ -25,6 +28,11 @@ module Reassociatable
       co = load_child(index, row["child_oid"].to_i)
       po = load_parent(index, row["parent_oid"].to_i)
       next unless co.present? && po.present?
+
+      sets << ', ' + AdminSet.find(po.authoritative_metadata_source_id).key
+      split_sets = sets.split(',').uniq.reject(&:blank?)
+      self.admin_set = split_sets.join(', ')
+      save
 
       attach_item(po)
       attach_item(co)
@@ -43,6 +51,7 @@ module Reassociatable
     [parents_needing_update, parent_destination_map]
   end
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   # verifies headers are included. child headers found in csv_exportable:90
   def check_headers(headers, row)

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -21,13 +21,21 @@ module Updatable
 
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def update_parent_objects
+    self.admin_set = ''
+    sets = admin_set
     return unless batch_action == "update parent objects"
     parsed_csv.each_with_index do |row, index|
       oid = row['oid'] unless ['oid'].nil?
       redirect = row['redirect_to'] unless ['redirect_to'].nil?
       parent_object = updatable_parent_object(oid, index)
       next unless parent_object
+      sets << ', ' + AdminSet.find(parent_object.authoritative_metadata_source_id).key
+      split_sets = sets.split(',').uniq.reject(&:blank?)
+      self.admin_set = split_sets.join(', ')
+      save
       next if redirect.present? && !validate_redirect(redirect)
       next unless check_for_children(redirect, parent_object)
 
@@ -44,6 +52,8 @@ module Updatable
   end
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   def remove_blanks(row, parent_object)
     blankable = %w[aspace_uri barcode bib digitization_note holding item project_identifier rights_statement redirect_to display_layout extent_of_digitization viewing_direction]

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -32,7 +32,7 @@ module Updatable
       redirect = row['redirect_to'] unless ['redirect_to'].nil?
       parent_object = updatable_parent_object(oid, index)
       next unless parent_object
-      sets << ', ' + AdminSet.find(parent_object.authoritative_metadata_source_id).key
+      sets << ', ' + parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save

--- a/app/views/batch_processes/index.html.erb
+++ b/app/views/batch_processes/index.html.erb
@@ -17,6 +17,7 @@
       <thead class='table-head'>
         <tr>
           <th scope='col'>Process ID</th>
+          <th scope='col'>Admin Set</th>
           <th scope='col'>User</th>
           <th scope='col'>Time</th>
           <th scope='col'>Size</th>

--- a/db/migrate/20220819214823_add_admin_set_to_batch_process.rb
+++ b/db/migrate/20220819214823_add_admin_set_to_batch_process.rb
@@ -1,0 +1,5 @@
+class AddAdminSetToBatchProcess < ActiveRecord::Migration[6.0]
+  def change
+    add_column :batch_processes, :admin_set, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_214806) do
+ActiveRecord::Schema.define(version: 2022_08_19_214823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_214806) do
     t.string "batch_status"
     t.string "batch_action", default: "create parent objects"
     t.string "output_csv"
+    t.string "admin_set"
     t.index ["oid"], name: "index_batch_processes_on_oid"
     t.index ["user_id"], name: "index_batch_processes_on_user_id"
   end

--- a/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
+++ b/spec/jobs/recreate_child_oid_ptiffs_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RecreateChildOidPtiffsJob, type: :job do
   end
   let(:user) { FactoryBot.create(:user) }
   let(:role) { FactoryBot.create(:role, name: editor) }
-  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:admin_set) { FactoryBot.create(:admin_set, id: 1) }
   let(:batch_process) { FactoryBot.create(:batch_process, user: user, batch_action: 'recreate child oid ptiffs') }
   let(:other_batch_process) { FactoryBot.create(:batch_process, user: user, batch_action: 'other recreate child oid ptiffs') }
   let(:metadata_source) { FactoryBot.create(:metadata_source) }

--- a/spec/jobs/update_fulltext_status_job_spec.rb
+++ b/spec/jobs/update_fulltext_status_job_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe UpdateFulltextStatusJob, type: :job, solr: true do
-  let(:parent_object) { FactoryBot.build(:parent_object, oid: '16797069') }
+  let(:admin_set) { FactoryBot.create(:admin_set, id: 1) }
+  let(:parent_object) { FactoryBot.build(:parent_object, oid: '16797069', admin_set: admin_set) }
 
   context 'with test active job queue' do
     def queue_adapter_for_test
@@ -22,7 +23,6 @@ RSpec.describe UpdateFulltextStatusJob, type: :job, solr: true do
   context 'batch process' do
     let(:user) { FactoryBot.create(:user) }
     let(:role) { FactoryBot.create(:role, name: editor) }
-    let(:admin_set) { FactoryBot.create(:admin_set) }
     let(:batch_process) { FactoryBot.create(:batch_process, user: user, batch_action: 'update fulltext status') }
     let(:metadata_source) { FactoryBot.create(:metadata_source) }
     let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_004_628, authoritative_metadata_source: metadata_source, admin_set_id: admin_set.id) }

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_admin_sets: true, undelayed: true do
   subject(:batch_process) { described_class.new }
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:admin_set) { FactoryBot.create(:admin_set, id: 1) }
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "shorter_fixture_ids.csv")) }
   let(:csv_upload_with_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "short_fixture_ids_with_source.csv")) }
   let(:delete_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "delete_parent_fixture_ids.csv")) }
@@ -416,6 +417,8 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
             batch_process.create_new_parent_csv
           end.to change { ParentObject.count }.from(0).to(1)
 
+          parent_object = ParentObject.first
+          parent_object.admin_set = admin_set
           delete_batch_process = described_class.new(batch_action: "delete parent objects", user_id: user.id)
           expect do
             delete_batch_process.file = delete_parent
@@ -438,6 +441,8 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
             batch_process.create_new_parent_csv
           end.to change { ChildObject.count }.from(0).to(2)
 
+          parent_object = ParentObject.first
+          parent_object.admin_set = admin_set
           delete_batch_process = described_class.new(batch_action: "delete child objects", user_id: user.id)
           expect do
             delete_batch_process.file = delete_child

--- a/spec/models/batch_process_update_parent_spec.rb
+++ b/spec/models/batch_process_update_parent_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
   subject(:batch_process) { described_class.new }
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:admin_set) { FactoryBot.create(:admin_set, id: 1) }
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "short_fixture_ids.csv")) }
   let(:csv_small) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "update_example.csv")) }
   let(:csv_missing) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "update_example_missing.csv")) }
@@ -60,6 +61,12 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(po_original.viewing_direction).to be_nil
       expect(po_original.visibility).to eq "Private"
 
+      pos = ParentObject.all
+      pos[0].admin_set = admin_set
+      pos[1].admin_set = admin_set
+      pos[2].admin_set = admin_set
+      pos[3].admin_set = admin_set
+      pos[4].admin_set = admin_set
       update_batch_process = described_class.new(batch_action: "update parent objects", user_id: user.id)
       expect do
         update_batch_process.file = csv_small
@@ -102,6 +109,12 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(po_original.rights_statement).to be_nil
       expect(po_original.viewing_direction).to be_nil
       expect(po_original.visibility).to eq "Private"
+      pos = ParentObject.all
+      pos[0].admin_set = admin_set
+      pos[1].admin_set = admin_set
+      pos[2].admin_set = admin_set
+      pos[3].admin_set = admin_set
+      pos[4].admin_set = admin_set
 
       update_batch_process = described_class.new(batch_action: "update parent objects", user_id: user.id)
       expect do
@@ -145,6 +158,12 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(po_original.rights_statement).to be_nil
       expect(po_original.viewing_direction).to be_nil
       expect(po_original.visibility).to eq "Private"
+      pos = ParentObject.all
+      pos[0].admin_set = admin_set
+      pos[1].admin_set = admin_set
+      pos[2].admin_set = admin_set
+      pos[3].admin_set = admin_set
+      pos[4].admin_set = admin_set
 
       update_batch_process = described_class.new(batch_action: "update parent objects", user_id: user.id)
       expect do
@@ -173,6 +192,12 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       batch_process.file = csv_upload
       batch_process.save
       batch_process.create_new_parent_csv
+      pos = ParentObject.all
+      pos[0].admin_set = admin_set
+      pos[1].admin_set = admin_set
+      pos[2].admin_set = admin_set
+      pos[3].admin_set = admin_set
+      pos[4].admin_set = admin_set
       update_batch_process = described_class.new(batch_action: "update parent objects", user_id: user.id)
       update_batch_process.file = csv_small
       update_batch_process.save

--- a/spec/system/batch_process_reassociation_redirect_spec.rb
+++ b/spec/system/batch_process_reassociation_redirect_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
   let(:batch_process) { described_class.new(batch_action: "reassociate child oids") }
   let(:user) { FactoryBot.create(:user) }
-  let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl', label: 'brbl') }
+  let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl', label: 'brbl', id: 1) }
   # parent object has two child objects
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
   let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2004550", admin_set_id: admin_set.id) }


### PR DESCRIPTION
# Summary
Batch processes will now track and display which admin sets are involved in the process.  

# Related Ticket
[#2174]()

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/186479058-7d976373-4060-4559-8204-5e7134fd98ed.png)

