### PR TITLE
Removes batch process and batch connection from Update IIIF Manifest Job

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -77,20 +77,6 @@ class BatchProcessesController < ApplicationController
     CreateParentOidCsvJob.perform_later(batch_process, *admin_set_id)
   end
 
-  def update_manifests
-    admin_set_id = params.dig(:admin_set_id)
-    admin_set = AdminSet.find(admin_set_id)
-    if current_user.viewer(admin_set) || current_user.editor(admin_set)
-      redirect_to admin_set_path(admin_set_id), notice: "IIIF Manifests queued for update. Please check Batch Process for status."
-    else
-      redirect_to admin_set_path(admin_set), alert: "User does not have permission to update Admin Set."
-      return false
-    end
-    batch_process = BatchProcess.new(batch_action: 'update parent objects', user: current_user)
-    batch_process.save!
-    UpdateManifestsJob.perform_later(0, admin_set_id, batch_process)
-  end
-
   def download_csv
     # Add BOM to force Excel to open correctly
     send_data "\xEF\xBB\xBF" + @batch_process.csv,

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -3,7 +3,7 @@
 class ParentObjectsController < ApplicationController
   before_action :set_parent_object, only: [:show, :edit, :update, :destroy, :update_metadata, :select_thumbnail, :solr_document]
   before_action :set_paper_trail_whodunnit
-  load_and_authorize_resource except: [:solr_document, :new, :create, :update_metadata, :all_metadata, :reindex, :select_thumbnail]
+  load_and_authorize_resource except: [:solr_document, :new, :create, :update_metadata, :all_metadata, :reindex, :select_thumbnail, :update_manifests]
 
   # GET /parent_objects
   # GET /parent_objects.json
@@ -141,12 +141,12 @@ class ParentObjectsController < ApplicationController
     admin_set_id = params.dig(:admin_set_id)
     admin_set = AdminSet.find(admin_set_id)
     if current_user.viewer(admin_set) || current_user.editor(admin_set)
+      UpdateManifestsJob.perform_later(admin_set_id)
       redirect_to admin_set_path(admin_set_id), notice: "IIIF Manifests queued for update. Please check Batch Process for status."
     else
       redirect_to admin_set_path(admin_set), alert: "User does not have permission to update Admin Set."
       return false
     end
-    UpdateManifestsJob.perform_later(admin_set_id)
   end
 
   def sync_from_preservica

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -142,7 +142,7 @@ class ParentObjectsController < ApplicationController
     admin_set = AdminSet.find(admin_set_id)
     if current_user.viewer(admin_set) || current_user.editor(admin_set)
       UpdateManifestsJob.perform_later(admin_set_id)
-      redirect_to admin_set_path(admin_set_id), notice: "IIIF Manifests queued for update. Please check Batch Process for status."
+      redirect_to admin_set_path(admin_set_id), notice: "IIIF Manifests queued for update."
     else
       redirect_to admin_set_path(admin_set), alert: "User does not have permission to update Admin Set."
       return false

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -137,6 +137,18 @@ class ParentObjectsController < ApplicationController
     end
   end
 
+  def update_manifests
+    admin_set_id = params.dig(:admin_set_id)
+    admin_set = AdminSet.find(admin_set_id)
+    if current_user.viewer(admin_set) || current_user.editor(admin_set)
+      redirect_to admin_set_path(admin_set_id), notice: "IIIF Manifests queued for update. Please check Batch Process for status."
+    else
+      redirect_to admin_set_path(admin_set), alert: "User does not have permission to update Admin Set."
+      return false
+    end
+    UpdateManifestsJob.perform_later(admin_set_id)
+  end
+
   def sync_from_preservica
     queue_parent_sync_from_preservica
     respond_to do |format|

--- a/app/jobs/update_manifests_job.rb
+++ b/app/jobs/update_manifests_job.rb
@@ -8,16 +8,15 @@ class UpdateManifestsJob < ApplicationJob
   end
 
   # rubocop:disable Style/OptionalArguments
-  def perform(start_position = 0, admin_set_id, batch_process)
+  def perform(admin_set_id, start_position = 0)
     visibilities = ["Public", "Yale Community Only"]
     parent_objects = ParentObject.where(admin_set_id: admin_set_id, visibility: visibilities).where.not(child_object_count: 0).order(:oid).offset(start_position).limit(UpdateManifestsJob.job_limit)
     last_job = parent_objects.count < UpdateManifestsJob.job_limit
     return unless parent_objects.count.positive? # stop if nothing is found
     parent_objects.each do |po|
-      po.current_batch_connection = batch_process&.batch_connections&.find_or_create_by(connectable: po)
-      GenerateManifestJob.perform_later(po, batch_process, po.current_batch_connection)
+      GenerateManifestJob.perform_later(po)
     end
