### PR TITLE
Adds admin set to update child objects batch process table

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -38,6 +38,8 @@ module Updatable
   # rubocop:disable Metrics/MethodLength
   def update_child_objects_caption
     return unless batch_action == "update child objects caption and label"
+    self.admin_set = ''
+    sets = admin_set
     po_arr = []
     parsed_csv.each_with_index do |row, index|
       oid = row['oid'] unless ['oid'].nil?
@@ -46,6 +48,10 @@ module Updatable
       parent_object = child_object.parent_object
       po_arr << parent_object
       attach_item(parent_object)
+      sets << ', ' + parent_object.admin_set.key
+      split_sets = sets.split(',').uniq.reject(&:blank?)
+      self.admin_set = split_sets.join(', ')
+      save!
       child_object.caption = row['caption'] unless row['caption'].nil?
       child_object.label = row['label'] unless row['label'].nil?
       child_object.save!


### PR DESCRIPTION
## Summary  
"Update Child Objects Caption and Label" Batch Process now records the parent objects admin sets on the Batch Process detail page.  
  
## Ticket  
#2234  
  
## Screenshot:  
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/24666568/197625935-6ff0570b-fcdd-4868-909f-bb760b3262f6.png">
