### PR TITLE
Increase delayed jobs max_run_time

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -6,7 +6,7 @@
 #   import: { priority: 20}
 # }
 Delayed::Worker.destroy_failed_jobs = false
-Delayed::Worker.max_run_time = 2.hours
+Delayed::Worker.max_run_time = 4.hours
 Delayed::Worker.default_queue_name = :default
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.logger = Rails.logger


### PR DESCRIPTION
attempt to fix timeout error on large PDF generation jobs. Will revert back to 2.hours if the job continues to time out at 4 hours