### PR TITLE
Alter Create Parent Objects Batch Process

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -206,7 +206,6 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
       else
         oid = row['oid']
         metadata_source = row['source']
-        # How would this work with csv's that only have oid and admin_set? Check if the csv ONLY has oid and admin_set first?
         if metadata_source.blank? && (row.count != 1 && row.count != 2)
           batch_processing_event("Skipping row [#{index + 2}]. Source cannot be blank.", 'Skipped Row')
           next

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -205,9 +205,10 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         end
       else
         oid = row['oid']
+        set = row['admin_set']
         metadata_source = row['source']
-        # How would this work with csv's that only have oid and admin_set? Check if the csv ONLY has oid and admin_set first?
-        if metadata_source.blank? && (row.count != 1 && row.count != 2)
+        # Check if the csv ONLY has oid and admin_set
+        if metadata_source.blank? && (set.present? && oid.present? && row.count > 2)
           batch_processing_event("Skipping row [#{index + 2}]. Source cannot be blank.", 'Skipped Row')
           next
         end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -206,6 +206,11 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
       else
         oid = row['oid']
         metadata_source = row['source']
+        # How would this work with csv's that only have oid and admin_set? Check if the csv ONLY has oid and admin_set first?
+        if metadata_source.blank? && (row.count != 1 && row.count != 2)
+          batch_processing_event("Skipping row [#{index + 2}]. Source cannot be blank.", 'Skipped Row')
+          next
+        end
         model = row['parent_model'] || 'complex'
         admin_set = editable_admin_set(row['admin_set'], oid, index)
         next unless admin_set

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -187,11 +187,12 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable  Metrics/MethodLength
   # rubocop:disable  Metrics/PerceivedComplexity
   # rubocop:disable  Metrics/CyclomaticComplexity
+  # rubocop:disable  Metrics/BlockLength
   def create_new_parent_csv
     self.admin_set = ''
     sets = admin_set
     parsed_csv.each_with_index do |row, index|
-      if row['digital_object_source'].present? && row['preservica_uri'].present?
+      if row['digital_object_source'].present? && row['preservica_uri'].present? && !row['preservica_uri'].blank?
         begin
           parent_object = CsvRowParentService.new(row, index, current_ability, user).parent_object
           setup_for_background_jobs(parent_object, row['source'])
@@ -213,7 +214,12 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         self.admin_set = split_sets.join(', ')
         save!
 
-        parent_object = ParentObject.find_or_initialize_by(oid: oid)
+        if oid.blank?
+          oid = OidMinterService.generate_oids(1)[0]
+          parent_object = ParentObject.new(oid: oid)
+        else
+          parent_object = ParentObject.find_or_initialize_by(oid: oid)
+        end
         # Only runs on newly created parent objects
         unless parent_object.new_record?
           batch_processing_event("Skipping row [#{index + 2}] with existing parent oid: #{oid}", 'Skipped Row')
@@ -237,6 +243,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:enable  Metrics/MethodLength
   # rubocop:enable  Metrics/PerceivedComplexity
   # rubocop:enable  Metrics/CyclomaticComplexity
+  # rubocop:enable  Metrics/BlockLength
 
   # CHECKS TO SEE IF USER HAS ABILITY TO EDIT AN ADMIN SET:
   def editable_admin_set(admin_set_key, oid, index)

