### PR TITLE
Updates param for congruency

### DIFF
--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -4,7 +4,7 @@ class DownloadOriginalController < ApplicationController
   def stage
     request = params
     begin
-      child_object = ChildObject.find(request['oid'].to_i)
+      child_object = ChildObject.find(request['child_oid'].to_i)
     rescue ActiveRecord::RecordNotFound
       render(json: { "title": "Invalid Child OID" }, status: 400) && (return false)
     end


### PR DESCRIPTION
# Summary
In blacklight the param is called 'child_oid' but in management it was only 'oid' so this MR updates the param to be called the same thing in both repositories.

# Related Ticket
[#2331](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2331)