### PR TITLE
Sets up parent object API

### DIFF
--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -2,33 +2,37 @@
 
 class Api::ParentObjectsController < ApplicationController
   skip_before_action :authenticate_user!
-  
+
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def retrieve_metadata
     return unless parent_found
     return unless parent_visibility_valid(@parent_object)
     render json: {
       "dcs": {
-          "oid": "#{@parent_object.oid}",
-          "visibility": "#{@parent_object.visibility}",
-          "metadata_source": metadata_source(@parent_object),
-          "bib":  "#{@parent_object.bib}",
-          "holding":  "#{@parent_object.holding}",
-          "item":  "#{@parent_object.item}",
-          "barcode":  "#{@parent_object.barcode}",
-          "aspace_uri":  "#{@parent_object.aspace_uri}",
-          "admin_set": "#{@parent_object.admin_set.label}",   
-          "child_object_count": "#{@parent_object.child_object_count}",
-          "representative_child_oid": "#{@parent_object.representative_child_oid}",
-          "rights_statement": "#{@parent_object.rights_statement}",
-          "extent_of_digitization": "#{@parent_object.extent_of_digitization}",
-          "digitization_note": "#{@parent_object.digitization_note}",
-          "call_number": "#{@parent_object.call_number}",
-          "container_grouping": "#{@parent_object.container_grouping}",
-          "redirect_to": "#{@parent_object.redirect_to}",
-          "iiif_manifest": "#{ENV['BLACKLIGHT_BASE_URL']}/manifests/#{@parent_object.oid}"  
+        "oid": @parent_object.oid.to_s,
+        "visibility": @parent_object.visibility.to_s,
+        "metadata_source": metadata_source(@parent_object),
+        "bib": @parent_object.bib.to_s,
+        "holding": @parent_object.holding.to_s,
+        "item": @parent_object.item.to_s,
+        "barcode": @parent_object.barcode.to_s,
+        "aspace_uri": @parent_object.aspace_uri.to_s,
+        "admin_set": @parent_object.admin_set.label.to_s,
+        "child_object_count": @parent_object.child_object_count.to_s,
+        "representative_child_oid": @parent_object.representative_child_oid.to_s,
+        "rights_statement": @parent_object.rights_statement.to_s,
+        "extent_of_digitization": @parent_object.extent_of_digitization.to_s,
+        "digitization_note": @parent_object.digitization_note.to_s,
+        "call_number": @parent_object.call_number.to_s,
+        "container_grouping": @parent_object.container_grouping.to_s,
+        "redirect_to": @parent_object.redirect_to.to_s,
+        "iiif_manifest": "#{ENV['BLACKLIGHT_BASE_URL']}/manifests/#{@parent_object.oid}"
       }
-    }
+    }, status: 200
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   def parent_found
     begin
@@ -46,14 +50,10 @@ class Api::ParentObjectsController < ApplicationController
   end
 
   def metadata_source(parent_object)
-    if parent_object.authoritative_metadata_source_id == 1
-      return "ils"
-    elsif parent_object.authoritative_metadata_source_id == 2
-      return "Voyager"
-    elsif parent_object.authoritative_metadata_source_id == 3
-      return "ArchiveSpace"
-    end
-    return "Metadata Source not found"
+    return "ils" if parent_object.authoritative_metadata_source_id == 1
+    return "Voyager" if parent_object.authoritative_metadata_source_id == 2
+    return "ArchiveSpace" if parent_object.authoritative_metadata_source_id == 3
+    "Metadata Source not found"
   end
 
   private
@@ -61,5 +61,4 @@ class Api::ParentObjectsController < ApplicationController
     def parent_object_params
       params.require(:parent_object).permit(:oid)
     end
-
 end

--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -4,46 +4,39 @@ class Api::ParentObjectsController < ApplicationController
   skip_before_action :authenticate_user!
   
   def retrieve_metadata
-    # look for parent
     return unless parent_found
