### PR TITLE
Allows preservica resync to fail

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -448,10 +448,10 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
                                                                         generation_uri: preservica_co[:preservica_generation_uri],
                                                                         bitstream_uri: preservica_co[:preservica_bitstream_uri] }
         end
-      rescue PreservicaImageServiceNetworkError => e
+      rescue PreservicaImageService::PreservicaImageServiceNetworkError => e
         batch_processing_event("Parent OID: #{row['oid']} because of #{e.message}", 'Skipped Import')
         raise
-      rescue PreservicaImageServiceError => e
+      rescue PreservicaImageService::PreservicaImageServiceError => e
         batch_processing_event("Parent OID: #{row['oid']} because of #{e.message}", 'Skipped Import')
         next
       end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -230,8 +230,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       replace_preservica_tif(co)
       co.save
     end
-    self.metadata_update = true
-    save!
 
     # create child records for any new items in preservica
     create_child_records

--- a/spec/fixtures/csv/preservica/preservica_parent_with_two_children.csv
+++ b/spec/fixtures/csv/preservica/preservica_parent_with_two_children.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+,brbl,aspace,/repositories/11/archival_objects/200000000,36,holding,item,barcode,Public,Preservica,/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c6,Preservation

--- a/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Representations>
+    <Representation type="Access" name="Access-2">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations/Access/1
+    </Representation>
+    <Representation type="Preservation" name="Preservation-1">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations/Preservation/1
+    </Representation>
+  </Representations>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff96306799/representations
+    </Self>
+  </AdditionalInformation>
+</RepresentationsResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations/Access.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations/Access.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Representation>
+    <xip:InformationObject>b31ba07e-88ce-4558-8e89-81cff9630799</xip:InformationObject>
+    <xip:Name>Access-2</xip:Name>
+    <xip:Type>Access</xip:Type>
+    <xip:ContentObjects>
+      <xip:ContentObject>ae328d84-e429-4d46-a865-9ee11157b489</xip:ContentObject>
+    </xip:ContentObjects>
+    <xip:RepresentationFormats/>
+    <xip:RepresentationProperties/>
+  </xip:Representation>
+  <ContentObjects>
+    <ContentObject title="mss_29_s03_b092_f0019" ref="ae328d84-e429-4d46-a865-9ee11157b489" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489
+    </ContentObject>
+  </ContentObjects>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations/Access-2
+    </Self>
+  </AdditionalInformation>
+</RepresentationResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations/Preservation.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799/representations/Preservation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Representation>
+    <xip:InformationObject>b31ba07e-88ce-4558-8e89-81cff9630699</xip:InformationObject>
+    <xip:Name>Preservation-1</xip:Name>
+    <xip:Type>Preservation</xip:Type>
+    <xip:ContentObjects>
+      <xip:ContentObject>ae328d84-e429-4d46-a865-9ee11157b489</xip:ContentObject>
+    </xip:ContentObjects>
+    <xip:RepresentationFormats/>
+    <xip:RepresentationProperties/>
+  </xip:Representation>
+  <ContentObjects>
+    <ContentObject title="mss_29_s03_b092_f0019" ref="ae328d84-e429-4d46-a865-9ee11157b489" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489
+    </ContentObject>
+  </ContentObjects>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630699/representations/Preservation/1
+    </Self>
+  </AdditionalInformation>
+</RepresentationResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Representations>
+    <Representation type="Access" name="Access-2">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations/Access/1
+    </Representation>
+    <Representation type="Preservation" name="Preservation-1">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations/Preservation/1
+    </Representation>
+  </Representations>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations
+    </Self>
+  </AdditionalInformation>
+</RepresentationsResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations/Access.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations/Access.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Representation>
+    <xip:InformationObject>b31ba07e-88ce-4558-8e89-81cff9630899</xip:InformationObject>
+    <xip:Name>Access-2</xip:Name>
+    <xip:Type>Access</xip:Type>
+    <xip:ContentObjects>
+      <xip:ContentObject>ae328d84-e429-4d46-a865-9ee11157b487</xip:ContentObject>
+    </xip:ContentObjects>
+    <xip:RepresentationFormats/>
+    <xip:RepresentationProperties/>
+  </xip:Representation>
+  <ContentObjects>
+    <ContentObject title="mss_29_s03_b092_f0019" ref="ae328d84-e429-4d46-a865-9ee11157b487" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487
+    </ContentObject>
+  </ContentObjects>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations/Access-2
+    </Self>
+  </AdditionalInformation>
+</RepresentationResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations/Preservation.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899/representations/Preservation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Representation>
+    <xip:InformationObject>b31ba07e-88ce-4558-8e89-81cff96306899</xip:InformationObject>
+    <xip:Name>Preservation-1</xip:Name>
+    <xip:Type>Preservation</xip:Type>
+    <xip:ContentObjects>
+      <xip:ContentObject>ae328d84-e429-4d46-a865-9ee11157b487</xip:ContentObject>
+    </xip:ContentObjects>
+    <xip:RepresentationFormats/>
+    <xip:RepresentationProperties/>
+  </xip:Representation>
+  <ContentObjects>
+    <ContentObject title="mss_29_s03_b092_f0019" ref="ae328d84-e429-4d46-a865-9ee11157b487" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487
+    </ContentObject>
+  </ContentObjects>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff96306899/representations/Preservation/1
+    </Self>
+  </AdditionalInformation>
+</RepresentationResponse>

--- a/spec/fixtures/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c6/children.xml
+++ b/spec/fixtures/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c6/children.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ChildrenResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Children>
+    <Child title="mss_29_s03_b092_f0019" ref="b31ba07e-88ce-4558-8e89-81cff9630799" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630799
+    </Child>
+    <Child title="mss_29_s03_b092_f0019_0001" ref="b31ba07e-88ce-4558-8e89-81cff9630899" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/b31ba07e-88ce-4558-8e89-81cff9630899
+    </Child>
+  </Children>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c6/children
+    </Self>
+  </AdditionalInformation>
+</ChildrenResponse>


### PR DESCRIPTION
# Summary
Batch processes for the preservica resync were failing due to an uninitialized constant error.  This MR adds the PreservicaImageService to alleviate that error and ensures that a failure message can be reported with a preservica resync.

# Related Ticket
[#2166](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2166)