### PR TITLE
Display Child info in Metadata API

### DIFF
--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -27,7 +27,8 @@ class Api::ParentObjectsController < ApplicationController
         "call_number": @parent_object.call_number.to_s,
         "container_grouping": @parent_object.container_grouping.to_s,
         "redirect_to": @parent_object.redirect_to.to_s,
-        "iiif_manifest": "#{ENV['BLACKLIGHT_BASE_URL']}/manifests/#{@parent_object.oid}"
+        "iiif_manifest": "#{ENV['BLACKLIGHT_BASE_URL']}/manifests/#{@parent_object.oid}",
+        "children": child_info(@parent_object)
       },
       "metadata": metadata_json(@parent_object)
     }, status: 200
@@ -62,6 +63,16 @@ class Api::ParentObjectsController < ApplicationController
     return parent_object.voyager_json if parent_object.authoritative_metadata_source_id == 2
     return parent_object.aspace_json if parent_object.authoritative_metadata_source_id == 3
     "Metadata not found"
+  end
+
+  def child_info(parent_object)
+    parent_object.child_objects.map do |co|
+      {
+        "oid": co.oid,
+        "label": co.label,
+        "caption": co.caption
+      }
+    end
   end
 
   private

--- a/app/controllers/api/parent_objects_controller.rb
+++ b/app/controllers/api/parent_objects_controller.rb
@@ -28,7 +28,8 @@ class Api::ParentObjectsController < ApplicationController
         "container_grouping": @parent_object.container_grouping.to_s,
         "redirect_to": @parent_object.redirect_to.to_s,
         "iiif_manifest": "#{ENV['BLACKLIGHT_BASE_URL']}/manifests/#{@parent_object.oid}"
-      }
+      },
+      "metadata": metadata_json(@parent_object)
     }, status: 200
   end
   # rubocop:enable Metrics/MethodLength
@@ -54,6 +55,13 @@ class Api::ParentObjectsController < ApplicationController
     return "Voyager" if parent_object.authoritative_metadata_source_id == 2
     return "ArchiveSpace" if parent_object.authoritative_metadata_source_id == 3
     "Metadata Source not found"
+  end
+
+  def metadata_json(parent_object)
+    return parent_object.ladybird_json if parent_object.authoritative_metadata_source_id == 1
+    return parent_object.voyager_json if parent_object.authoritative_metadata_source_id == 2
+    return parent_object.aspace_json if parent_object.authoritative_metadata_source_id == 3
+    "Metadata not found"
   end
 
   private

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       visibility: 'Private'
     }
   end
-  let(:admin_set){FactoryBot.create(:admin_set)}
-  let(:parent_object){FactoryBot.create(:parent_object, oid: 123, admin_set: admin_set, visibility: "Public")}
-  let(:child_object){FactoryBot.create(:child_object, oid: 456_789, parent_object: parent_object, caption: 'caption', label: 'label')}
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: 123, admin_set: admin_set, visibility: "Public") }
+  let(:child_object) { FactoryBot.create(:child_object, oid: 456_789, parent_object: parent_object, caption: 'caption', label: 'label') }
 
   describe 'GET with valid oid' do
     it 'renders a successful response' do

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       authoritative_metadata_source_id: 1,
       admin_set: AdminSet.find_by_key('brbl'),
       bib: '123',
-      visibility: 'Public'
+      visibility: 'Public',
+      ladybird_json: {
+        oid: '12345',
+        uri: '/uri_example'
+      }
     }
   end
   let(:invalid_visibility) do
@@ -45,4 +49,14 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       expect(response.body).to eq("{\"title\":\"Parent Object is restricted.\"}")
     end
   end
+
+  # rubocop:disable Metrics/LineLength
+  describe 'GET metadata from parent object' do
+    it 'displays objects metadata' do
+      ParentObject.create! valid_attributes
+      get "/api/parent/#{valid_attributes[:oid]}"
+      expect(response.body).to match("[{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"123\",...tp://localhost:3000/manifests/2004628\"},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}]")
+    end
+  end
+  # rubocop:enable Metrics/LineLength
 end

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       visibility: 'Private'
     }
   end
+  let(:admin_set){FactoryBot.create(:admin_set)}
+  let(:parent_object){FactoryBot.create(:parent_object, oid: 123, admin_set: admin_set, visibility: "Public")}
+  let(:child_object){FactoryBot.create(:child_object, oid: 456_789, parent_object: parent_object, caption: 'caption', label: 'label')}
 
   describe 'GET with valid oid' do
     it 'renders a successful response' do
@@ -55,7 +58,15 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
     it 'displays objects metadata' do
       ParentObject.create! valid_attributes
       get "/api/parent/#{valid_attributes[:oid]}"
