### PR TITLE
Specifies admin set for batch process

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -380,7 +380,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
     ParentObject.create(oid: oid) do |parent_object|
       set_values_from_mets(parent_object, metadata_source)
-      sets << ', ' + AdminSet.find(parent_object.authoritative_metadata_source_id).key
+      sets << ', ' + parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -380,10 +380,12 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
     ParentObject.create(oid: oid) do |parent_object|
       set_values_from_mets(parent_object, metadata_source)
-      sets << ', ' + parent_object.admin_set.key
-      split_sets = sets.split(',').uniq.reject(&:blank?)
-      self.admin_set = split_sets.join(', ')
-      save
+      if parent_object.admin_set.present?
+        sets << ', ' + parent_object.admin_set.key
+        split_sets = sets.split(',').uniq.reject(&:blank?)
+        self.admin_set = split_sets.join(', ')
+        save
+      end
     end
     PreservicaIngest.create(parent_oid: oid, preservica_id: mets_doc.parent_uuid, batch_process_id: id, ingest_time: Time.current) unless mets_doc.parent_uuid.nil?
   end

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -181,7 +181,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
     end
 
     describe 'recreating child oid ptiffs' do
-      # let(:admin_set_recreate) { FactoryBot.create(:admin_set) }
       let(:role) { FactoryBot.create(:role, name: editor) }
       let(:parent_object) { ParentObject.find(30_000_317) }
       let(:child_object) { parent_object.child_objects.first }

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       po = ParentObject.find(30_000_557)
       expect(po.admin_set).not_to be_nil
       expect(po.admin_set.key).to eq "brbl"
+      expect(batch_process.admin_set).to eq " brbl"
     end
 
     it "creates a preservica ingest with parent uuid from the METs document" do
@@ -123,6 +124,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       pj = PreservicaIngest.find_by_parent_oid(30_000_557)
       expect(pj.preservica_id).to eq "c91ce4e1-10d2-4e33-8df3-83f081ff0125"
       expect(pj.batch_process_id).to eq batch_process.id
+      expect(batch_process.admin_set).to eq " brbl"
     end
 
     context "when parent object already exists" do


### PR DESCRIPTION
# Summary
Rather than find by authoritative metadata source this specifies the admin set of the parent object.  

# Related Ticket
[#2174](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2174)