### PR TITLE
Adds digitization funding source to parent object show and edit pages

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -220,7 +220,7 @@ class ParentObjectsController < ApplicationController
       cur_params = params.require(:parent_object).permit(:oid, :admin_set, :project_identifier, :bib, :holding, :item, :barcode, :aspace_uri, :last_ladybird_update, :last_voyager_update,
                                                          :last_aspace_update, :visibility, :last_id_update, :authoritative_metadata_source_id, :viewing_direction,
                                                          :display_layout, :representative_child_oid, :rights_statement, :extent_of_digitization,
-                                                         :digitization_note, :redirect_to, :preservica_uri, :digital_object_source, :preservica_representation_type)
+                                                         :digitization_note, :digitization_funding_source, :redirect_to, :preservica_uri, :digital_object_source, :preservica_representation_type)
       cur_params[:admin_set] = AdminSet.find_by(key: cur_params[:admin_set]) if cur_params[:admin_set]
       cur_params
     end

--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -37,6 +37,7 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
       visibility: { source: "ParentObject.visibility", cond: :string_eq, searchable: true, options: ["Public", "Yale Community Only", "Private"], orderable: true },
       extent_of_digitization: { source: "ParentObject.extent_of_digitization", cond: :string_eq, searchable: true, options: ["Completely digitized", "Partially digitized"], orderable: true },
       digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true },
+      digitization_funding_source: { source: "ParentObject.digitization_funding_source", cond: :like, searchable: true, orderable: true },
       project_identifier: { source: "ParentObject.project_identifier", searchable: true, orderable: true }
     }
   end
@@ -66,6 +67,7 @@ class ParentObjectDatatable < AjaxDatatablesRails::ActiveRecord
         visibility: parent_object.visibility,
         extent_of_digitization: parent_object.extent_of_digitization,
         digitization_note: parent_object.digitization_note,
+        digitization_funding_source: parent_object.digitization_funding_source,
         DT_RowId: parent_object.oid,
         project_identifier: parent_object.project_identifier
       }

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -123,6 +123,7 @@ module SolrIndexable
         description_tesim: json_to_index["description"],
         digital_ssim: json_to_index["digital"],
         digitization_note_tesi: generate_digitization_note(json_to_index["digitization_note"]),
+        digitization_funding_source_tesi: generate_digitization_funding_source(json_to_index["digitization_funding_source"]),
         edition_ssim: json_to_index["edition"],
         extent_ssim: json_to_index["extent"],
         extentOfDigitization_ssim: extent_of_digitization,
@@ -280,6 +281,10 @@ module SolrIndexable
 
   def generate_digitization_note(digitization_note)
     digitization_note.presence || self&.digitization_note || nil
+  end
+
+  def generate_digitization_funding_source(digitization_funding_source)
+    digitization_funding_source.presence || self&.digitization_funding_source || nil
   end
 
   # not ASpace records will use the repository value

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -31,6 +31,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   after_destroy :pdf_deletion
   after_destroy :digital_object_delete
   paginates_per 50
+  validates :digitization_funding_source, length: { maximum: 255 }
   # rubocop:disable Metrics/LineLength
   validates :redirect_to, format: { with: /\A((http|https):\/\/)?(collections-test.|collections-uat.|collections.)?library.yale.edu\/catalog\//, message: " in incorrect format. Please enter DCS url https://collections.library.yale.edu/catalog/123", allow_blank: true }
   # rubocop:enable Metrics/LineLength

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -83,6 +83,14 @@
   </div>
   <br>
 
+  <div class="form-row">
+    <div class="col-med-9">
+      <%= form.label :digitization_funding_source %>
+      <%= form.text_field :digitization_funding_source %>
+    </div>
+  </div>
+  <br>
+
 
   <h6 class="form-subgroup-title">Voyager identifiers</h6>
   <div class="voyager_identifiers, form-row">

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -41,6 +41,7 @@
           <th scope='col'>Visibility</th>
           <th scope='col'>Extent of Digitization</th>
           <th scope='col'>Digitization Note</th>
+          <th scope='col'>Digitization Funding Source</th>
           <th scope='col'>Project ID</th>
         </tr>
       </thead>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -92,6 +92,9 @@
   <dt>Digitization Note:</dt>
   <dd><%= @parent_object.digitization_note %></dd>
 
+  <dt>Digitization Funding Source:</dt>
+  <dd><%= @parent_object.digitization_funding_source %></dd>
+
   <dt>Viewing Direction:</dt>
   <dd><%= @parent_object.viewing_direction %></dd>
 

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -59,7 +59,7 @@ METADATA_FIELDS = {
     ]
   },
   digitization_funding_source: {
-    label: 'Digitization Note',
+    label: 'Digitization Funding Source',
     solr_fields: [
       'digitization_funding_source_tesi'
     ]

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -58,6 +58,12 @@ METADATA_FIELDS = {
       'digitization_note_tesi'
     ]
   },
