### PR TITLE
Makes error message more specific

### DIFF
--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -40,8 +40,9 @@ class PreservicaImageService
       elsif @pattern == :pattern_two
         @information_objects = [Preservica::InformationObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)]
       end
-    rescue StandardError
-      raise PreservicaImageServiceError.new("Unable to log in to Preservica", @uri.to_s)
+    rescue StandardError => e
+      # raise PreservicaImageServiceError.new("Unable to log in to Preservica", @uri.to_s)
+      raise PreservicaImageServiceError.new(e.to_s, @uri.to_s)
     end
     begin
       process_information_objects(representation_type)

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_no_sha_pattern_1
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] SHA mismatch found in Preservica for bitstream: 1.").or start_with("Skipping row [2] Failed to open TCP connection to testpreservica:443 (Connection refused")
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] SHA mismatch found in Preservica for bitstream: 1.").or start_with("Skipping row [2] Failed to open TCP connection to testpreservica:443")
     end.to change { ChildObject.count }.by(0)
   end
 

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_with_children
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Unable to log in for /preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.")
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Unable to login for /preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.")
     end.to change { ChildObject.count }.by(0)
   end
 
@@ -227,7 +227,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_no_sha_pattern_1
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] SHA mismatch found in Preservica for bitstream: 1.").or eq("Skipping row [2] Unable to log in to Preservica for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a7u8y.")
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] SHA mismatch found in Preservica for bitstream: 1.").or start_with("Skipping row [2] Failed to open TCP connection to testpreservica:443 (Connection refused")
     end.to change { ChildObject.count }.by(0)
   end
 

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_with_children
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Unable to log in to Preservica for /preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.")
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Unable to log in for /preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.")
     end.to change { ChildObject.count }.by(0)
   end
 
@@ -143,7 +143,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_no_structural
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Unable to log in to Preservica for /preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519d6.")
+      expect(batch_process.batch_ingest_events[0].reason).to start_with("Skipping row [2] Failed to open TCP connection to testpreservica:443")
     end.to change { ChildObject.count }.by(0)
   end
 


### PR DESCRIPTION
# Summary
Instead of no error message this will forward a more specific error message to the user.

# Related Ticket
[#2166](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2166)