### PR TITLE
Adds admin set to goobi scan

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -380,7 +380,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
     ParentObject.create(oid: oid) do |parent_object|
       set_values_from_mets(parent_object, metadata_source)
-      sets << ', ' + parent_object.admin_set.key
+      sets << ', ' + AdminSet.find(parent_object.authoritative_metadata_source_id).key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save

--- a/spec/datatables/preservica_ingest_datatable_spec.rb
+++ b/spec/datatables/preservica_ingest_datatable_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PreservicaIngestDatatable, type: :datatable, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
+  let(:admin_set) { FactoryBot.create(:admin_set, id: 2) }
   columns = ['parent_oid', 'child_oid', 'parent_preservica_id', 'parent_preservica_id', 'batch_process_id', 'timestamp']
 
   it 'can handle an empty model set' do
@@ -25,6 +26,7 @@ RSpec.describe PreservicaIngestDatatable, type: :datatable, prep_metadata_source
     end
 
     it 'renders data with proper permissions' do
+      admin_set
       batch_process_xml
       output = PreservicaIngestDatatable.new(datatable_sample_params(columns), current_ability: Ability.new(user)).data
 

--- a/spec/requests/batch_processes_request_spec.rb
+++ b/spec/requests/batch_processes_request_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:user) }
+  let(:admin_set) { FactoryBot.create(:admin_set, id: 3) }
   before do
     login_as user
   end
@@ -25,6 +26,7 @@ RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
       )
     end
     it "returns http success" do
+      admin_set
       get "/batch_processes/#{batch_process_xml.id}/download"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("application/xml")

--- a/spec/system/batch_process_detail_spec.rb
+++ b/spec/system/batch_process_detail_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
   let(:user) { FactoryBot.create(:user, uid: "johnsmith2530") }
+  let(:admin_set) { FactoryBot.create(:admin_set, id: 2) }
   before do
     stub_ptiffs_and_manifests
     stub_metadata_cloud("2004628")
@@ -123,6 +124,7 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
       )
     end
     it "can see the details of the import" do
+      admin_set
       visit batch_process_path(batch_process)
       expect(page).to have_content(batch_process.id.to_s)
       expect(page).to have_content("johnsmith2530")
@@ -143,6 +145,7 @@ RSpec.describe "Batch Process detail page", type: :system, prep_metadata_sources
       )
     end
     it "can see the details of the import" do
+      admin_set
       visit batch_process_path(batch_process)
       expect(page).to have_content(batch_process.id.to_s)
       expect(page).to have_content("johnsmith2530")

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
+  let(:admin_set_two) { FactoryBot.create(:admin_set, id: 2) }
 
   around do |example|
     original_path = ENV["GOOBI_MOUNT"]
@@ -314,6 +315,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
   end
   context "when uploading an xml" do
     it "uploads and increases xml count and gives a success message" do
+      admin_set_two
       expect(BatchProcess.count).to eq 0
       page.attach_file("batch_process_file", fixture_path + '/goobi/metadata/30000317_20201203_140947/111860A_8394689_mets.xml')
       click_button("Submit")
@@ -324,6 +326,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
     context "deleting a parent object" do
       before do
+        admin_set_two
         page.attach_file("batch_process_file", fixture_path + '/goobi/metadata/30000317_20201203_140947/111860A_8394689_mets.xml')
         click_button("Submit")
       end
@@ -352,6 +355,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     end
 
     it "create preservica ingest for the parent and children objects" do
+      admin_set_two
       # rubocop:disable RSpec/AnyInstance
       allow_any_instance_of(SetupMetadataJob).to receive(:check_mets_images).and_return(true)
       allow_any_instance_of(ParentObject).to receive(:default_fetch).and_return(true)
@@ -365,6 +369,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     end
 
     it "does not create preservica ingest if no parent uuid" do
+      admin_set_two
       # rubocop:disable RSpec/AnyInstance
       allow_any_instance_of(SetupMetadataJob).to receive(:check_mets_images).and_return(true)
       allow_any_instance_of(ParentObject).to receive(:default_fetch).and_return(true)


### PR DESCRIPTION
# Summary
Goobi scan was not included in initial work for this ticket.  This MR captures the admin set in goobi scan as well.  Also confirms that export by admin set is returning the key not the label.

# Related Ticket
[#2174](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2174)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/188952452-8788430d-b323-40c1-a90b-f9b0f9029507.png)
