### PR TITLE
Bumps RSpec and dependency versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
-  gem 'rspec-rails', '~> 4.0.0'
+  gem 'rspec-rails', '~> 5.0.0'
   gem 'vcr', '~> 6.0'
   gem 'webmock', '~> 3.8', '>= 3.8.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,10 +340,10 @@ GEM
     rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-rails (4.0.2)
-      actionpack (>= 4.2)
-      activesupport (>= 4.2)
-      railties (>= 4.2)
+    rspec-rails (5.0.3)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
@@ -498,7 +498,7 @@ DEPENDENCIES
   rails_semantic_logger (>= 4.4.4)
   rolify
   rsolr (~> 2.3)
-  rspec-rails (~> 4.0.0)
+  rspec-rails (~> 5.0.0)
   sass-rails (>= 6)
   selenium-webdriver
   shoulda-matchers (~> 4.0)


### PR DESCRIPTION
# Summary
Bumps RSpec to v5.0.0

# Related Ticket
[#2188](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2188)