### PR TITLE
default visibility to private if not valid visibility

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -79,11 +79,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     [nil, "Completely digitized", "Partially digitized"]
   end
 
-  # validates :visibility, inclusion: { in: visibilities, allow_nil: true,
-  #                                     message: "%{value} is not a valid value" }
-
   def validate_visibility
-    return true if ['Private', 'Public', 'Redirect', 'Yale Community Only'].include?(self.visibility)
+    return true if ['Private', 'Public', 'Redirect', 'Yale Community Only'].include?(visibility)
 
     self.visibility = 'Private'
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -80,7 +80,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def validate_visibility
-    return true if ['Private', 'Public', 'Redirect', 'Yale Community Only'].include?(visibility)
+    return true if ParentObject.visibilities.include?(visibility)
 
     self.visibility = 'Private'
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -38,6 +38,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :redirect_to, format: { with: /\A((http|https):\/\/)?(collections-test.|collections-uat.|collections.)?library.yale.edu\/catalog\//, message: " in incorrect format. Please enter DCS url https://collections.library.yale.edu/catalog/123", presence: true, if: proc { visibility == "Redirect" } }
   # rubocop:enable Metrics/LineLength
   validates :preservica_uri, presence: true, format: { with: %r{\A/}, message: " in incorrect format. URI must start with a /" }, if: proc { digital_object_source == "Preservica" }
+  before_save :validate_visibility
 
   def check_for_redirect
     minify if redirect_to.present?
@@ -78,8 +79,14 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     [nil, "Completely digitized", "Partially digitized"]
   end
 
-  validates :visibility, inclusion: { in: visibilities, allow_nil: true,
-                                      message: "%{value} is not a valid value" }
+  # validates :visibility, inclusion: { in: visibilities, allow_nil: true,
+  #                                     message: "%{value} is not a valid value" }
+
+  def validate_visibility
+    return true if ['Private', 'Public', 'Redirect', 'Yale Community Only'].include?(self.visibility)
+
+    self.visibility = 'Private'
+  end
 
   def initialize(attributes = nil)
     super

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -269,10 +269,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       expect(parent_object_nil.valid?).to eq false
     end
 
-    let(:parent_object_restricted) { described_class.create(visibility: "Restricted Access") }
-    it "other visibility does not validate" do
-      expect(parent_object_restricted.valid?).to eq false
-      expect(parent_object_restricted.visibility).to eq "Restricted Access"
+    let(:parent_object) { described_class.create(oid: 123, admin_set: FactoryBot.create(:admin_set), visibility: "Restricted Access") }
+    it "visibility defaults to Private if not a valid visibility" do
+      expect(parent_object.valid?).to eq true
+      expect(parent_object.visibility).to eq "Private"
     end
 
     let(:parent_object_public) { described_class.create(oid: "2005512", visibility: "Public", admin_set: FactoryBot.create(:admin_set)) }


### PR DESCRIPTION
## Summary  
If an object does not have a valid visibility, default to "Private"  
  
## Screenshots:  
This is the "Open With Permission" visibility object that was failing on create. Object now gets created successfully with a "Private" visibility:  
<img width="1549" alt="image" src="https://user-images.githubusercontent.com/24666568/224857162-d56c8407-cd14-4226-9508-7e6509768212.png">
  
Parent Object Datatable was not counting the child objects because the object was not getting created successfully. Child Object Count is now counted correctly and reflected on the datatable (Object 12479170):  
<img width="1214" alt="image" src="https://user-images.githubusercontent.com/24666568/224857324-cd80cbeb-4147-4a23-be67-bf693e7eefda.png">
