### PR TITLE
Adds ability to add and remove user roles to permission sets

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -29,7 +29,7 @@ class RolesController < ApplicationController
   private
 
     def verify_user
-      authorize!(current_ability, :manage, @item) unless current_user.has_role? :sysadmin
+      authorize!(current_ability, :manage, @item) unless current_user.has_role?(:sysadmin) || current_user.has_role?(:administrator, @item)
     end
 
     def set_user

--- a/app/views/permission_sets/show.html.erb
+++ b/app/views/permission_sets/show.html.erb
@@ -24,7 +24,7 @@
   <tbody>
     <% User.with_role(:approver, @permission_set).order('last_name ASC').each do |user| %>
       <tr>
-        <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %></td>
+        <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %><%= link_to 'X', remove_roles_path(uid: user.uid, item_class: 'PermissionSet', item_id: @permission_set.id, role: :approver), method: :delete unless current_user.has_role?(:approver, @permission_set)%></td>
       </tr>
     <% end %>
   </tbody>
@@ -39,11 +39,15 @@
   <tbody>
     <% User.with_role(:administrator, @permission_set).order('last_name ASC').each do |user| %>
         <tr>
-          <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %></td>
+          <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %><%= link_to 'X', remove_roles_path(uid: user.uid, item_class: 'PermissionSet', item_id: @permission_set.id, role: :administrator), method: :delete unless current_user.has_role?(:approver, @permission_set)%></td>
         </tr>
     <% end %>
   </tbody>
 </table>
+
+<% if can? :edit, @permission_set %>
+  <%= render partial: 'shared/add_role', locals: {item: @permission_set} %>
+<% end %>
 
 <br />
 <% if can? :edit, @permission_set %>

--- a/app/views/shared/_add_role.html.erb
+++ b/app/views/shared/_add_role.html.erb
@@ -2,7 +2,7 @@
   <p>Add</p>
   <%= text_field_tag(:uid, "", required: true, class: 'form-control', placeholder: 'NetID') %>
   <p>as</p>
-  <%= select_tag(:role, options_for_select(['viewer', 'editor']), { :class => 'form-control', required: true }) %>
+  <%= select_tag(:role, options_for_select(item == @admin_set ? ['viewer', 'editor'] : ['approver', 'administrator']), { :class => 'form-control', required: true }) %>
   <%= hidden_field_tag :item_class, item.class.to_s %>
   <%= hidden_field_tag :item_id, item.id %>
   <div class='actions'>

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
       end
       it 'can add and remove user roles to permission set' do
         visit "/permission_sets/#{permission_set.id}/"
-        fill_in('uid', with: "#{user_2.uid}")
+        fill_in('uid', with: user_2.uid.to_s)
         click_on 'Save'
         expect(page).to have_content("User: #{user_2.uid} added as approver")
         all('a', text: 'X')[0].click
@@ -199,7 +199,7 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
       end
       it 'can add and remove user roles to permission set' do
         visit "/permission_sets/#{permission_set.id}/"
-        fill_in('uid', with: "#{user.uid}")
+        fill_in('uid', with: user.uid.to_s)
         click_on 'Save'
         expect(page).to have_content("User: #{user.uid} added as approver")
         all('a', text: 'X')[0].click

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
   end
 
   context 'Editing and creating Permission Sets' do
-    describe 'editing and creating permission sets as a sysadmin' do
+    describe 'editing, creating, and adding/removing user roles to permission sets as a sysadmin' do
       before do
         user_2
         user.add_role(:sysadmin)

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:user) }
+  let(:user_2) { FactoryBot.create(:user) }
   let(:approver_user) { FactoryBot.create(:user) }
-  let(:administrator_user) { FactoryBot.create(:user) }
+  let(:administrator_user) { FactoryBot.create(:user, uid: 'admin') }
   let(:permission_set) { FactoryBot.create(:permission_set, label: "set 1") }
   let(:permission_set_2) { FactoryBot.create(:permission_set, label: "set 2") }
 
@@ -146,6 +147,7 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
   context 'Editing and creating Permission Sets' do
     describe 'editing and creating permission sets as a sysadmin' do
       before do
+        user_2
         user.add_role(:sysadmin)
       end
       it 'can be viewed' do
@@ -169,11 +171,20 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
         expect(page).to have_content("key example")
         expect(page).to have_content("label example")
       end
+      it 'can add and remove user roles to permission set' do
+        visit "/permission_sets/#{permission_set.id}/"
+        fill_in('uid', with: "#{user_2.uid}")
+        click_on 'Save'
+        expect(page).to have_content("User: #{user_2.uid} added as approver")
+        all('a', text: 'X')[0].click
+        expect(page).to have_content("User: #{user_2.uid} removed as approver")
+      end
     end
 
-    describe 'editing and creating permission sets as an administrator' do
+    describe 'editing, creating, and adding/removing user roles to permission sets as an administrator' do
       before do
         login_as administrator_user
+        user
         permission_set.add_administrator(administrator_user)
       end
       it 'can be viewed' do
@@ -185,6 +196,14 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
       it 'can be accessed' do
         visit "/permission_sets/#{permission_set.id}/edit"
         expect(page).to have_content("Editing Permission Set")
+      end
+      it 'can add and remove user roles to permission set' do
+        visit "/permission_sets/#{permission_set.id}/"
+        fill_in('uid', with: "#{user.uid}")
+        click_on 'Save'
+        expect(page).to have_content("User: #{user.uid} added as approver")
+        all('a', text: 'X')[0].click
+        expect(page).to have_content("User: #{user.uid} removed as approver")
       end
       it 'can be created' do
         visit "/permission_sets/new"
@@ -201,13 +220,22 @@ RSpec.describe "PermissionSets", type: :system, prep_metadata_sources: true do
 
     describe 'editing and creating permission sets as an approver' do
       before do
+        administrator_user
         login_as approver_user
         permission_set.add_approver(approver_user)
+        permission_set.add_administrator(administrator_user)
       end
       it 'cannot be viewed' do
         visit '/permission_sets'
         expect(page).not_to have_content("Create New Permission Set")
         expect(page).not_to have_link("Edit")
+      end
+      it 'cannot remove or add users from a permission set' do
+        visit "/permission_sets/#{permission_set.id}"
+        expect(page).to have_content("(admin)")
+        expect(page).not_to have_link("X")
+        expect(page).not_to have_content("NetID")
+        expect(page).not_to have_content("Save")
       end
       it 'cannot be accessed' do
         visit "/permission_sets/#{permission_set.id}/edit"


### PR DESCRIPTION
## Summary  
Adds the ability to add and remove users to a permission set. Sysadmins can add/remove to any permission set. Administrators can only add/remove to permission sets they are administrators for.  
  
## Ticket  
[#2263](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2263)
  
## Screenshot  
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/24666568/199571814-84cb113e-e73a-4b50-ae94-6ee2c8863e2f.png">
  
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/24666568/199571867-3fc6b00b-e56d-4246-922f-dfb68955f037.png">
