### PR TITLE
Remove T&C and set Inactive

### DIFF
--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class PermissionSetsController < ApplicationController
-  load_and_authorize_resource except: [:permission_set_terms, :new_term, :post_permission_set_terms]
-  before_action :set_permission_set, only: [:show, :edit, :update, :destroy, :permission_set_terms, :post_permission_set_terms, :new_term]
+  load_and_authorize_resource except: [:permission_set_terms, :new_term, :post_permission_set_terms, :deactivate_permission_set_terms]
+  before_action :set_permission_set, only: [:show, :edit, :update, :destroy, :permission_set_terms, :post_permission_set_terms, :new_term, :deactivate_permission_set_terms]
 
   # GET /permission_sets
   # GET /permission_sets.json
@@ -65,6 +65,12 @@ class PermissionSetsController < ApplicationController
   def post_permission_set_terms
     authorize!(:update, @permission_set)
     @permission_set.activate_terms!(current_user, params[:title], params[:body])
+    redirect_to permission_set_terms_permission_set_url(@permission_set)
+  end
+
+  def deactivate_permission_set_terms
+    authorize!(:update, @permission_set)
+    @permission_set.inactivate_terms_by!(current_user)
     redirect_to permission_set_terms_permission_set_url(@permission_set)
   end
 

--- a/app/views/permission_sets/terms.html.erb
+++ b/app/views/permission_sets/terms.html.erb
@@ -35,7 +35,7 @@
 </div>
 <% if @permission_set.active_permission_set_terms %>
 <div class="row">
-  <div class="col btn-width"><%= button_to "Remove", "/", method: :get, class: "btn btn-large btn-secondary" %></div>
+  <div class="col btn-width"><%= button_to "Remove", deactivate_permission_set_terms_permission_set_path, method: :post, data: {confirm: "Are you sure you want to deactivate the active Terms and Conditions?"}, class: "btn btn-large btn-secondary" %></div>
   <div class="col">Remove the requirement for users to agree to the Terms and Conditions when accessing content in this Permission Set.</div>
 </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     get 'permission_set_terms', on: :member
     get 'new_term', on: :member
     post 'post_permission_set_terms', on: :member
+    post 'deactivate_permission_set_terms', on: :member
   end
   resources :permission_requests
   resources :preservica_ingests

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -427,6 +427,16 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
         expect(page).to have_content("Active Version")
       end
 
+      it "can deactivate a current term and condition" do
+        login_as administrator_user
+        term
+        permission_set.add_administrator(administrator_user)
+        visit "permission_sets/#{permission_set.id}/permission_set_terms/"
+        expect(page).to have_content("Remove")
+        click_button "Remove"
+        expect(page).not_to have_content("Remove")
+      end
+
       it "cannot create a new term if not an administrator" do
         login_as user
         visit "permission_sets/#{permission_set.id}/new_term"


### PR DESCRIPTION
## Summary  
Clicking "Remove" on terms and conditions inactivates the current active term and condition  
  
## Ticket  
[2358](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2358)

## Screenshots  
  
When clicking "Remove":  
<img width="1779" alt="image" src="https://user-images.githubusercontent.com/24666568/217652818-4991fd75-def8-45c3-86a0-2f8cdf162c42.png">
  
After Removing ("Remove" button no longer visible and Active Version set to None):  
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/24666568/217652893-c8ae568b-08d2-4000-949e-2055945b8436.png">
