### PR TITLE
Creates API call to save original to S3 job

### DIFF
--- a/app/controllers/api/download_controller.rb
+++ b/app/controllers/api/download_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Api::DownloadController < ApplicationController
+
+  def stage
+    request = params
+    begin
+      child_object = ChildObject.find(request['oid'].to_i)
+    rescue ActiveRecord::RecordNotFound
+      render(json: { "title": "Invalid Child OID" }, status: 400) && (return false)
+    end
+    return unless check_child_visibility(child_object)
+    SaveOriginalToS3Job.perform(child_object.oid)
+  end
+
+
+  def check_child_visibility(child_object)
+    if child_object.parent_object.visibility != "Yale Community Only" || child_object.parent_object.visibility != "Public"
+      render(json: { "title": "Child Object is restricted." }, status: 403) && (return false)
+    end
+    true
+  end
+end

--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -14,7 +14,8 @@ class DownloadOriginalController < ApplicationController
   end
 
   def check_child_visibility(child_object)
-    render(json: { "title": "Child Object is restricted." }, status: 403) && (return false) if child_object.parent_object.visibility == "Private" || child_object.parent_object.visibility == "Redirect"
+    render(json: { "title": "Child Object is restricted." }, status: 403) && (return false) unless
+    child_object.parent_object.visibility == "Public" || child_object.parent_object.visibility == "Yale Community Only"
     true
   end
 

--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -2,7 +2,6 @@
 
 class DownloadOriginalController < ApplicationController
   def stage
-    byebug
     request = params
     begin
       child_object = ChildObject.find(request['oid'].to_i)
@@ -14,11 +13,8 @@ class DownloadOriginalController < ApplicationController
     render(json: { "title": "Child object staged for download." }, status: 200)
   end
 
-
   def check_child_visibility(child_object)
-    if child_object.parent_object.visibility == "Private" || child_object.parent_object.visibility == "Redirect"
-      render(json: { "title": "Child Object is restricted." }, status: 403) && (return false)
-    end
+    render(json: { "title": "Child Object is restricted." }, status: 403) && (return false) if child_object.parent_object.visibility == "Private" || child_object.parent_object.visibility == "Redirect"
     true
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resources :permission_requests, only: [:create]
   end
 
+  get '/api/download/stage/child/:oid', to: 'download#stage'
+
   get '/show_token', to: 'users#show_token', as: :show_token
   get '/update_token', to: 'manifest#update_token', as: :update_token
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resources :permission_requests, only: [:create]
   end
 
-  get '/api/download/stage/child/:oid', to: 'download#stage'
+  get '/api/download/stage/child/:oid', to: 'download_original#stage'
 
   get '/show_token', to: 'users#show_token', as: :show_token
   get '/update_token', to: 'manifest#update_token', as: :update_token

--- a/spec/requests/download_original_spec.rb
+++ b/spec/requests/download_original_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Download Original API', type: :request, prep_metadata_sources: true, prep_admin_sets: true do
+  let(:user) { FactoryBot.create(:sysadmin_user) }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:oid) { 2_034_600 }
+  let(:oid_2) { 17_105_661 }
+  let(:parent) { FactoryBot.create(:parent_object, oid: oid, admin_set: admin_set, visibility: 'Yale Community Only') }
+  let(:parent_2) { FactoryBot.create(:parent_object, oid: oid_2, admin_set: admin_set, visibility: 'Private') }
+  let(:child_object) { FactoryBot.create(:child_object, oid: '123456', parent_object: parent) }
+  let(:child_object_2) { FactoryBot.create(:child_object, oid: '2345678', parent_object: parent_2) }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  around do |example|
+    original_image_bucket = ENV['S3_SOURCE_BUCKET_NAME']
+    original_download_bucket = ENV['S3_DOWNLOAD_BUCKET_NAME']
+    original_access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
+    ENV['S3_SOURCE_BUCKET_NAME'] = 'not-a-real-bucket'
+    ENV['S3_DOWNLOAD_BUCKET_NAME'] = 'fake-download-bucket'
+    ENV["ACCESS_MASTER_MOUNT"] = File.join(fixture_path, "images/ptiff_images")
+    example.run
+    ENV['S3_SOURCE_BUCKET_NAME'] = original_image_bucket
+    ENV['S3_DOWNLOAD_BUCKET_NAME'] = original_download_bucket
+    ENV["ACCESS_MASTER_MOUNT"] = original_access_master_mount
+  end
+
+  before do
+    stub_metadata_cloud(oid)
+    stub_metadata_cloud(oid_2)
+    stub_request(:head, 'https://fake-download-bucket.s3.amazonaws.com/download/tiff/56/12/34/56/123456.tif')
+        .to_return(status: 200, body: '', headers: {})
+    parent
+    parent_2
+    child_object
+    child_object_2
+    login_as user
+    user.add_role(:editor, admin_set)
+  end
+
+  describe 'POST /api/download/stage/child/:oid' do
+    it 'creates a new job to copy to s3' do
+      expect do
+        get "/api/download/stage/child/#{child_object.oid}", params: {oid: child_object.oid}, headers: headers
+      end.to change {Delayed::Job.count}.by(1)
+      # expect(SaveOriginalToS3Job).to receive(:perform_later).once
+      # expect(response).to have_http_status(:ok) # 200
+    end
+
+    it 'errors if object is not YCO or Public' do
+      get "/api/download/stage/child/#{child_object_2.oid}", params: {oid: child_object_2.oid}, headers: headers
+      expect(SaveOriginalToS3Job).not_to receive(:perform_later)
+      expect(response).to have_http_status(:forbidden) # 403
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Sets up an API that when called will trigger the job to save an original to S3.

# Related Ticket
[#2321](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2321)