-    # check visibility
-    return unless parent_visibility_valid(parent_object)
-    # return metadata
+    return unless parent_visibility_valid(@parent_object)
     render json: {
       "dcs": {
-          "oid": "123",
-          "visibility": "Public",
-          "metadata_source": "ils",
-          "bib":  ".....",
-          "holding":  ".....",
-          "item":  ".....",
-          "barcode":  ".....",
-          "aspace_uri":  ".....",
-          "admin_set": "Beinecke",   
-          "child_object_count": 43,
-          "representative_child_oid": 123,
-          "rights_statement": "....",
-          "extent_of_digitization": "...",
-          "digitization_note": "...",
-          "call_number": "...",
-          "container_grouping": "...",
-          "redirect_to": "....",
-          # use blacklight base url env var
-          "iiif_manifest": "https://collections-*.library.yale.edu/manifests/123"  
+          "oid": "#{@parent_object.oid}",
+          "visibility": "#{@parent_object.visibility}",
+          "metadata_source": "#{@parent_object.authoritative_metadata_source_id}",
+          "bib":  "#{@parent_object.bib}",
+          "holding":  "#{@parent_object.holding}",
+          "item":  "#{@parent_object.item}",
+          "barcode":  "#{@parent_object.barcode}",
+          "aspace_uri":  "#{@parent_object.aspace_uri}",
+          "admin_set": "#{@parent_object.admin_set.label}",   
+          "child_object_count": "#{@parent_object.child_object_count}",
+          "representative_child_oid": "#{@parent_object.representative_child_oid}",
+          "rights_statement": "#{@parent_object.rights_statement}",
+          "extent_of_digitization": "#{@parent_object.extent_of_digitization}",
+          "digitization_note": "#{@parent_object.digitization_note}",
+          "call_number": "#{@parent_object.call_number}",
+          "container_grouping": "#{@parent_object.container_grouping}",
+          "redirect_to": "#{@parent_object.redirect_to}",
+          "iiif_manifest": "#{ENV['BLACKLIGHT_BASE_URL']}/manifests/#{@parent_object.oid}"  
       }
     }
   end
 
-
-
   def parent_found
     begin
-      parent_object = ParentObject.find(params['oid'].to_i)
+      @parent_object = ParentObject.find(params['oid'].to_i)
     rescue ActiveRecord::RecordNotFound
       render(json: { "title": "Invalid Parent OID" }, status: 404) && (return false)
     end
-    # maybe this should be @parent_object?
-    parent_object
+    @parent_object
   end
 
   def parent_visibility_valid(parent_object)

--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Api::ParentObjectsController < ApplicationController
+  skip_before_action :authenticate_user!
+  
+  def retrieve_metadata
+    # look for parent
+    return unless parent_found
+    # check visibility
+    return unless parent_visibility_valid(parent_object)
+    # return metadata
+    render json: {
+      "dcs": {
+          "oid": "123",
+          "visibility": "Public",
+          "metadata_source": "ils",
+          "bib":  ".....",
+          "holding":  ".....",
+          "item":  ".....",
+          "barcode":  ".....",
+          "aspace_uri":  ".....",
+          "admin_set": "Beinecke",   
+          "child_object_count": 43,
+          "representative_child_oid": 123,
+          "rights_statement": "....",
+          "extent_of_digitization": "...",
+          "digitization_note": "...",
+          "call_number": "...",
+          "container_grouping": "...",
+          "redirect_to": "....",
+          # use blacklight base url env var
+          "iiif_manifest": "https://collections-*.library.yale.edu/manifests/123"  
+      }
+    }
+  end
+
+
+
+  def parent_found
+    begin
+      parent_object = ParentObject.find(params['oid'].to_i)
+    rescue ActiveRecord::RecordNotFound
+      render(json: { "title": "Invalid Parent OID" }, status: 404) && (return false)
+    end
+    # maybe this should be @parent_object?
+    parent_object
+  end
+
+  def parent_visibility_valid(parent_object)
+    render(json: { "title": "Parent Object is restricted." }, status: 403) && (return false) unless
+    parent_object.visibility == "Public" || parent_object.visibility == "Yale Community Only"
+    true
+  end
+
+  private
+
+    def parent_object_params
+      params.require(:parent_object).permit(:oid)
+    end
+
+end

--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -10,7 +10,7 @@ class Api::ParentObjectsController < ApplicationController
       "dcs": {
           "oid": "#{@parent_object.oid}",
           "visibility": "#{@parent_object.visibility}",
-          "metadata_source": "#{@parent_object.authoritative_metadata_source_id}",
+          "metadata_source": metadata_source(@parent_object),
           "bib":  "#{@parent_object.bib}",
           "holding":  "#{@parent_object.holding}",
           "item":  "#{@parent_object.item}",
@@ -43,6 +43,17 @@ class Api::ParentObjectsController < ApplicationController
     render(json: { "title": "Parent Object is restricted." }, status: 403) && (return false) unless
     parent_object.visibility == "Public" || parent_object.visibility == "Yale Community Only"
     true
+  end
+
+  def metadata_source(parent_object)
+    if parent_object.authoritative_metadata_source_id == 1
+      return "ils"
+    elsif parent_object.authoritative_metadata_source_id == 2
+      return "Voyager"
+    elsif parent_object.authoritative_metadata_source_id == 3
+      return "ArchiveSpace"
+    end
+    return "Metadata Source not found"
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   get 'api/oid/new(/:number)', to: 'oid_minter#generate_oids', as: :new_oid
 
+  get 'api/parent/:oid', to: 'api/parent_objects#retrieve_metadata'
+  
   get 'api/permission_sets/:id/terms', to: 'permission_sets#terms_api', as: :terms_api
 
   get 'api/permission_sets/:permission_set_id/permission_set_terms/:permission_set_terms_id/agree/:sub', to: 'permission_sets#agreement_term'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get 'api/oid/new(/:number)', to: 'oid_minter#generate_oids', as: :new_oid
 
   get 'api/parent/:oid', to: 'api/parent_objects#retrieve_metadata'
-  
+
   get 'api/permission_sets/:id/terms', to: 'permission_sets#terms_api', as: :terms_api
 
   get 'api/permission_sets/:permission_set_id/permission_set_terms/:permission_set_terms_id/agree/:sub', to: 'permission_sets#agreement_term'

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, prep_admin_sets: true do
+  let(:valid_attributes) do
+    {
+      oid: "2004628",
+      authoritative_metadata_source_id: 1,
+      admin_set: AdminSet.find_by_key('brbl'),
+      bib: "123"
+    }
+  end
+
+  describe "GET with valid oid" do
+    it "renders a successful response" do
+      ParentObject.create! valid_attributes
+      get "/api/parent/#{valid_attributes[:oid]}"
+      expect(response).to be_successful
+    end
+  end
+
+end

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -45,5 +45,4 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       expect(response.body).to eq("{\"title\":\"Parent Object is restricted.\"}")
     end
   end
-
 end

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -10,12 +10,39 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       bib: "123"
     }
   end