-      expect(response.body).to match("[{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"123\",...tp://localhost:3000/manifests/2004628\"},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}]")
+      expect(response.body).to eq("{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"123\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"Beinecke Library\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/2004628\",\"children\":[]},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}")
+    end
+
+    it 'displays child information' do
+      admin_set
+      parent_object
+      child_object
+      get "/api/parent/123"
+      expect(response.body).to eq("{\"dcs\":{\"oid\":\"123\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"MyString\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/123\",\"children\":[{\"oid\":456789,\"label\":\"label\",\"caption\":\"caption\"}]},\"metadata\":null}")
     end
   end
   # rubocop:enable Metrics/LineLength

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
     it 'displays objects metadata' do
       ParentObject.create! valid_attributes
       get "/api/parent/#{valid_attributes[:oid]}"
-      expect(response.body).to match("{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"123\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"Beinecke Library\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/2004628\",\"children\":[]},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}")
+      expect(response.body).to match("[{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"123\",...tp://localhost:3000/manifests/2004628\"},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}]")
     end
 
     it 'displays child information' do
@@ -66,7 +66,7 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       parent_object
       child_object
       get "/api/parent/123"
-      expect(response.body).to match("{\"dcs\":{\"oid\":\"123\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"MyString\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/123\",\"children\":[{\"oid\":456789,\"label\":\"label\",\"caption\":\"caption\"}]},\"metadata\":null}")
+      expect(response.body).to match("[{\"dcs\":{\"oid\":\"123\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"\",\"...3\",\"children\":[{\"oid\":456789,\"label\":\"label\",\"caption\":\"caption\"}]},\"metadata\":null}]")
     end
   end
   # rubocop:enable Metrics/LineLength

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
     it 'displays objects metadata' do
       ParentObject.create! valid_attributes
       get "/api/parent/#{valid_attributes[:oid]}"
-      expect(response.body).to eq("{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"123\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"Beinecke Library\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/2004628\",\"children\":[]},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}")
+      expect(response.body).to eq("{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"123\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"Beinecke Library\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/2004628\",\"children\":[]},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}")
     end
 
     it 'displays child information' do
@@ -66,7 +66,7 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       parent_object
       child_object
       get "/api/parent/123"
-      expect(response.body).to eq("{\"dcs\":{\"oid\":\"123\",\"visibility\":\"Public\",\"metadata_source\":\"ils\",\"bib\":\"\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"MyString\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/123\",\"children\":[{\"oid\":456789,\"label\":\"label\",\"caption\":\"caption\"}]},\"metadata\":null}")
+      expect(response.body).to eq("{\"dcs\":{\"oid\":\"123\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"MyString\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/123\",\"children\":[{\"oid\":456789,\"label\":\"label\",\"caption\":\"caption\"}]},\"metadata\":null}")
     end
   end
   # rubocop:enable Metrics/LineLength

--- a/spec/requests/api/parent_objects_spec.rb
+++ b/spec/requests/api/parent_objects_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
     it 'displays objects metadata' do
       ParentObject.create! valid_attributes
       get "/api/parent/#{valid_attributes[:oid]}"
-      expect(response.body).to eq("{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"123\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"Beinecke Library\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/2004628\",\"children\":[]},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}")
+      expect(response.body).to match("{\"dcs\":{\"oid\":\"2004628\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"123\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"Beinecke Library\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/2004628\",\"children\":[]},\"metadata\":{\"oid\":\"12345\",\"uri\":\"/uri_example\"}}")
     end
 
     it 'displays child information' do
@@ -66,7 +66,7 @@ RSpec.describe '/api/parent/oid', type: :request, prep_metadata_sources: true, p
       parent_object
       child_object
       get "/api/parent/123"
-      expect(response.body).to eq("{\"dcs\":{\"oid\":\"123\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"MyString\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/123\",\"children\":[{\"oid\":456789,\"label\":\"label\",\"caption\":\"caption\"}]},\"metadata\":null}")
+      expect(response.body).to match("{\"dcs\":{\"oid\":\"123\",\"visibility\":\"Public\",\"metadata_source\":\"Ladybird\",\"bib\":\"\",\"holding\":\"\",\"item\":\"\",\"barcode\":\"\",\"aspace_uri\":\"\",\"admin_set\":\"MyString\",\"child_object_count\":\"\",\"representative_child_oid\":\"\",\"rights_statement\":\"\",\"extent_of_digitization\":\"\",\"digitization_note\":\"\",\"call_number\":\"\",\"container_grouping\":\"\",\"redirect_to\":\"\",\"iiif_manifest\":\"http://localhost:3000/manifests/123\",\"children\":[{\"oid\":456789,\"label\":\"label\",\"caption\":\"caption\"}]},\"metadata\":null}")
     end
   end
   # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
## Summary  
Child OID, Caption, and Label now display in the DCS metadata block.  
  
## Ticket  
[2420](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=22765065)  
  
## Screenshots  
<img width="806" alt="image" src="https://user-images.githubusercontent.com/24666568/227290602-318e9a34-59fe-468a-b576-916e0e4d5aef.png">
  
<img width="762" alt="image" src="https://user-images.githubusercontent.com/24666568/227290792-d4e9d248-2967-4b05-ac89-8ecaa4b61b36.png">
