### PR TITLE
Stubs PDF generation in Preservica tests

### DIFF
--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     user.add_role(:editor, admin_set)
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children

--- a/spec/models/preservica/preservica_import_pattern_two_spec.rb
+++ b/spec/models/preservica/preservica_import_pattern_two_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     user.add_role(:editor, admin_set)
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/structural-objects/2fe35e8c-c21a-444a-a2e2-e3c926b519c6/children

--- a/spec/models/preservica/preservica_import_spec.rb
+++ b/spec/models/preservica/preservica_import_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     user.add_role(:editor, admin_set)
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     user.add_role(:editor, admin_set)
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
   end

--- a/spec/models/preservica/preservica_sequential_add_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_add_sync_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   before do
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations

--- a/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_generation_bitstream_sync_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   before do
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     stub_preservica_fixtures_set_of_three_changing_generation

--- a/spec/models/preservica/preservica_sequential_subtract_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_subtract_sync_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   before do
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations

--- a/spec/models/preservica/preservica_sequential_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_sync_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   before do
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations

--- a/spec/models/preservica/preservica_sync_spec.rb
+++ b/spec/models/preservica/preservica_sync_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   before do
     login_as(:user)
     batch_process.user_id = user.id
+    stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children


### PR DESCRIPTION
Stub PDF generation in Preservica tests since PDF is not required by test suite.