### PR TITLE
Permission set show

### DIFF
--- a/app/assets/stylesheets/permission_sets.scss
+++ b/app/assets/stylesheets/permission_sets.scss
@@ -1,0 +1,29 @@
+.table.permission-set-show-table {
+  display: inline-block;
+  width: auto;
+  vertical-align: top;
+
+  th {
+    width: 300px;
+  }
+
+  .user-role {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+.table.permission-set-index-table {
+  display: inline-block;
+  width: auto;
+  vertical-align: top;
+
+  th {
+    width: 300px;
+  }
+
+  .user-role {
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -17,11 +17,9 @@ class PermissionSetsController < ApplicationController
     end
   end
 
-  def show
-  end
+  def show; end
 
-  def edit
-  end
+  def edit; end
 
   private
 

--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -17,6 +17,12 @@ class PermissionSetsController < ApplicationController
     end
   end
 
+  def show
+  end
+
+  def edit
+  end
+
   private
 
     # Use callbacks to share common setup or constraints between actions.

--- a/app/views/permission_sets/index.html.erb
+++ b/app/views/permission_sets/index.html.erb
@@ -9,15 +9,15 @@
 <table class='table table-striped permission-set-index-table' aria-label='Label Permission Set'>
   <thead class='thead-dark'>
     <tr>
+    <th scope='col'> Key </th>
       <th scope='col'> Label </th>
-      <th scope='col'> Key </th>
     </tr>
   </thead>
   <tbody>
     <% @visible_permission_sets.each do |sets| %>
       <tr>
-        <td class='permission-set-label'><%= sets.label %></td>
         <td class='permission-set-label'><%= sets.key %></td>
+        <td class='permission-set-label'><%= link_to sets.label, permission_set_path(sets)  %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/permission_sets/show.html.erb
+++ b/app/views/permission_sets/show.html.erb
@@ -1,0 +1,52 @@
+<%= render partial: "/management/flash_messages" %>
+
+<p>
+  <strong>Key:</strong>
+  <%= @permission_set.key %>
+</p>
+
+<p>
+  <strong>Label:</strong>
+  <%= @permission_set.label %>
+</p>
+
+<p>
+  <strong>Max Request Queue Length:</strong>
+  <%= @permission_set.max_queue_length %>
+</p>
+
+<table class='table table-striped permission-set-show-table' aria-label='Approvers Permission Set'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'> Approvers </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% User.with_role(:approver, @permission_set).order('last_name ASC').each do |user| %>
+      <tr>
+        <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<table class='table table-striped permission-set-show-table' aria-label='Administrators Permission Set'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'> Administrators </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% User.with_role(:administrator, @permission_set).order('last_name ASC').each do |user| %>
+        <tr>
+          <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %></td>
+        </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br />
+<% if can? :edit, @permission_set %>
+  <%= link_to 'Edit', edit_permission_set_path(@permission_set) %> |
+<% end %>
+<%= link_to 'Back', permission_sets_path %>

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -4,11 +4,15 @@ require 'rails_helper'
 
 RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:user) }
+  let(:approver_user) { FactoryBot.create(:user) }
+  let(:administrator_user) { FactoryBot.create(:user) }
   let(:permission_set) { FactoryBot.create(:permission_set, label: "set 1") }
   let(:permission_set_2) { FactoryBot.create(:permission_set, label: "set 2") }
 
   before do
     login_as user
+    permission_set
+    permission_set_2
   end
 
   context 'PermissionSets page access' do
@@ -69,7 +73,6 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
   context 'users can only see permission sets they have access to' do
     describe 'approvers roles' do
       before do
-        permission_set_2
         permission_set.add_approver(user)
       end
       it 'can only see sets they are approvers for' do
@@ -82,7 +85,6 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
 
     describe 'adminstrator roles' do
       before do
-        permission_set
         permission_set_2.add_administrator(user)
       end
       it 'can only see sets they are administrators for' do
@@ -96,14 +98,47 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
     describe 'sysadmin roles' do
       before do
         user.add_role(:sysadmin)
-        permission_set
-        permission_set_2
       end
       it 'can see all of the permission sets' do
         visit '/permission_sets'
         expect(page).to have_content("Permission Sets")
         expect(page).to have_content("set 2")
         expect(page).to have_content("set 1")
+      end
+    end
+  end
+
+  context 'permission set showpage' do
+    describe 'approvers and administrators' do
+      before do
+        login_as approver_user
+        administrator_user
+        permission_set.add_approver(approver_user)
+        permission_set_2
+      end
+      it 'cannot access permission set showpage theyre not approved for' do
+        visit "/permission_sets/#{permission_set_2.id}"
+        expect(page).to have_content("Access denied")
+      end
+    end
+
+    describe 'displays permission sets' do
+      before do
+        user.add_role(:sysadmin)
+        permission_set.add_approver(approver_user)
+        permission_set.add_administrator(administrator_user)
+      end
+      it 'metadata' do
+        visit "/permission_sets/#{permission_set.id}"
+        expect(page).to have_content("set 1")
+        expect(page).to have_content("Permission Key")
+        expect(page).to have_content("Max Request Queue Length: 1")
+      end
+      it 'approvers and administrators' do
+        visit "/permission_sets/#{permission_set.id}"
+        expect(page).to have_content("set 1")
+        expect(page).to have_content("#{approver_user.first_name}")
+        expect(page).to have_content("#{administrator_user.first_name}")
       end
     end
   end

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
       it 'approvers and administrators' do
         visit "/permission_sets/#{permission_set.id}"
         expect(page).to have_content("set 1")
-        expect(page).to have_content("#{approver_user.first_name}")
-        expect(page).to have_content("#{administrator_user.first_name}")
+        expect(page).to have_content(approver_user.first_name.to_s)
+        expect(page).to have_content(administrator_user.first_name.to_s)
       end
     end
   end


### PR DESCRIPTION
## Summary  
Permission Set showpage. Sysadmins can view any permission set. Administrators and Approvers can only visit the permission set showpages that they are administrators/approvers for. Each Permission Set showpage lists the approver and administrator users assigned to that permission set.  "Edit" link is only available to administrator or sysadmin users. 
  
## 
Ticket #2230  
  
## Screenshot  
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/24666568/194915032-0d42421e-08eb-4cf3-8ba8-6609d9f96f09.png">
