### PR TITLE
change admin label to key admin set export

### DIFF
--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -35,7 +35,7 @@ module CsvExportable
 
   def parent_object_csv_rows(*admin_set_id)
     parent_objects_array(*admin_set_id).map do |po|
-      [po.oid, po.admin_set.label, po.source_name,
+      [po.oid, po.admin_set.key, po.source_name,
        po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
        po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
        po.last_ladybird_update, po.last_voyager_update,

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.parent_output_csv).to include "2034600"
         expect(BatchProcess.last.parent_output_csv).to include "Preservica"
         expect(BatchProcess.last.parent_output_csv).to include "/preservica_uri"
+        expect(BatchProcess.last.parent_output_csv).to include "brbl"
         expect(BatchProcess.last.parent_output_csv).not_to include "2005512"
       end
 


### PR DESCRIPTION
To fix #2204 https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2204
change admin set label to admin set key in the parent export csv