### PR TITLE
Repairs specs broken in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           POSTGRES_PASSWORD: password
       - image: seleniarm/standalone-chromium:latest
         name: chrome    
-    parallelism: 4
+    parallelism: 5
     executor: docker/docker
     steps:
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           POSTGRES_PASSWORD: password
       - image: seleniarm/standalone-chromium:latest
         name: chrome    
-    parallelism: 5
+    parallelism: 4
     executor: docker/docker
     steps:
       - setup_remote_docker

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-Webdrivers.cache_time = 3
+# TODO  Webdrivers.cache_time = 3
 Capybara.default_max_wait_time = 8
 Capybara.default_driver = :rack_test
 
@@ -9,7 +9,7 @@ ENV['WEB_HOST'] ||= `hostname -s`.strip
 
 capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
   chromeOptions: {
-    args: %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
+    args: %w[disable-gpu headless no-sandbox whitelisted-ips window-size=1400,1400]
   }
 )
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -13,9 +13,15 @@ capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
   }
 )
 
+options = Selenium::WebDriver::Chrome::Options.new(args: ["headless"])
+options.add_argument(
+  "--enable-features=NetworkService,NetworkServiceInProcess"
+)
+
 Capybara.register_driver :chrome do |app|
   d = Capybara::Selenium::Driver.new(app,
                                      browser: :remote,
+                                     options: options,
                                      desired_capabilities: capabilities,
                                      url: "http://chrome:4444/wd/hub")
   # Fix for capybara vs remote files. Selenium handles this for us

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # TODO  Webdrivers.cache_time = 3
-Capybara.default_max_wait_time = 8
+Capybara.default_max_wait_time = 10
 Capybara.default_driver = :rack_test
 
 # Setup chrome headless driver
@@ -41,28 +41,5 @@ RSpec.configure do |config|
     # rails system specs reset app_host each time so needs to be forced on each test
     Capybara.app_host = "http://#{ENV['WEB_HOST']}:#{Capybara.server_port}"
     driven_by :chrome
-  end
-end
-
-# @TODO Remove this Monkey Patch after issue is resolved with running Chrome 74 in
-#       headless mode: https://github.com/teamcapybara/capybara/issues/2181
-module Selenium
-  module WebDriver
-    class Options
-      # capybara/rspec installs a RSpec callback that runs after each test and resets
-      # the session - part of which is deleting all cookies. However the call to Chrome
-      # Webdriver to delete all cookies in Chrome 74 hangs when run in headless mode
-      # (the reasons for which are still unknown).
-      #
-      # Fortunately, the call to set a cookie is still functioning and we can rely
-      # on expired cookies being cleared by Chrome, so we iterate over all current
-      # cookies and set their expiry date to some time in the past - effectively
-      # deleting them.
-      def delete_all_cookies
-        all_cookies.each do |cookie|
-          add_cookie(name: cookie[:name], value: '', expires: Time.zone.now - 1.second)
-        end
-      end
-    end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # TODO  Webdrivers.cache_time = 3
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 8
 Capybara.default_driver = :rack_test
 
 # Setup chrome headless driver
@@ -9,7 +9,7 @@ ENV['WEB_HOST'] ||= `hostname -s`.strip
 
 capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
   chromeOptions: {
-    args: %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
+    args: %w[headless enable-features=NetworkService,NetworkServiceInProcess disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
   }
 )
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,7 +9,7 @@ ENV['WEB_HOST'] ||= `hostname -s`.strip
 
 capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
   chromeOptions: {
-    args: %w[disable-gpu headless no-sandbox whitelisted-ips window-size=1400,1400]
+    args: %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
   }
 )
 
@@ -29,7 +29,7 @@ Capybara.server_host = '0.0.0.0'
 Capybara.server_port = 3007
 Capybara.always_include_port = true
 Capybara.app_host = "http://#{ENV['WEB_HOST']}:#{Capybara.server_port}"
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :chrome
 
 # Setup rspec
 RSpec.configure do |config|

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# TODO  Webdrivers.cache_time = 3
+Webdrivers.cache_time = 3
 Capybara.default_max_wait_time = 8
 Capybara.default_driver = :rack_test
 
@@ -15,7 +15,7 @@ capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
 
 Capybara.register_driver :chrome do |app|
   d = Capybara::Selenium::Driver.new(app,
-                                     browser: :chrome,
+                                     browser: :remote,
                                      desired_capabilities: capabilities,
                                      url: "http://chrome:4444/wd/hub")
   # Fix for capybara vs remote files. Selenium handles this for us
@@ -29,7 +29,7 @@ Capybara.server_host = '0.0.0.0'
 Capybara.server_port = 3007
 Capybara.always_include_port = true
 Capybara.app_host = "http://#{ENV['WEB_HOST']}:#{Capybara.server_port}"
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :chrome
 
 # Setup rspec
 RSpec.configure do |config|

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -13,15 +13,9 @@ capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
   }
 )
 
-options = Selenium::WebDriver::Chrome::Options.new(args: ["headless"])
-options.add_argument(
-  "--enable-features=NetworkService,NetworkServiceInProcess"
-)
-
 Capybara.register_driver :chrome do |app|
   d = Capybara::Selenium::Driver.new(app,
                                      browser: :remote,
-                                     options: options,
                                      desired_capabilities: capabilities,
                                      url: "http://chrome:4444/wd/hub")
   # Fix for capybara vs remote files. Selenium handles this for us
@@ -47,5 +41,28 @@ RSpec.configure do |config|
     # rails system specs reset app_host each time so needs to be forced on each test
     Capybara.app_host = "http://#{ENV['WEB_HOST']}:#{Capybara.server_port}"
     driven_by :chrome
+  end
+end
+
+# @TODO Remove this Monkey Patch after issue is resolved with running Chrome 74 in
+#       headless mode: https://github.com/teamcapybara/capybara/issues/2181
+module Selenium
+  module WebDriver
+    class Options
+      # capybara/rspec installs a RSpec callback that runs after each test and resets
+      # the session - part of which is deleting all cookies. However the call to Chrome
+      # Webdriver to delete all cookies in Chrome 74 hangs when run in headless mode
+      # (the reasons for which are still unknown).
+      #
+      # Fortunately, the call to set a cookie is still functioning and we can rely
+      # on expired cookies being cleared by Chrome, so we iterate over all current
+      # cookies and set their expiry date to some time in the past - effectively
+      # deleting them.
+      def delete_all_cookies
+        all_cookies.each do |cookie|
+          add_cookie(name: cookie[:name], value: '', expires: Time.zone.now - 1.second)
+        end
+      end
+    end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -15,7 +15,7 @@ capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
 
 Capybara.register_driver :chrome do |app|
   d = Capybara::Selenium::Driver.new(app,
-                                     browser: :remote,
+                                     browser: :chrome,
                                      desired_capabilities: capabilities,
                                      url: "http://chrome:4444/wd/hub")
   # Fix for capybara vs remote files. Selenium handles this for us

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -29,7 +29,7 @@ Capybara.server_host = '0.0.0.0'
 Capybara.server_port = 3007
 Capybara.always_include_port = true
 Capybara.app_host = "http://#{ENV['WEB_HOST']}:#{Capybara.server_port}"
-Capybara.javascript_driver = :chrome
+Capybara.javascript_driver = :headless_chrome
 
 # Setup rspec
 RSpec.configure do |config|


### PR DESCRIPTION
# Summary
Specs that pass locally are failing in CI.  This MR aims to repair the broken test suite.

# Related Ticket
[#2278](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2278)