### PR TITLE
Back button to Terms page

### DIFF
--- a/app/views/permission_sets/terms.html.erb
+++ b/app/views/permission_sets/terms.html.erb
@@ -39,4 +39,5 @@
   <div class="col">Remove the requirement for users to agree to the Terms and Conditions when accessing content in this Permission Set.</div>
 </div>
 <% end %>
+<%= link_to 'Back', permission_set_path(@permission_set) %>
 </div>

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -360,6 +360,7 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
           within(active_version_element) do
             expect(page).to have_content(terms.activated_at.to_s)
           end
+          expect(page).to have_link("Back")
         end
 
         it "terms page displays None when terms are inactivated" do


### PR DESCRIPTION
## Summary  
"Back" button now present on the terms and conditions showpage  
  
## Ticket  
[2380](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=20514257)  
  
## Screenshot  
<img width="1776" alt="image" src="https://user-images.githubusercontent.com/24666568/220476197-245f26f5-3b00-4d11-b11e-66e501dd8fe7.png">