+  digitization_funding_source: {
+    label: 'Digitization Note',
+    solr_fields: [
+      'digitization_funding_source_tesi'
+    ]
+  },
   extent: {
     label: 'Extent',
     solr_fields: [

--- a/db/migrate/20220831211639_add_digitization_funding_to_parent_object.rb
+++ b/db/migrate/20220831211639_add_digitization_funding_to_parent_object.rb
@@ -1,0 +1,5 @@
+class AddDigitizationFundingToParentObject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :parent_objects, :digitization_funding_source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_214806) do
+ActiveRecord::Schema.define(version: 2022_08_31_211639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_214806) do
     t.string "digital_object_source", default: "None"
     t.string "preservica_representation_type"
     t.datetime "last_preservica_update"
+    t.string "digitization_funding_source"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["aspace_uri"], name: "index_parent_objects_on_aspace_uri"
     t.index ["authoritative_metadata_source_id"], name: "index_parent_objects_on_authoritative_metadata_source_id"

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
       digital_object_source: "Preservica",
       preservica_uri: "/preservica_uri",
       digitization_note: nil,
+      digitization_funding_source: nil,
       extent_of_digitization: nil,
       holding: nil,
       item: nil,

--- a/spec/models/concerns/solr_indexable_spec.rb
+++ b/spec/models/concerns/solr_indexable_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe SolrIndexable, type: :model do
     expect(solr_document[:digitization_note_tesi]).to eq(['digitization note'])
   end
 
+  it "indexes the digitization funding source" do
+    solr_document = solr_indexable.to_solr('digitization_funding_source' => ['digitization funding source'])
+    expect(solr_document[:digitization_funding_source_tesi]).to eq(['digitization funding source'])
+  end
+
   it "indexes the ancestor titles" do
     solr_document = solr_indexable.to_solr('ancestorTitles' => ['ancestor title'])
     expect(solr_document[:ancestorTitles_tesim]).to eq(['ancestor title'])


### PR DESCRIPTION
## Summary
Adds digitization funding source to:
- parent object show and edit pages
- parent object datatable and exports

## Related Ticket
[#2180](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2180)

## Screenshots

### PO Show Page
![PO show page](https://user-images.githubusercontent.com/39319859/187803962-4d1898bd-68d4-4588-b9dd-69e843056107.JPG)

### PO Edit Page
![edit PO page](https://user-images.githubusercontent.com/39319859/187803977-2503a0ea-9e99-4d4c-b52d-66181eefb864.JPG)

### PO Index Datatable
![PO index datatable](https://user-images.githubusercontent.com/39319859/188208105-2dc42611-88c7-4ca8-90fe-6cab2a0df607.JPG)

### PO Excel Export (snake_case label ticket not merged yet)
![excel export](https://user-images.githubusercontent.com/39319859/188208112-1f97eb48-753f-4d53-ab8c-692ebf828479.JPG)

### PO CSV Export
![csv export](https://user-images.githubusercontent.com/39319859/188208113-5c8fa7e9-8560-44cd-8302-43771728280f.JPG)