-    UpdateManifestsJob.perform_later(start_position + parent_objects.count, admin_set_id) unless last_job
+    UpdateManifestsJob.perform_later(admin_set_id, start_position + parent_objects.count) unless last_job
   end
   # rubocop:enable Style/OptionalArguments
 end

--- a/app/views/admin_sets/show.html.erb
+++ b/app/views/admin_sets/show.html.erb
@@ -9,7 +9,7 @@
 <div id="admin_set_button_row">
   <a href="#BatchUpdateMetadata" role="button" class="btn btn-large btn-secondary" data-toggle="modal">Batch Update Metadata</a>
   <%= button_to "Export Parent Objects", export_parent_objects_batch_processes_url(admin_set: @admin_set.key, admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary export_button" %>
-  <%= button_to "Update IIIF Manifests", update_manifests_batch_processes_url(admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary update_manifest" %>
+  <%= button_to "Update IIIF Manifests", update_manifests_parent_objects_url(admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary update_manifest" %>
 </div>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resources :batch_processes do
     collection do
       post :export_parent_objects
-      post :update_manifests
       post :import
       post :trigger_mets_scan
       get :download_template
@@ -35,6 +34,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     collection do
       post :reindex
       post :all_metadata
+      post :update_manifests
     end
     member do
       post :update_metadata

--- a/spec/requests/batch_processes_request_spec.rb
+++ b/spec/requests/batch_processes_request_spec.rb
@@ -21,38 +21,6 @@ RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
     end
   end
 
-  context "Update IIIF Manifests" do
-    before do
-      stub_metadata_cloud("2002826")
-      login_as sysadmin_user
-      admin_set_2
-      admin_set_2.add_editor(sysadmin_user)
-      parent_object
-      parent_object_2
-    end
-
-    around do |example|
-      perform_enqueued_jobs do
-        example.run
-      end
-    end
-
-    describe "with valid attributes" do
-      it "can start the Update Manifests Job" do
-        expect(GenerateManifestJob).to receive(:perform_later).exactly(1).times
-        post update_manifests_batch_processes_url(admin_set_id: admin_set_2.id)
-      end
-    end
-
-    describe "without edit access to admin set" do
-      it "does not queue a iiif manifest update" do
-        admin_set_2.remove_editor(sysadmin_user)
-        expect(GenerateManifestJob).to receive(:perform_later).exactly(0).times
-        post update_manifests_batch_processes_url(admin_set_id: admin_set_2.id)
-      end
-    end
-  end
-
   describe "GET /download with XML" do
     let(:batch_process_xml) do
       FactoryBot.create(

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       visit admin_sets_path
       click_link(admin_set.key.to_s)
       click_on("Update IIIF Manifests")
-      expect(page).to have_content "IIIF Manifests queued for update. Please check Batch Process for status."
+      expect(page).to have_content "IIIF Manifests queued for update."
     end
 
     it 'removes the viewer role from a user when they are given an editor role' do
@@ -231,6 +231,13 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       visit admin_sets_path(admin_set)
       expect(page).to have_content("Access denied")
       expect(page).not_to have_content "Update IIIF Manifests"
+    end
+    it 'cannot update iiif manifests without edit permission' do
+      login_as sysadmin_user
+      visit admin_sets_path
+      click_link(admin_set.key.to_s)
+      click_on("Update IIIF Manifests")
+      expect(page).to have_content "User does not have permission to update Admin Set."
     end
   end
 end

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -75,12 +75,10 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
 
     it 'can update iiif manifests' do
       admin_set.add_editor(sysadmin_user)
-      expect(BatchProcess.count).to eq 0
       visit admin_sets_path
       click_link(admin_set.key.to_s)
       click_on("Update IIIF Manifests")
       expect(page).to have_content "IIIF Manifests queued for update. Please check Batch Process for status."
-      expect(BatchProcess.count).to eq 1
     end
 
     it 'removes the viewer role from a user when they are given an editor role' do
@@ -230,13 +228,9 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       expect(page).to have_content("Access denied")
     end
     it 'cannot update iiif manifests' do
-      login_as sysadmin_user
-      expect(BatchProcess.count).to eq 0
-      visit admin_sets_path
-      click_link(admin_set.key.to_s)
-      click_on("Update IIIF Manifests")
-      expect(page).to have_content "User does not have permission to update Admin Set."
-      expect(BatchProcess.count).to eq 0
+      visit admin_sets_path(admin_set)
+      expect(page).to have_content("Access denied")
+      expect(page).not_to have_content "Update IIIF Manifests"
     end
   end
 end


### PR DESCRIPTION
# Summary
Refactor of feature to update IIIF manifests.  No longer uses batch process or batch connection in the job.

# Related Ticket
[#2347](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2347)