### PR TITLE
Skips auth check for action

### DIFF
--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DownloadOriginalController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def stage
     request = params
     begin


### PR DESCRIPTION
# Summary
Access will be restricted to cluster so this removes the authorization check before a call is submitted.

# Related Ticket
[#2331](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2331)