--- a/spec/fixtures/aspace/AS-781086.json
+++ b/spec/fixtures/aspace/AS-781086.json
@@ -1,0 +1,81 @@
+{
+  "jsonModelType": "ArchiveSpaceSolrRecord",
+  "source": "aspace",
+  "recordType": "archival_object",
+  "uri": "/aspace/repositories/12/archival_objects/781086",
+  "identifier": "/aspace/repositories/12/archival_objects/781086",
+  "localRecordNumber": "YCAL MSS 42",
+  "callNumber": "YCAL MSS 42",
+  "containerGrouping": "Box 25, folder 787-93",
+  "creator": [
+    "Wharton, Edith, 1862-1937"
+  ],
+  "title": [
+    "Grant, Robert"
+  ],
+  "date": [
+    "1905-39"
+  ],
+  "language": [
+    "English"
+  ],
+  "languageCode": [
+    "eng"
+  ],
+  "description": [
+
+  ],
+  "rights": [
+    "The Edith Wharton Collection is the physical property of the Beinecke Rare Book and Manuscript Library. Literary rights, including coyright, belong to the authors or their legal heirs or assigns. For further information, consult the appropriate curator.",
+    "The materials are open for research."
+  ],
+  "orbisBibId": "3435140",
+  "orbisBarcode": "39002075038423",
+  "findingAid": [
+    "http://hdl.handle.net/10079/fa/beinecke.wharton"
+  ],
+  "dateStructured": [
+    "1905/1939"
+  ],
+  "resourceType": "mixed materials",
+  "provenanceUncontrolled": "The collection was formed from gifts from the Edith Wharton Estate (1938-1939), Gaillard Lapsley (1938-1946), Oscar Lichtenberg (1959-1965), Percy Lubbock (1954), Georges Markow-Totevy (1980), and Louis Auchincloss (?), with smaller bequests from numerous other donors (especially John Hugh Smith and Margaret Chanler) and with purchases with Beinecke funds.",
+  "ancestorTitles": [
+    "Personal Correspondence",
+    "Edith Wharton collection (YCAL MSS 42)",
+    "Beinecke Rare Book and Manuscript Library (BRBL)"
+  ],
+  "ancestorDisplayStrings": [
+    "Series II: Personal Correspondence, Dates 1885-1937",
+    "Edith Wharton collection",
+    "Beinecke Rare Book and Manuscript Library (BRBL)"
+  ],
+  "ancestorIdentifiers": [
+    "/aspace/repositories/11/archival_objects/608166",
+    "/aspace/repositories/11/resources/1575",
+    "/aspace/repositories/11"
+  ],
+  "repository": "Beinecke Rare Book and Manuscript Library (BRBL)",
+  "createdBeginDate": [
+    "1905"
+  ],
+  "createdEndDate": [
+    "1939"
+  ],
+  "createdEarliestDate": "1905",
+  "archiveSpaceUri": "/repositories/12/archival_objects/781086",
+  "archivalSort": "00001.00038",
+  "dependentUris": [
+    "/aspace/repositories/11/top_containers/72818",
+    "/aspace/repositories/12/archival_objects/781086",
+    "/aspace/agents/people/62209",
+    "/aspace/repositories/11/archival_objects/608166",
+    "/aspace/repositories/11/resources/1575",
+    "/aspace/repositories/11"
+  ],
+  "children": [
+
+  ],
+  "abstract": [
+    "The Edith Wharton Collection consists of manuscripts, correspondence, photographs, and personal papers relating to the life and career of American author Edith Wharton, as well as letters and research material gathered by Gaillard Lapsley, Percy Lubbock, Oscar Lichtenberg, Georges Markow-Totevy, and Louis Auchincloss."
+  ]
+}

--- a/spec/fixtures/csv/parent_no_admin_set.csv
+++ b/spec/fixtures/csv/parent_no_admin_set.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+,,ils,,,,,,,,,

--- a/spec/fixtures/csv/parent_no_oid.csv
+++ b/spec/fixtures/csv/parent_no_oid.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+,jss,aspace,,,,,,,,,

--- a/spec/fixtures/csv/parent_no_source.csv
+++ b/spec/fixtures/csv/parent_no_source.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+,ils,,,,,,,,,,

--- a/spec/fixtures/csv/parent_no_source.csv
+++ b/spec/fixtures/csv/parent_no_source.csv
@@ -1,2 +1,2 @@
 oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
-,ils,,,,,,,,,,
+123,ils,,,,,,,,,,

--- a/spec/fixtures/csv/preservica/preservica_parent_no_admin_set.csv
+++ b/spec/fixtures/csv/preservica/preservica_parent_no_admin_set.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+,,aspace,/repositories/11/archival_objects/515305,36,holding,item,barcode,Public,Preservica,/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5,Preservation

--- a/spec/fixtures/csv/preservica/preservica_parent_no_source.csv
+++ b/spec/fixtures/csv/preservica/preservica_parent_no_source.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+,sml,,/repositories/11/archival_objects/515305,36,holding,item,barcode,Public,Preservica,/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5,Preservation

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.file = no_admin_set
           batch_process.save
         end.not_to change { ParentObject.count }