+  let(:invalid_visibility) do
+    {
+      oid: "2000000",
+      authoritative_metadata_source_id: 1,
+      admin_set: AdminSet.find_by_key('brbl'),
+      bib: "123",
+      visibility: "Private"
+    }
+  end
 
+  # This one spec isnt passing for some reason...
   describe "GET with valid oid" do
     it "renders a successful response" do
       ParentObject.create! valid_attributes
       get "/api/parent/#{valid_attributes[:oid]}"
       expect(response).to be_successful
+    end
+  end
+
+  describe "GET with invalid oid" do
+    it "renders a 404 response" do
+      get "/api/parent/12345"
+      expect(response).to have_http_status(404)
+      expect(response.body).to eq("{\"title\":\"Invalid Parent OID\"}")
+    end
+  end
+
+  describe "GET with invalid visibility" do
+    it "renders a 403 response" do
+      ParentObject.create! invalid_visibility
+      get "/api/parent/#{invalid_visibility[:oid]}"
+      expect(response).to have_http_status(403)
+      expect(response.body).to eq("{\"title\":\"Parent Object is restricted.\"}")
     end
   end
 

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -4,46 +4,45 @@ require 'rails_helper'
 RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, prep_admin_sets: true do
   let(:valid_attributes) do
     {
-      oid: "2004628",
+      oid: '2004628',
       authoritative_metadata_source_id: 1,
       admin_set: AdminSet.find_by_key('brbl'),
-      bib: "123"
+      bib: '123',
+      visibility: 'Public'
     }
   end
   let(:invalid_visibility) do
     {
-      oid: "2000000",
+      oid: '2000000',
       authoritative_metadata_source_id: 1,
       admin_set: AdminSet.find_by_key('brbl'),
-      bib: "123",
-      visibility: "Private"
+      bib: '123',
+      visibility: 'Private'
     }
   end
 
-  # This one spec isnt passing for some reason...
-  describe "GET with valid oid" do
-    it "renders a successful response" do
+  describe 'GET with valid oid' do
+    it 'renders a successful response' do
       ParentObject.create! valid_attributes
       get "/api/parent/#{valid_attributes[:oid]}"
-      expect(response).to be_successful
+      expect(response).to have_http_status(200)
     end
   end
 
-  describe "GET with invalid oid" do
-    it "renders a 404 response" do
-      get "/api/parent/12345"
+  describe 'GET with invalid oid' do
+    it 'renders a 404 response' do
+      get '/api/parent/12345'
       expect(response).to have_http_status(404)
       expect(response.body).to eq("{\"title\":\"Invalid Parent OID\"}")
     end
   end
 
-  describe "GET with invalid visibility" do
-    it "renders a 403 response" do
+  describe 'GET with invalid visibility' do
+    it 'renders a 403 response' do
       ParentObject.create! invalid_visibility
       get "/api/parent/#{invalid_visibility[:oid]}"
       expect(response).to have_http_status(403)
       expect(response.body).to eq("{\"title\":\"Parent Object is restricted.\"}")
     end
   end
-
 end


### PR DESCRIPTION
# Summary
Initial response for API to retrieve parent object metadata for QuickSearch.

# Related Ticket
[#2418](https://github.com/yalelibrary/YUL-DC/issues/2418)  
  
# Screenshot:  
<img width="771" alt="image" src="https://user-images.githubusercontent.com/24666568/226978760-d149a8bc-f5b4-4d5c-b3df-49a88c0157d9.png">
