### PR TITLE
Create form for permission set terms and conditions

### DIFF
--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class PermissionSetsController < ApplicationController
-  load_and_authorize_resource except: [:permission_set_terms]
-  before_action :set_permission_set, only: [:show, :edit, :update, :destroy, :permission_set_terms]
+  load_and_authorize_resource except: [:permission_set_terms, :new_term, :post_permission_set_terms]
+  before_action :set_permission_set, only: [:show, :edit, :update, :destroy, :permission_set_terms, :post_permission_set_terms, :new_term]
 
   # GET /permission_sets
   # GET /permission_sets.json
@@ -58,6 +58,16 @@ class PermissionSetsController < ApplicationController
     end
   end
 
+  def new_term
+    authorize!(:update, @permission_set)
+  end
+
+  def post_permission_set_terms
+    authorize!(:update, @permission_set)
+    @permission_set.activate_terms!(current_user, params[:title], params[:body])
+    redirect_to permission_set_terms_permission_set_url(@permission_set)
+  end
+
   private
 
     # Use callbacks to share common setup or constraints between actions.
@@ -67,6 +77,6 @@ class PermissionSetsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def permission_set_params
-      params.require(:permission_set).permit(:key, :label, :max_queue_length)
+      params.require(:permission_set).permit(:key, :label, :max_queue_length, permission_set_terms_attributes: [:id, :title, :body])
     end
 end

--- a/app/views/permission_sets/new_term.html.erb
+++ b/app/views/permission_sets/new_term.html.erb
@@ -1,0 +1,22 @@
+<p>
+  <h2>Terms and Conditions for <%= @permission_set.label %></h2>
+</p>
+
+<%= form_with url: "post_permission_set_terms", method: :post do |form| %>
+    <div class="field form-group">
+      <%= form.label :title %>
+      <%= form.text_field(:title, required: true, class: "form-control") %>
+    </div>
+
+    <div class="field form-group">
+      <%= form.label :body %>
+      <%= form.text_area(:body, required: true, class: "form-control") %>
+    </div>
+  <div class="actions">
+    <br />
+    <%= form.submit("Create Terms and Conditions", data: (@permission_set.permission_set_terms&.last&.activated_at.present?  ?  { confirm:  "Create new Terms and Conditions? This will replace the existing terms."} : { confirm:  "Create new Terms and Conditions? Users will be required to agree to these terms."}), class: "btn-primary btn") %>
+    <br />
+    <br />
+    <%= link_to 'Back', permission_sets_path(@permission_set) %>
+  </div>
+<% end %>

--- a/app/views/permission_sets/terms.html.erb
+++ b/app/views/permission_sets/terms.html.erb
@@ -30,7 +30,7 @@
 <div class="permission-set-actions">
 <h3>Actions</h3>
 <div class="row">
-  <div class="col btn-width"><%= button_to "Create", "/", method: :get, class: "btn btn-large btn-secondary" %></div>
+  <div class="col btn-width"><%= button_to "Create", 'new_term', method: :get, class: "btn btn-large btn-secondary" %></div>
   <div class="col">Create a new version. The new version will become active and all users of content in this Permission Set will be required to agree to the new Terms and Conditions</div>
 </div>
 <% if @permission_set.active_permission_set_terms %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resources :admin_sets
   resources :permission_sets do
     get 'permission_set_terms', on: :member
+    get 'new_term', on: :member
+    post 'post_permission_set_terms', on: :member
   end
   resources :permission_requests
   resources :preservica_ingests

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
 
       it "show page displays None" do
         visit "/permission_sets/#{permission_set.id}"
-        expect(page).to have_content("Key: Permission Key")
+        expect(page).to have_content(sets)
         within(permission_set_terms_element) do
           expect(page).to have_content("None")
         end

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true, js: true do
+RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
   let(:user) { FactoryBot.create(:user) }
   let(:user_2) { FactoryBot.create(:user) }
   let(:approver_user) { FactoryBot.create(:user) }
@@ -415,14 +415,7 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true, js:
         fill_in('Title', with: "Title")
         fill_in('Body', with: "Body")
         click_on "Create Terms and Conditions"
-        expect(page.driver.browser.switch_to.alert.text).to eq("Create new Terms and Conditions? Users will be required to agree to these terms.")
-        page.driver.browser.switch_to.alert.accept
         expect(page).to have_content("ACTIVE")
-        visit "permission_sets/#{permission_set.id}/new_term"
-        fill_in('Title', with: "Title")
-        fill_in('Body', with: "Body")
-        click_on "Create Terms and Conditions"
-        expect(page.driver.browser.switch_to.alert.text).to eq("Create new Terms and Conditions? This will replace the existing terms.")
       end
 
       it "cannot create a new term if not an administrator" do


### PR DESCRIPTION
## Summary  
Adds the Create Terms and Conditions form for permission sets.  
  
## Ticket  
[2370](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2370)  
  
## Screenshots:  
<img width="1781" alt="image" src="https://user-images.githubusercontent.com/24666568/217100426-3b248849-2891-4ab1-878f-f54681ef1744.png">
  
Confirmation when no existing T&C present:  
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/24666568/217100542-e1a7c509-07fd-4e06-a961-8083804b5b84.png">
  
Confirmation when overriding existing T&C:  
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/24666568/217100650-db881f3d-b02f-4a23-a576-4ce765302136.png">
