### PR TITLE
Redirect dropdown option

### DIFF
--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -64,10 +64,17 @@
       <%= form.select(:authoritative_metadata_source_id, [['Ladybird', 1], ['Voyager', 2], ['ArchiveSpace', 3]]) %>
     </div>
 
-    <div class="col-med-3">
-      <%= form.label :visibility %>
-      <%= form.select(:visibility, ParentObject.visibilities) %>
-    </div>
+    <% if parent_object.child_object_ids.count == 0 %>
+      <div class="col-med-3">
+        <%= form.label :visibility %>
+        <%= form.select(:visibility, ParentObject.visibilities) %>
+      </div>
+    <% else %>
+      <div class="col-med-3">
+        <%= form.label :visibility %>
+        <%= form.select(:visibility, ["Private", "Public", "Yale Community Only"]) %>
+      </div>
+    <% end %>
   </div>
   <br>
 


### PR DESCRIPTION
## Summary  
Users are no longer able to select "Redirect" visibility from the Visibility dropdown if the parent object has children.  
  
## Ticket  
[2312](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2312)  
  
## Screenshots  
Without Child Objects:  
<img width="844" alt="image" src="https://user-images.githubusercontent.com/24666568/206249265-a63f9b0f-92e7-48fe-b62d-9d899ed75f06.png">  
  
With child objects:  
<img width="748" alt="image" src="https://user-images.githubusercontent.com/24666568/206249361-a3fbcd33-c722-4ac8-bf54-46ce51c2c89d.png">

