### PR TITLE
Save BatchConnection during setup

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -247,8 +247,8 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def setup_for_background_jobs(object, metadata_source)
     object.authoritative_metadata_source = MetadataSource.find_by(metadata_cloud_name: (metadata_source.presence || 'ladybird')) if object.class == ParentObject
     object.current_batch_process = self
-    object.current_batch_connection = batch_connections.build(connectable: object)
-    object.current_batch_connection.save! if object.class == ChildObject
+    object.current_batch_connection = batch_connections.find_by(connectable: object) || batch_connections.build(connectable: object)
+    object.current_batch_connection.save!
   end
 
   # RECREATE CHILD OID PTIFFS: -------------------------------------------------------------------- #


### PR DESCRIPTION
Check for existing connection in `setup_for_background_jobs` so that duplicates are not created.
Save the batch connection when it is created so that it can be found from other ParentObject instances.