### PR TITLE
Active Permission Set Terms API

### DIFF
--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -77,7 +77,7 @@ class PermissionSetsController < ApplicationController
     end
     # check for terms on set
     if permission_set.permission_set_terms.blank? || permission_set.permission_set_terms.last.inactivated_at.present?
-      render(json: { }, status: 204)
+      render(json: {}, status: 204)
     else
       term = permission_set.permission_set_terms.last
       active_term = term.slice(:id, :title, :body)

--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -76,10 +76,10 @@ class PermissionSetsController < ApplicationController
       render(json: { "title": "Permission Set not found" }, status: 400) && (return false)
     end
     # check for terms on set
-    if permission_set.permission_set_terms.blank? || permission_set.permission_set_terms.last.inactivated_at.present?
+    if permission_set.permission_set_terms.blank? || !permission_set.active_permission_set_terms
       render(json: {}, status: 204)
     else
-      term = permission_set.permission_set_terms.last
+      term = permission_set.active_permission_set_terms
       active_term = term.slice(:id, :title, :body)
       render json: active_term.to_json
     end

--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -77,7 +77,7 @@ class PermissionSetsController < ApplicationController
     end
     # check for terms on set
     if permission_set.permission_set_terms.blank? || permission_set.permission_set_terms.last.inactivated_at.present?
-      render(json: { "title": "Permission Set does not have any active terms and conditions" }, status: 200)
+      render(json: { }, status: 204)
     else
       term = permission_set.permission_set_terms.last
       active_term = term.slice(:id, :title, :body)

--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -76,18 +76,12 @@ class PermissionSetsController < ApplicationController
       render(json: { "title": "Permission Set not found" }, status: 400) && (return false)
     end
     # check for terms on set
-    if permission_set.permission_set_terms.blank?
-      render(json: { "title": "Permission Set does not have any terms and conditions" }, status: 200)
+    if permission_set.permission_set_terms.blank? || permission_set.permission_set_terms.last.inactivated_at.present?
+      render(json: { "title": "Permission Set does not have any active terms and conditions" }, status: 200)
     else
       term = permission_set.permission_set_terms.last
-      # check for active term
-      if term.inactivated_at.present?
-        render(json: { "title": "This permission set does not have any active Terms and Conditions" }, status: 200)
-      else
-        # render current active term
-        term.slice(:id, :title, :body)
-        render json: term.to_json
-      end
+      active_term = term.slice(:id, :title, :body)
+      render json: active_term.to_json
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   get 'api/oid/new(/:number)', to: 'oid_minter#generate_oids', as: :new_oid
 
+  get 'api/permission_sets/:id/terms', to: 'permission_sets#terms_api', as: :terms_api
+
   namespace :api do
     resources :permission_requests, only: [:create]
   end

--- a/spec/requests/permission_set_spec.rb
+++ b/spec/requests/permission_set_spec.rb
@@ -69,8 +69,7 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
     end
     it 'can display terms not found' do
       get terms_api_path(permission_set_2)
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq("{\"title\":\"Permission Set does not have any active terms and conditions\"}")
+      expect(response).to have_http_status(204)
     end
     it 'displays permission set not found' do
       get terms_api_path(12)
@@ -79,8 +78,7 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
     end
     it 'displays permission set without an active term and condition' do
       get terms_api_path(permission_set_3)
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq("{\"title\":\"Permission Set does not have any active terms and conditions\"}")
+      expect(response).to have_http_status(204)
     end
   end
 end

--- a/spec/requests/permission_set_spec.rb
+++ b/spec/requests/permission_set_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
   let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
   let(:permission_set_2) { FactoryBot.create(:permission_set, label: 'set 2') }
   let(:permission_set_3) { FactoryBot.create(:permission_set, label: 'set 3') }
-  let(:terms) { FactoryBot.create(:permission_set_term, permission_set_id: permission_set.id) }
+  let(:terms) { FactoryBot.create(:permission_set_term, activated_at: Time.zone.now, permission_set_id: permission_set.id) }
   let(:terms_2) { FactoryBot.create(:permission_set_term, inactivated_at: Time.zone.now, permission_set_id: permission_set_3.id) }
 
   before do

--- a/spec/requests/permission_set_spec.rb
+++ b/spec/requests/permission_set_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
     it 'can display terms not found' do
       get terms_api_path(permission_set_2)
       expect(response).to have_http_status(200)
-      expect(response.body).to eq("{\"title\":\"Permission Set does not have any terms and conditions\"}")
+      expect(response.body).to eq("{\"title\":\"Permission Set does not have any active terms and conditions\"}")
     end
     it 'displays permission set not found' do
       get terms_api_path(12)
@@ -80,7 +80,7 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
     it 'displays permission set without an active term and condition' do
       get terms_api_path(permission_set_3)
       expect(response).to have_http_status(200)
-      expect(response.body).to eq("{\"title\":\"This permission set does not have any active Terms and Conditions\"}")
+      expect(response.body).to eq("{\"title\":\"Permission Set does not have any terms and conditions\"}")
     end
   end
 end

--- a/spec/requests/permission_set_spec.rb
+++ b/spec/requests/permission_set_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
     it 'displays permission set without an active term and condition' do
       get terms_api_path(permission_set_3)
       expect(response).to have_http_status(200)
-      expect(response.body).to eq("{\"title\":\"Permission Set does not have any terms and conditions\"}")
+      expect(response.body).to eq("{\"title\":\"Permission Set does not have any active terms and conditions\"}")
     end
   end
 end


### PR DESCRIPTION
## Summary  
`/api/permission_sets/:id/terms` returns the active terms and conditions for the permission set.  
  
## Ticket  
[2376](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2376)  
  
## Screenshots:  
  
Active Term:  
<img width="884" alt="image" src="https://user-images.githubusercontent.com/24666568/217964010-7bdfeaeb-6619-4565-b091-793cc723ea5c.png">
  
Invalid Permission Set:  
<img width="722" alt="image" src="https://user-images.githubusercontent.com/24666568/217964061-3eed3fa2-6ffa-4a39-9b40-8fd959d89b92.png">
