### PR TITLE
Permission Set edit and new pages

### DIFF
--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -21,6 +21,36 @@ class PermissionSetsController < ApplicationController
 
   def edit; end
 
+  # PATCH/PUT /permission_sets/1
+  # PATCH/PUT /permission_sets/1.json
+  def update
+    respond_to do |format|
+      if @permission_set.update(permission_set_params)
+        format.html { redirect_to @permission_set, notice: 'Permission set was successfully updated.' }
+        format.json { render :show, status: :ok, location: @permission_set }
+      else
+        format.html { render :edit }
+        format.json { render json: @permission_set.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # POST /permission_sets
+  # POST /permission_sets.json
+  def create
+    @permission_set = PermissionSet.new(permission_set_params)
+
+    respond_to do |format|
+      if @permission_set.save
+        format.html { redirect_to @permission_set, notice: 'Permission set was successfully created.' }
+        format.json { render :show, status: :created, location: @permission_set }
+      else
+        format.html { render :new }
+        format.json { render json: @permission_set.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
   private
 
     # Use callbacks to share common setup or constraints between actions.
@@ -30,6 +60,6 @@ class PermissionSetsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def permission_set_params
-      params.require(:permission_set).permit(:key, :label)
+      params.require(:permission_set).permit(:key, :label, :max_queue_length)
     end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,6 +4,8 @@ class Ability
   include CanCan::Ability
 
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def initialize(user)
     alias_action :create, :read, :update, :destroy, to: :crud
     return unless user
@@ -19,12 +21,13 @@ class Ability
     can [:crud], ChildObject, parent_object: { admin_set: { roles: { name: editor_roles, users: { id: user.id } } } }
     can [:crud], ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
     can [:view_list], PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:approver, :any) || user.has_role?(:administrator, :any)
-    can [:create_set], PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
-    can [:crud], PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
+    can [:create_set, :crud], PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
     can [:read, :approve], PermissionSet, roles: { name: approver_roles, users: { id: user.id } }
     can [:crud, :approve], PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
   end
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def apply_sysadmin_abilities
     can :manage, User

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,6 +19,8 @@ class Ability
     can [:crud], ChildObject, parent_object: { admin_set: { roles: { name: editor_roles, users: { id: user.id } } } }
     can [:crud], ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
     can [:view_list], PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:approver, :any) || user.has_role?(:administrator, :any)
+    can [:create_set], PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
+    can [:crud], PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
     can [:read, :approve], PermissionSet, roles: { name: approver_roles, users: { id: user.id } }
     can [:crud, :approve], PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
   end

--- a/app/views/permission_sets/_form.html.erb
+++ b/app/views/permission_sets/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: permission_set, local: true) do |form| %>
+  <% if permission_set.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(permission_set.errors.count, "error") %> prohibited this permission_set from being saved:</h2>
+
+      <ul>
+        <% permission_set.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field form-group">
+    <%= form.label :key %>
+    <%= form.text_field(:key, required: true, class: "form-control") %>
+  </div>
+
+  <div class="field form-group">
+    <%= form.label :label %>
+    <%= form.text_field(:label, required: true, class: "form-control") %>
+  </div>
+
+  <div class="field form-group">
+    <%= form.label :max_queue_length %>
+    <%= form.text_field(:max_queue_length, class: "form-control") %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit(@permission_set.persisted? ? "Update Permission Set" : "Create Permission Set", class: "btn-primary btn") %>
+  </div>
+<% end %>

--- a/app/views/permission_sets/edit.html.erb
+++ b/app/views/permission_sets/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Permission Set</h1>
+
+<%= render 'form', permission_set: @permission_set %>
+
+<%= link_to 'Show', @permission_set %> |
+<%= link_to 'Back', permission_sets_path %>

--- a/app/views/permission_sets/index.html.erb
+++ b/app/views/permission_sets/index.html.erb
@@ -5,19 +5,32 @@
     <h1>Permission Sets (TBD)</h1>
   </div>
 </div>
-
+<div class="heading">
+  <% if can? :create_set, PermissionSet %>
+    <div class='col'>
+      <div class='button-list'>
+        <%= link_to 'Create New Permission Set', new_permission_set_path, class: "btn button primary-button" %>
+      </div>
+    </div>
+  <% end %>
+</div>
+<br />
 <table class='table table-striped permission-set-index-table' aria-label='Label Permission Set'>
   <thead class='thead-dark'>
     <tr>
-    <th scope='col'> Key </th>
+      <th scope='col'> Key </th>
       <th scope='col'> Label </th>
