### PR TITLE
Adds PermissionSetTerm model and supporting methods

### DIFF
--- a/app/models/permission_set.rb
+++ b/app/models/permission_set.rb
@@ -2,6 +2,7 @@
 class PermissionSet < ApplicationRecord
   has_many :permission_requests
   has_many :parent_objects
+  has_many :permission_set_terms
   resourcify
   validates :key, presence: true
   validates :label, presence: true
@@ -22,5 +23,20 @@ class PermissionSet < ApplicationRecord
 
   def remove_administrator(user)
     user.remove_role(:administrator, self)
+  end
+
+  def active_permission_set_terms
+    permission_set_terms.find_by('not(permission_set_terms.activated_at is null) and (permission_set_terms.inactivated_at is null)')
+  end
+
+  def inactivate_terms_by!(user)
+    active_permission_set_terms&.inactivate_by!(user)
+    save!
+  end
+
+  def activate_terms!(user, title, body)
+    new_terms = PermissionSetTerm.create!(permission_set: self, title: title, body: body)
+    new_terms.activate_by!(user)
+    new_terms
   end
 end

--- a/app/models/permission_set_term.rb
+++ b/app/models/permission_set_term.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class PermissionSetTerm < ApplicationRecord
+  belongs_to :permission_set
+  belongs_to :inactivated_by, foreign_key: 'inactivated_by_id', primary_key: 'id', class_name: 'User', optional: true
+  belongs_to :activated_by, foreign_key: 'activated_by_id', primary_key: 'id', class_name: 'User', optional: true
+
+  attr_readonly :title, :body
+
+  def activate_by!(user)
+    raise "Unable to activate previously activated permission set" unless activated_at.nil?
+    raise "User cannot be nil" unless user
+    PermissionSetTerm.transaction do
+      time = Time.zone.now
+      prior_active_terms = permission_set.active_permission_set_terms
+      if prior_active_terms && prior_active_terms != self
+        prior_active_terms.inactivated_by = user
+        prior_active_terms.inactivated_at = time
+        prior_active_terms.save!
+      end
+      self.activated_by = user
+      self.activated_at = time
+      save!
+    end
+  end
+
+  def inactivate_by!(user)
+    raise "Unable to inactivate inactivated permission set" unless activated_at
+    raise "Unable to inactivate previously inactivated permission set" unless inactivated_at.nil?
+    raise "User cannot be nil" unless user
+    self.inactivated_by = user
+    self.inactivated_at = Time.zone.now
+    save!
+  end
+end

--- a/app/views/permission_sets/index.html.erb
+++ b/app/views/permission_sets/index.html.erb
@@ -20,6 +20,8 @@
     <tr>
       <th scope='col'> Key </th>
       <th scope='col'> Label </th>
+      <th scope='col'> Terms Title </th>
+      <th scope='col'> Terms Activated </th>
       <th scope='col'> Edit </th>
     </tr>
   </thead>
@@ -28,6 +30,8 @@
       <tr>
         <td class='permission-set-label'><%= permission_set.key %></td>
         <td class='permission-set-label'><%= link_to permission_set.label, permission_set_path(permission_set)  %></td>
+        <td class='permission-set-label'><%= permission_set.active_permission_set_terms&.title || "None"  %></td>
+        <td class='permission-set-label'><%= permission_set.active_permission_set_terms&.activated_by.uid || "n/a"  %></td>
         <% if can? :edit, permission_set %>
           <td class='permission-set-label'><%= link_to "Edit", edit_permission_set_path(permission_set)  %></td>
         <% end %>

--- a/app/views/permission_sets/index.html.erb
+++ b/app/views/permission_sets/index.html.erb
@@ -31,7 +31,7 @@
         <td class='permission-set-label'><%= permission_set.key %></td>
         <td class='permission-set-label'><%= link_to permission_set.label, permission_set_path(permission_set)  %></td>
         <td class='permission-set-label'><%= permission_set.active_permission_set_terms&.title || "None"  %></td>
