### PR TITLE
Adds metadata to parent API

### DIFF
--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -51,9 +51,9 @@ class Api::ParentObjectsController < ApplicationController
   end
 
   def metadata_source(parent_object)
-    return "ils" if parent_object.authoritative_metadata_source_id == 1
+    return "Ladybird" if parent_object.authoritative_metadata_source_id == 1
     return "Voyager" if parent_object.authoritative_metadata_source_id == 2
-    return "ArchiveSpace" if parent_object.authoritative_metadata_source_id == 3
+    return "ArchivesSpace" if parent_object.authoritative_metadata_source_id == 3
     "Metadata Source not found"
   end
 

--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -28,7 +28,8 @@ class Api::ParentObjectsController < ApplicationController
         "container_grouping": @parent_object.container_grouping.to_s,
         "redirect_to": @parent_object.redirect_to.to_s,
         "iiif_manifest": "#{ENV['BLACKLIGHT_BASE_URL']}/manifests/#{@parent_object.oid}"
-      }
+      },
+      "metadata": metadata_json(@parent_object)
     }, status: 200
   end
   # rubocop:enable Metrics/MethodLength
@@ -54,6 +55,13 @@ class Api::ParentObjectsController < ApplicationController
     return "Voyager" if parent_object.authoritative_metadata_source_id == 2
     return "ArchiveSpace" if parent_object.authoritative_metadata_source_id == 3
     "Metadata Source not found"
+  end
+
+  def metadata_json(parent_object)
+    return parent_object.ladybird_json if parent_object.authoritative_metadata_source_id == 1
+    return parent_object.voyager_json if parent_object.authoritative_metadata_source_id == 2
+    return parent_object.aspace_json if parent_object.authoritative_metadata_source_id == 3
+    "Metadata not found"
   end
 
   private

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       authoritative_metadata_source_id: 1,
       admin_set: AdminSet.find_by_key('brbl'),
       bib: '123',
-      visibility: 'Public'
+      visibility: 'Public',
+      ladybird_json: {
+        oid: '12345',
+        uri: '/uri_example'
+      }
     }
   end
   let(:invalid_visibility) do
@@ -45,4 +49,14 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       expect(response.body).to eq("{\"title\":\"Parent Object is restricted.\"}")
     end
   end
+
+  # rubocop:disable Metrics/LineLength
+  describe 'GET metadata from parent object' do
+    it 'displays objects metadata' do
+      ParentObject.create! valid_attributes
+      get "/api/parent/#{valid_attributes[:oid]}"
+      expect(response.body).to match("[{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"123\",...tp://localhost:3000/manifests/2004628\"},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}]")
+    end
+  end
+  # rubocop:enable Metrics/LineLength
 end

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
     it 'displays objects metadata' do
       ParentObject.create! valid_attributes
       get "/api/parent/#{valid_attributes[:oid]}"
-      expect(response.body).to match("[{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"123\",...tp://localhost:3000/manifests/2004628\"},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}]")
+      expect(response.body).to match("[{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"123\",...tp://localhost:3000/manifests/2004628\"},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}]")
     end
   end
   # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
## Summary  
Parent Objects API now displays the objects JSON metadata.  
  
## Ticket  
[2419](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=22636704)  
  
## Screenshot  
<img width="702" alt="image" src="https://user-images.githubusercontent.com/24666568/227043308-06c98b6b-72ef-4f12-a100-3ee13be5f1f4.png">

