### PR TITLE
Permission set model and abilities

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,6 +3,7 @@
 class Ability
   include CanCan::Ability
 
+  # rubocop:disable Metrics/AbcSize
   def initialize(user)
     alias_action :create, :read, :update, :destroy, to: :crud
     return unless user
@@ -20,6 +21,7 @@ class Ability
     can [:read, :approve], PermissionSet, roles: { name: approver_roles, users: { id: user.id } }
     can [:crud, :approve], PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
   end
+  # rubocop:enable Metrics/AbcSize
 
   def apply_sysadmin_abilities
     can :manage, User

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,11 +17,14 @@ class Ability
     can :reindex_admin_set, AdminSet, roles: { name: editor_roles, users: { id: user.id } }
     can [:crud], ChildObject, parent_object: { admin_set: { roles: { name: editor_roles, users: { id: user.id } } } }
     can [:crud], ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
+    can [:read, :approve], PermissionSet, roles: { name: approver_roles, users: { id: user.id } }
+    can [:crud, :approve], PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
   end
 
   def apply_sysadmin_abilities
     can :manage, User
     can :crud, AdminSet
+    can :crud, PermissionSet
     can :read, ParentObject
     can :read, ChildObject
     can :read, PreservicaIngest
@@ -38,5 +41,13 @@ class Ability
 
   def editor_roles
     ['editor']
+  end
+
+  def approver_roles
+    ['approver']
+  end
+
+  def administrator_roles
+    ['administrator']
   end
 end

--- a/app/models/permission_set.rb
+++ b/app/models/permission_set.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class PermissionSet < ApplicationRecord
+  resourcify
+  validates :key, presence: true
+  validates :label, presence: true
+
+  def add_approver(user)
+    remove_administrator(user) if user.administrator(self)
+    user.add_role(:approver, self)
+  end
+
+  def remove_approver(user)
+    user.remove_role(:approver, self)
+  end
+
+  def add_administrator(user)
+    remove_approver(user) if user.approver(self)
+    user.add_role(:administrator, self)
+  end
+
+  def remove_administrator(user)
+    user.remove_role(:administrator, self)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,14 @@ class User < ApplicationRecord
     has_role?(:editor, admin_set)
   end
 
+  def administrator(permission_set)
+    has_role?(:administrator, permission_set)
+  end
+
+  def approver(permission_set)
+    has_role?(:approver, permission_set)
+  end
+
   def viewer(admin_set)
     has_role?(:viewer, admin_set)
   end

--- a/db/migrate/20220928165554_create_permission_sets.rb
+++ b/db/migrate/20220928165554_create_permission_sets.rb
@@ -1,0 +1,11 @@
+class CreatePermissionSets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :permission_sets do |t|
+      t.text :label
+      t.text :key
+      t.integer :max_queue_length, default: 10
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2022_09_28_165554) do
 
-ActiveRecord::Schema.define(version: 2022_08_31_211639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -198,6 +198,14 @@ ActiveRecord::Schema.define(version: 2022_08_31_211639) do
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true
     t.index ["project_identifier"], name: "index_parent_objects_on_project_identifier"
     t.index ["redirect_to"], name: "index_parent_objects_on_redirect_to"
+  end
+
+  create_table "permission_sets", force: :cascade do |t|
+    t.text "label"
+    t.text "key"
+    t.integer "max_queue_length", default: 10
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "preservica_ingests", force: :cascade do |t|

--- a/spec/factories/permission_sets.rb
+++ b/spec/factories/permission_sets.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :permission_set do
+    label { "Permission Label" }
+    key { "Permission Key" }
+    max_queue_length { 1 }
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -11,11 +11,17 @@ RSpec.describe Ability, type: :model do
   let(:parent_object) { FactoryBot.create(:parent_object, oid: 16_057_779, authoritative_metadata_source: metadata_source, admin_set: admin_set) }
   let(:child_object) { FactoryBot.create(:child_object, parent_object: parent_object) }
   let(:child_object2) { FactoryBot.create(:child_object, oid: 900_000_000, parent_object: parent_object) }
+  let(:permission_set) { FactoryBot.create(:permission_set) }
 
   describe 'for a sysadmin' do
     it 'grants manage role to User' do
       ability = Ability.new(sysadmin_user)
       assert ability.can?(:manage, User)
+    end
+
+    it 'grants crud roles to Permission Set' do
+      ability = Ability.new(sysadmin_user)
+      assert ability.can?(:crud, PermissionSet)
     end
 
     it 'grants read access to a ParentObject' do
@@ -220,6 +226,38 @@ RSpec.describe Ability, type: :model do
     it "disallows allow add_member on an Admin Set" do
       ability = Ability.new(user)
       assert ability.cannot?(:add_member, admin_set)
+    end
+  end
+
+  describe 'for an approver on Permission Sets' do
+    before do
+      user.add_role :approver, permission_set
+    end
+    it 'allows approver to read Permission Set' do
+      ability = Ability.new(user)
+      assert ability.can?(:read, permission_set)
+    end
+    it 'allows approver to approve Permission Set' do
+      ability = Ability.new(user)
+      assert ability.can?(:approve, permission_set)
+    end
+    it 'does not allow approver to crud Permission Set' do
+      ability = Ability.new(user)
+      assert ability.cannot?(:crud, permission_set)
+    end
+  end
+
+  describe 'for an administrator on Permission Sets' do
+    before do
+      user.add_role :administrator, permission_set
+    end
+    it 'allows administrator to crud Permission Set' do
+      ability = Ability.new(user)
+      assert ability.can?(:crud, permission_set)
+    end
+    it 'allows administrator to approve Permission Set' do
+      ability = Ability.new(user)
+      assert ability.can?(:approve, permission_set)
     end
   end
 end

--- a/spec/models/permission_set_spec.rb
+++ b/spec/models/permission_set_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PermissionSet, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:permission_set) { FactoryBot.create(:permission_set) }
+
+  describe "user permission set roles" do
+    it "adds an approver" do
+      expect(user.roles).to be_empty
+      permission_set.add_approver(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("approver")
+    end
+
+    it "removes an approver" do
+      permission_set.add_approver(user)
+      expect(user.roles.count).to eq(1)
+      permission_set.remove_approver(user)
+      expect(user.roles.count).to eq(0)
+    end
+
+    it "adds an administrator" do
+      expect(user.roles).to be_empty
+      permission_set.add_administrator(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("administrator")
+    end
+
+    it "removes an administrator" do
+      permission_set.add_administrator(user)
+      expect(user.roles.count).to eq(1)
+      permission_set.remove_administrator(user)
+      expect(user.roles.count).to eq(0)
+    end
+
+    it "removes an administrator when a approver is added" do
+      permission_set.add_administrator(user)
+      expect(user.roles.count).to eq(1)
+      permission_set.add_approver(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("approver")
+    end
+
+    it "removes an approver when an administrator is added" do
+      permission_set.add_approver(user)
+      expect(user.roles.count).to eq(1)
+      permission_set.add_administrator(user)
+      expect(user.roles.count).to eq(1)
+      expect(user.roles.first.name).to eq("administrator")
+    end
+  end
+end


### PR DESCRIPTION
## Summary  
Permission Set model has been created.  
Added 2 user roles: Administrator and Approver. Administrator roles can crud and approve PermissionSets. Approver can read and approve PermissionSet.   
  
## Ticket  
#2213  
  