-        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown admin set [] for parent: 200000000")
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown admin set [] for parent: ")
       end
       it "can fails when csv has no source" do
         expect do

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  subject(:batch_process) { described_class.new }
+  let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:admin_set_one) { FactoryBot.create(:admin_set, key: 'jss') }
+  let(:no_oid_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "parent_no_oid.csv")) }
+
+  around do |example|
+    original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
+    original_access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
+    ENV["S3_SOURCE_BUCKET_NAME"] = "yale-test-image-samples"
+    ENV['ACCESS_MASTER_MOUNT'] = File.join("spec", "fixtures", "images", "access_masters")
+    perform_enqueued_jobs do
+      example.run
+    end
+    ENV["S3_SOURCE_BUCKET_NAME"] = original_image_bucket
+    ENV["ACCESS_MASTER_MOUNT"] = original_access_master_mount
+  end
+
+  before do
+    user.add_role(:editor, admin_set_one)
+    login_as(:user)
+    batch_process.user_id = user.id
+  end
+
+  describe "with the metadata cloud mocked" do
+    before do
+      stub_metadata_cloud("AS-781086", "aspace")
+    end
+
+    context "Create Parent Object batch process with a csv" do
+      it "can create a parent_object" do
+        # byebug
+        expect do
+          batch_process.file = no_oid_parent
+          batch_process.save
+        end.to change { ParentObject.count }.from(0).to(1)
+        po = ParentObject.first
+        expect(po.oid).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
 
   describe "with the metadata cloud mocked" do
     before do
-      # stub_metadata_cloud("AS-781086", "aspace")
+      stub_metadata_cloud("AS-781086", "aspace")
     end
 
     context "Create Parent Object batch process with a csv" do
@@ -40,7 +40,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.save
         end.to change { ParentObject.count }.from(0).to(1)
         po = ParentObject.first
-        byebug
         expect(po.oid).not_to be_nil
       end
       it "can fails when csv has no admin set" do

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -24,13 +24,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     ENV['PRESERVICA_HOST'] = preservica_host
     ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
     ENV['ACCESS_MASTER_MOUNT'] = access_host
-    fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children]
-
-    fixtures.each do |fixture|
-      stub_request(:get, "https://test#{fixture}").to_return(
-        status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
-      )
-    end
   end
 
   before do
@@ -41,6 +34,32 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
+    fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Access
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Preservation
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Access
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Preservation
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Access
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Preservation
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1]
+
+    fixtures.each do |fixture|
+      stub_request(:get, "https://test#{fixture}").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
+      )
+    end
+    stub_preservica_tifs_set_of_three
   end
 
   it 'can send an error when Preservica credentials are not set' do
@@ -63,7 +82,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_no_source
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with no metadata source.")
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown source []. Source must be 'ils' or 'aspace'")
     end.not_to change { ParentObject.count }
   end
 

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     ENV['PRESERVICA_HOST'] = preservica_host
     ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
     ENV['ACCESS_MASTER_MOUNT'] = access_host
+    fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children]
+
+    fixtures.each do |fixture|
+      stub_request(:get, "https://test#{fixture}").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
+      )
+    end
   end
 
   before do

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
   subject(:batch_process) { BatchProcess.new }
   let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl') }
+  let(:sml_admin_set) { FactoryBot.create(:admin_set, key: 'sml') }
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
   let(:preservica_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent.csv")) }
+  let(:preservica_parent_no_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent_no_source.csv")) }
 
   around do |example|
     preservica_host = ENV['PRESERVICA_HOST']
@@ -25,6 +27,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
 
   before do
     user.add_role(:editor, admin_set)
+    user.add_role(:editor, sml_admin_set)
     login_as(:user)
     batch_process.user_id = user.id
     stub_pdfs
@@ -42,5 +45,20 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(batch_process.batch_ingest_events.count).to eq(1)
       expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with admin set [brbl] for parent: 200000000. Preservica credentials not set for brbl.")
     end.not_to change { ParentObject.count }
+  end
+
+  it 'can send an error when no metadata source is set' do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
+    # rubocop:enable RSpec/AnyInstance
+    expect do
+      batch_process.file = preservica_parent_no_source
+      batch_process.save
+      expect(batch_process.batch_ingest_events.count).to eq(1)
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with no metadata source.")
+    end.not_to change { ParentObject.count }
+  end
+
+  it 'can send an error when no admin set is set' do
   end
 end

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
   end
 
+  # around do |example|
+  #   perform_enqueued_jobs do
+  #     example.run
+  #   end
+  # end
+
   before do
     stub_ptiffs_and_manifests
     stub_metadata_cloud("2034600")


### PR DESCRIPTION
# Summary
Confirms expected behavior of 'Create Parent Object' Batch Process and allows for special case creation of OIDs with appropriate csv.

# Related Ticket 
[#2403](https://github.com/yalelibrary/YUL-DC/issues/2403)