### PR TITLE
Changed wording of extent_of_digitization

### DIFF
--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -65,7 +65,7 @@ class ParentObjectDatatable < ApplicationDatatable
         last_aspace_update: parent_object.last_aspace_update,
         last_id_update: parent_object.last_id_update,
         visibility: parent_object.visibility,
-        extent_of_digitization: parent_object.extent_of_digitization,
+        extent_of_digitization: digitization(parent_object),
         digitization_note: parent_object.digitization_note,
         digitization_funding_source: parent_object.digitization_funding_source,
         DT_RowId: parent_object.oid,
@@ -74,6 +74,16 @@ class ParentObjectDatatable < ApplicationDatatable
     end
   end
   # rubocop:enable Rails/OutputSafety,Metrics/MethodLength
+
+  def digitization(parent_object)
+    if parent_object.extent_of_digitization == "Completely digitized"
+      "This object has been completely digitized."
+    elsif parent_object.extent_of_digitization == "Partially digitized"
+      "This object has been partially digitized."
+    else
+      parent_object.extent_of_digitization
+    end
+  end
 
   def oid_column(parent_object)
     result = []

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -92,8 +92,14 @@
   <dd><%= sanitize @parent_object.rights_statement, tags: %w(a), attributes: %w(href) %></dd>
 
   <dt>Extent of Digitization:</dt>
-  <dd><%= @parent_object.extent_of_digitization %></dd>
-
+  <% if @parent_object.extent_of_digitization == "Completely digitized" %>
+    <dd>This object has been completely digitized.</dd>
+  <% elsif @parent_object.extent_of_digitization == "Partially digitized" %>
+    <dd>This object has been partially digitized.</dd>
+  <% else %>
+    <dd><%= @parent_object.extent_of_digitization %></dd>
+  <% end %>
+  
   <dt>Digitization Note:</dt>
   <dd><%= @parent_object.digitization_note %></dd>
 

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       click_on("Edit")
       page.select("Partially digitized", from: "Extent of digitization")
       click_on("Save Parent Object And Update Metadata")
-      expect(page).to have_content("Partially digitized")
+      expect(page).to have_content("This object has been partially digitized")
     end
   end
 


### PR DESCRIPTION
## Summary  
Parent Objects extend_of_digitization has been updated to now read "This object has been completely digitized." and "This object has been partially digitized."  
This change applies to the Parent Object showpage and datatable.  
  
## Ticket  
[2335](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2335)  
  
## Screenshots:  
<img width="1774" alt="image" src="https://user-images.githubusercontent.com/24666568/216132097-dff9b4f9-c719-4e14-b074-3ff1a18e1c11.png">
  
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/24666568/216132209-54a4e394-201e-4f4c-8f7b-79eaeb015a8d.png">