-        <td class='permission-set-label'><%= permission_set.active_permission_set_terms&.activated_by.uid || "n/a"  %></td>
+        <td class='permission-set-label'><%= permission_set.active_permission_set_terms&.activated_by&.uid || "n/a"  %></td>
         <% if can? :edit, permission_set %>
           <td class='permission-set-label'><%= link_to "Edit", edit_permission_set_path(permission_set)  %></td>
         <% end %>

--- a/db/migrate/20230126211951_create_permission_set_terms.rb
+++ b/db/migrate/20230126211951_create_permission_set_terms.rb
@@ -1,0 +1,14 @@
+class CreatePermissionSetTerms < ActiveRecord::Migration[6.0]
+  def change
+    create_table :permission_set_terms do |t|
+      t.integer :permission_set_id, foreign_key: true
+      t.integer :activated_by_id, foreign_key: true
+      t.timestamp :activated_at
+      t.integer :inactivated_by_id, foreign_key: true
+      t.timestamp :inactivated_at
+      t.string :title
+      t.text :body
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_01_212207) do
+ActiveRecord::Schema.define(version: 2023_01_26_211951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,6 +228,18 @@ ActiveRecord::Schema.define(version: 2022_12_01_212207) do
     t.index ["permission_request_user_id"], name: "index_permission_requests_on_permission_request_user_id"
     t.index ["permission_set_id"], name: "index_permission_requests_on_permission_set_id"
     t.index ["user_id"], name: "index_permission_requests_on_user_id"
+  end
+
+  create_table "permission_set_terms", force: :cascade do |t|
+    t.integer "permission_set_id"
+    t.integer "activated_by_id"
+    t.datetime "activated_at"
+    t.integer "inactivated_by_id"
+    t.datetime "inactivated_at"
+    t.string "title"
+    t.text "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "permission_sets", force: :cascade do |t|

--- a/spec/factories/permission_set_terms.rb
+++ b/spec/factories/permission_set_terms.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :permission_set_term do
+    activated_at { nil }
+    activated_by { nil }
+    inactivated_at { nil }
+    inactivated_by { nil }
+    title { "Permission Set Terms" }
+    body { "These are some terms" }
+  end
+end

--- a/spec/models/permission_set_spec.rb
+++ b/spec/models/permission_set_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe PermissionSet, type: :model do
   let(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
   let(:permission_set) { FactoryBot.create(:permission_set) }
+  let(:permission_set_terms) { FactoryBot.create(:permission_set_term, permission_set: permission_set) }
 
   describe "user permission set roles" do
     it "adds an approver" do
@@ -49,6 +51,63 @@ RSpec.describe PermissionSet, type: :model do
       permission_set.add_administrator(user)
       expect(user.roles.count).to eq(1)
       expect(user.roles.first.name).to eq("administrator")
+    end
+  end
+
+  describe "activate_terms!" do
+    it "creates and sets the active permission set terms" do
+      permission_set.activate_terms!(user, "Test1", "Body1")
+      expect(permission_set.active_permission_set_terms.title).to eq "Test1"
+      expect(permission_set.active_permission_set_terms.body).to eq "Body1"
+    end
+
+    it "deactivates prior active terms" do
+      permission_set_terms.activate_by!(user)
+      expect(permission_set.active_permission_set_terms).to eq permission_set_terms
+      expect(permission_set_terms.inactivated_at).to eq nil
+      new_permission_set_terms = permission_set.activate_terms!(user2, "Test1", "Body1")
+      expect(permission_set.active_permission_set_terms).to eq new_permission_set_terms
+      permission_set_terms.reload
+      expect(permission_set_terms.inactivated_at).not_to be nil
+      expect(permission_set_terms.inactivated_by).to eq user2
+    end
+  end
+
+  describe "active_permission_set_terms" do
+    it "is nil when there are none" do
+      expect(permission_set.active_permission_set_terms).to eq nil
+    end
+
+    it "is nil when none are activated" do
+      permission_set_terms.activated_at = nil
+      permission_set_terms.save!
+      permission_set.reload
+      expect(permission_set.active_permission_set_terms).to eq nil
+    end
+
+    it "is the terms when one is activated" do
+      permission_set_terms.activate_by!(user)
+      permission_set_terms.save!
+      permission_set.reload
+      expect(permission_set.active_permission_set_terms).to eq permission_set_terms
+    end
+
+    it "is nil after deactivation" do
+      permission_set_terms.activate_by!(user)
+      permission_set_terms.save!
+      permission_set.reload
+      expect(permission_set.active_permission_set_terms).to eq permission_set_terms
+      permission_set.inactivate_terms_by!(user)
+      expect(permission_set.active_permission_set_terms).to eq nil
+    end
+
+    it "is nil when they are all inactive" do
+      permission_set_terms.activate_by!(user)
+      permission_set.reload
+      expect(permission_set.active_permission_set_terms).to eq permission_set_terms
+      permission_set_terms.inactivate_by!(user)
+      permission_set.reload
+      expect(permission_set.active_permission_set_terms).to eq nil
     end
   end
 

--- a/spec/models/permission_set_term_spec.rb
+++ b/spec/models/permission_set_term_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PermissionSetTerm, type: :model do
+  let(:user) { FactoryBot.create(:user, id: 33) }
+  let(:permission_set) { FactoryBot.create(:permission_set) }
+  let(:permission_set_terms) { FactoryBot.create(:permission_set_term, permission_set: permission_set) }
+  let(:permission_set_terms2) { FactoryBot.create(:permission_set_term, permission_set: permission_set) }
+
+  it "exists" do
+    expect(described_class).to be_a(Class)
+  end
+
+  it "sets the activate date when activated" do
+    expect(permission_set_terms.activated_at).to be nil
+    permission_set_terms.activate_by!(user)
+    expect(permission_set_terms.activated_at).not_to be nil
+  end
+
+  it "sets the inactivate date when inactivated" do
+    expect(permission_set_terms.inactivated_at).to be nil
+    permission_set_terms.activate_by!(user)
+    permission_set_terms.inactivate_by!(user)
+    expect(permission_set_terms.inactivated_at).not_to be nil
+  end
+
+  it "deactivates prior terms when a new terms is activated" do
+    permission_set_terms.activate_by!(user)
+    expect(permission_set_terms.inactivated_at).to be nil
+    expect(permission_set_terms.activated_at).not_to be nil
+    expect(permission_set_terms2.activated_at).to be nil
+    permission_set_terms2.activate_by!(user)
+    permission_set_terms.reload
+    expect(permission_set_terms.inactivated_at).not_to be nil
+    expect(permission_set_terms2.activated_at).not_to be nil
+  end
+
+  it "has readonly body" do
+    permission_set_terms
+    old_body = permission_set_terms.body
+    permission_set_terms.body = "Test2"
+    permission_set_terms.save!
+    permission_set_terms.reload
+    expect(permission_set_terms.body).to eq old_body
+  end
+
+  it "has readonly title" do
+    permission_set_terms
+    old_title = permission_set_terms.title
+    permission_set_terms.title = "Test2 Title"
+    permission_set_terms.save!
+    permission_set_terms.reload
+    expect(permission_set_terms.title).to eq old_title
+  end
+
+  it "raises an error when activating an already activated permission_set_terms" do
+    permission_set_terms.activate_by!(user)
+    expect do
+      permission_set_terms.activate_by!(user)
+    end.to raise_error("Unable to activate previously activated permission set")
+  end
+
+  it "raises an error when inactivating an already inactivated permission_set_terms" do
+    permission_set_terms.activate_by!(user)
+    permission_set_terms.inactivate_by!(user)
+    expect do
+      permission_set_terms.inactivate_by!(user)
+    end.to raise_error("Unable to inactivate previously inactivated permission set")
+  end
+
+  it "raises an error when inactivating a permission_set_terms that was never activated" do
+    expect do
+      permission_set_terms.inactivate_by!(user)
+    end.to raise_error("Unable to inactivate inactivated permission set")
+  end
+end


### PR DESCRIPTION
- Adds new model with relationships: `PermissionSetTerm`
- Adds `PermissionSet.activate_terms!(user,title,body)` to create and activate new terms
- Adds `PermissionSet.inactivate_terms!(user)` to deactivate the active terms
- Adds `PermissionSet.active_permission_set_terms` to get the active terms

(Some preliminary work is included for displaying terms on the PermissionSet terms page because it made it easier to do manual testing.)