### PR TITLE
Batch process update child objects

### DIFF
--- a/app/jobs/update_child_objects_job.rb
+++ b/app/jobs/update_child_objects_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UpdateChildObjectsJob < ApplicationJob
+  queue_as :default
+
+  discard_on StandardError, Net::OpenTimeout
+
+  def default_priority
+    50
+  end
+
+  def perform(batch_process)
+    batch_process.update_child_objects_caption
+  end
+end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -25,7 +25,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   # LISTS AVAILABLE BATCH ACTIONS
   def self.batch_actions
-    ['create parent objects', 'update parent objects', 'delete parent objects', 'delete child objects', 'export all parent objects by admin set',
+    ['create parent objects', 'update parent objects', 'update child objects caption and label', 'delete parent objects', 'delete child objects', 'export all parent objects by admin set',
      'export child oids', 'reassociate child oids', 'recreate child oid ptiffs', 'update fulltext status', 'resync with preservica']
   end
 
@@ -151,6 +151,8 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         CreateChildOidCsvJob.perform_later(self)
       when 'update parent objects'
         UpdateParentObjectsJob.perform_later(self)
+      when 'update child objects caption and label'
+        UpdateChildObjectsJob.perform_later(self)
       when 'reassociate child oids'
         ReassociateChildOidsJob.perform_later(self)
       when 'recreate child oid ptiffs'

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -46,8 +46,8 @@ module Updatable
       parent_object = child_object.parent_object
       po_arr << parent_object
       attach_item(parent_object)
-      child_object.caption = row['caption']
-      child_object.label = row['label']
+      child_object.caption = row['caption'] unless row['caption'].nil?
+      child_object.label = row['label'] unless row['label'].nil?
       child_object.save!
       processing_event_for_child(child_object)
     end

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -32,6 +32,10 @@ module Updatable
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def update_child_objects_caption
     return unless batch_action == "update child objects caption and label"
     po_arr = []
@@ -47,17 +51,13 @@ module Updatable
       child_object.save!
       processing_event_for_child(child_object)
     end
-    unique_po = po_arr.uniq{ |x| x.oid }
-    unique_po.each do |parent_object| 
+    unique_po = po_arr.uniq(&:oid)
+    unique_po.each do |parent_object|
       trigger_setup_metadata(parent_object)
       processing_event_for_parent(parent_object)
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def update_parent_objects
     self.admin_set = ''
     sets = admin_set

--- a/public/batch_processes/templates/update_child_objects_caption_and_label.csv
+++ b/public/batch_processes/templates/update_child_objects_caption_and_label.csv
@@ -1,0 +1,1 @@
+oid,label,caption

--- a/spec/fixtures/csv/update_child_object_caption.csv
+++ b/spec/fixtures/csv/update_child_object_caption.csv
@@ -1,0 +1,4 @@
+oid,caption,label
+10736292,caption 2,label 2
+67890,new caption,new label
+12,another caption,another label

--- a/spec/models/batch_process_update_child_objects_spec.rb
+++ b/spec/models/batch_process_update_child_objects_spec.rb
@@ -51,15 +51,15 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
         expect(child_object_3.label).to eq "co3 label"
         batch_process.file = csv_upload
         batch_process.save
-        updated_child_object = ChildObject.find(10736292)
-        updated_child_object_2 = ChildObject.find(67890)
-        updated_child_object_3 = ChildObject.find(12)
+        updated_child_object = ChildObject.find(10_736_292)
+        updated_child_object_two = ChildObject.find(67_890)
+        updated_child_object_three = ChildObject.find(12)
         expect(updated_child_object.caption).to eq "caption 2"
         expect(updated_child_object.label).to eq "label 2"
-        expect(updated_child_object_2.caption).to eq "new caption"
-        expect(updated_child_object_2.label).to eq "new label"
-        expect(updated_child_object_3.caption).to eq "another caption"
-        expect(updated_child_object_3.label).to eq "another label"
+        expect(updated_child_object_two.caption).to eq "new caption"
+        expect(updated_child_object_two.label).to eq "new label"
+        expect(updated_child_object_three.caption).to eq "another caption"
+        expect(updated_child_object_three.label).to eq "another label"
       end
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
 
     with_versioning do
       it "can't update child objects based on csv import" do
-        child_object = ChildObject.find(10736292)
+        child_object = ChildObject.find(10_736_292)
         expect(child_object.caption).to eq "caption"
         expect(child_object.label).to eq "label"
       end

--- a/spec/models/batch_process_update_child_objects_spec.rb
+++ b/spec/models/batch_process_update_child_objects_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
+  subject(:batch_process) { described_class.new(batch_action: "update child objects caption and label") }
+  let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:role) { FactoryBot.create(:role, name: editor) }
+  let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "update_child_object_caption.csv")) }
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
+  let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
+  let(:child_object_2) { FactoryBot.create(:child_object, oid: "67890", caption: "co2 caption", label: "co2 label", parent_object: parent_object_2) }
+  let(:child_object_3) { FactoryBot.create(:child_object, oid: "12", caption: "co3 caption", label: "co3 label", parent_object: parent_object_2) }
+  let(:child_object) { FactoryBot.create(:child_object, caption: "caption", label: "label", parent_object: parent_object) }
+
+  around do |example|
+    perform_enqueued_jobs do
+      original_path_ocr = ENV['OCR_DOWNLOAD_BUCKET']
+      ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
+      example.run
+      ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
+    end
+  end
+
+  before do
+    stub_metadata_cloud("2002826")
+    stub_metadata_cloud("2004548")
+    stub_ptiffs_and_manifests
+    parent_object
+    parent_object_2
+    child_object
+    child_object_2
+    child_object_3
+    login_as(:user)
+  end
+
+  describe "updating child object as a user with an editor role" do
+    before do
+      user.add_role(:editor, admin_set)
+      batch_process.user_id = user.id
+    end
+
+    with_versioning do
+      it "can update child and parent object relationships based on csv import" do
+        expect(child_object.caption).to eq "caption"
+        expect(child_object.label).to eq "label"
+        expect(child_object_2.caption).to eq "co2 caption"
+        expect(child_object_2.label).to eq "co2 label"
+        expect(child_object_3.caption).to eq "co3 caption"
+        expect(child_object_3.label).to eq "co3 label"
+        batch_process.file = csv_upload
+        batch_process.save
+        updated_child_object = ChildObject.find(10736292)
+        updated_child_object_2 = ChildObject.find(67890)
+        updated_child_object_3 = ChildObject.find(12)
+        expect(updated_child_object.caption).to eq "caption 2"
+        expect(updated_child_object.label).to eq "label 2"
+        expect(updated_child_object_2.caption).to eq "new caption"
+        expect(updated_child_object_2.label).to eq "new label"
+        expect(updated_child_object_3.caption).to eq "another caption"
+        expect(updated_child_object_3.label).to eq "another label"
+      end
+    end
+  end
+
+  describe "reassociation as a user without an editor role" do
+    before do
+      user.add_role(:viewer, admin_set)
+      batch_process.user_id = user.id
+      batch_process.file = csv_upload
+      batch_process.save
+    end
+
+    with_versioning do
+      it "can't update child objects based on csv import" do
+        child_object = ChildObject.find(10736292)
+        expect(child_object.caption).to eq "caption"
+        expect(child_object.label).to eq "label"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary  
Adds the ability to use batch process to update a child  objects caption and label.  
  
## Ticket  
#2234  
  