+      <th scope='col'> Edit </th>
     </tr>
   </thead>
   <tbody>
-    <% @visible_permission_sets.each do |sets| %>
+    <% @visible_permission_sets.each do |permission_set| %>
       <tr>
-        <td class='permission-set-label'><%= sets.key %></td>
-        <td class='permission-set-label'><%= link_to sets.label, permission_set_path(sets)  %></td>
+        <td class='permission-set-label'><%= permission_set.key %></td>
+        <td class='permission-set-label'><%= link_to permission_set.label, permission_set_path(permission_set)  %></td>
+        <% if can? :edit, permission_set %>
+          <td class='permission-set-label'><%= link_to "Edit", edit_permission_set_path(permission_set)  %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/permission_sets/new.html.erb
+++ b/app/views/permission_sets/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Permission Set</h1>
+
+<%= render 'form', permission_set: @permission_set %>
+
+<%= link_to 'Back', permission_sets_path %>

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -142,4 +142,81 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
       end
     end
   end
+
+  context 'Editing and creating Permission Sets' do
+    describe 'editing and creating permission sets as a sysadmin' do
+      before do
+        user.add_role(:sysadmin)
+      end
+      it 'can be viewed' do
+        visit '/permission_sets'
+        expect(page).to have_content("Create New Permission Set")
+        expect(page).to have_link("Edit", count: 2)
+        expect(page).to have_content("Edit", count: 3)
+      end
+      it 'can be accessed' do
+        visit "/permission_sets/#{permission_set.id}/edit"
+        expect(page).to have_content("Editing Permission Set")
+      end
+      it 'can be created' do
+        visit "/permission_sets/new"
+        expect(page).to have_content("New Permission Set")
+        fill_in('permission_set_key', with: 'key example')
+        fill_in('permission_set_label', with: 'label example')
+        fill_in('permission_set_max_queue_length', with: '10')
+        click_on 'Create Permission Set'
+        expect(page).to have_content("Permission set was successfully created.")
+        expect(page).to have_content("key example")
+        expect(page).to have_content("label example")
+      end
+    end
+
+    describe 'editing and creating permission sets as an administrator' do
+      before do
+        login_as administrator_user
+        permission_set.add_administrator(administrator_user)
+      end
+      it 'can be viewed' do
+        visit '/permission_sets'
+        expect(page).to have_content("Create New Permission Set")
+        expect(page).to have_link("Edit")
+        expect(page).to have_content("Edit").twice
+      end
+      it 'can be accessed' do
+        visit "/permission_sets/#{permission_set.id}/edit"
+        expect(page).to have_content("Editing Permission Set")
+      end
+      it 'can be created' do
+        visit "/permission_sets/new"
+        expect(page).to have_content("New Permission Set")
+        fill_in('permission_set_key', with: 'key example')
+        fill_in('permission_set_label', with: 'label example')
+        fill_in('permission_set_max_queue_length', with: '10')
+        click_on 'Create Permission Set'
+        expect(page).to have_content("Permission set was successfully created.")
+        expect(page).to have_content("key example")
+        expect(page).to have_content("label example")
+      end
+    end
+
+    describe 'editing and creating permission sets as an approver' do
+      before do
+        login_as approver_user
+        permission_set.add_approver(approver_user)
+      end
+      it 'cannot be viewed' do
+        visit '/permission_sets'
+        expect(page).not_to have_content("Create New Permission Set")
+        expect(page).not_to have_link("Edit")
+      end
+      it 'cannot be accessed' do
+        visit "/permission_sets/#{permission_set.id}/edit"
+        expect(page).to have_content("Access denied")
+      end
+      it 'cannot be created' do
+        visit "/permission_sets/new"
+        expect(page).to have_content("Access denied")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary  
Created the "new" form for creating permission sets. This form can only be accessed by sysadmins and permission set administrators.  
Added "Edit" links to the permission set index page. Edit links are only visible by sysadmin and administrator roles.  
Added a "Create new Permission Set" button on the index page thats only visible to sysadmin and administrator roles.  
Permission Set showpage displays all approvers and administrators for that specific permission set.  
  
## Ticket  
#2226  
  
## Screenshots  
New Permission Set form:  
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/24666568/195441639-ea2abc2c-c43e-4252-9edd-a6ac944880a9.png">  
  
Permission Set Index w/ Create new Permission Set button and Edit links next to each permission set:  
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/24666568/195441816-b899d5f7-d882-4a1d-a669-5012e7c5a477.png">
  
Edit Permission Set:  
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/24666568/195441885-1e1b0edb-6e5e-4311-a655-eb30bf20f2fb.png">

  
 