### PR TITLE
Adds date created to parent object datatable

### DIFF
--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -38,7 +38,8 @@ class ParentObjectDatatable < ApplicationDatatable
       extent_of_digitization: { source: "ParentObject.extent_of_digitization", cond: :string_eq, searchable: true, options: ["Completely digitized", "Partially digitized"], orderable: true },
       digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true },
       digitization_funding_source: { source: "ParentObject.digitization_funding_source", cond: :like, searchable: true, orderable: true },
-      project_identifier: { source: "ParentObject.project_identifier", searchable: true, orderable: true }
+      project_identifier: { source: "ParentObject.project_identifier", searchable: true, orderable: true },
+      created_at: { source: "ParentObject.created_at", searchable: true, orderable: true }
     }
   end
   # rubocop: enable Metrics/MethodLength
@@ -69,7 +70,8 @@ class ParentObjectDatatable < ApplicationDatatable
         digitization_note: parent_object.digitization_note,
         digitization_funding_source: parent_object.digitization_funding_source,
         DT_RowId: parent_object.oid,
-        project_identifier: parent_object.project_identifier
+        project_identifier: parent_object.project_identifier,
+        created_at: parent_object.created_at
       }
     end
   end

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -43,7 +43,7 @@
           <th scope='col'>Digitization Note</th>
           <th scope='col'>Digitization Funding Source</th>
           <th scope='col'>Project Identifier</th>
-          <th scope='col'>Created At</th>
+          <th scope='col'>Date Created</th>
 
         </tr>
       </thead>

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -43,6 +43,7 @@
           <th scope='col'>Digitization Note</th>
           <th scope='col'>Digitization Funding Source</th>
           <th scope='col'>Project Identifier</th>
+          <th scope='col'>Created At</th>
 
         </tr>
       </thead>

--- a/db/migrate/20230403212042_add_created_at_index_to_parent_objects.rb
+++ b/db/migrate/20230403212042_add_created_at_index_to_parent_objects.rb
@@ -1,0 +1,5 @@
+class AddCreatedAtIndexToParentObjects < ActiveRecord::Migration[6.1]
+  def change
+    add_index  :parent_objects, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_27_231942) do
+ActiveRecord::Schema.define(version: 2023_04_03_212042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,6 +201,7 @@ ActiveRecord::Schema.define(version: 2023_03_27_231942) do
     t.index ["barcode"], name: "index_parent_objects_on_barcode"
     t.index ["bib"], name: "index_parent_objects_on_bib"
     t.index ["call_number"], name: "index_parent_objects_on_call_number"
+    t.index ["created_at"], name: "index_parent_objects_on_created_at"
     t.index ["holding"], name: "index_parent_objects_on_holding"
     t.index ["item"], name: "index_parent_objects_on_item"
     t.index ["oid"], name: "index_parent_objects_on_oid", unique: true

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
     oid = '2034600'
 
     stub_metadata_cloud(oid)
-    FactoryBot.create(:parent_object, oid: oid, admin_set: admin_set, project_identifier: '67', digital_object_source: "Preservica", preservica_uri: "/preservica_uri")
-
+    po = FactoryBot.create(:parent_object, oid: oid, admin_set: admin_set, project_identifier: '67', digital_object_source: "Preservica", preservica_uri: "/preservica_uri")
     output = ParentObjectDatatable.new(datatable_sample_params(columns), view_context: parent_object_datatable_view_mock, current_ability: Ability.new(user)).data
 
     expect(output.size).to eq(1)
@@ -44,7 +43,8 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
       last_voyager_update: nil,
       oid: '<a href="/parent_objects/2034600">2034600</a> <a href="/management/parent_objects/2034600/edit"><i class="fa fa-pencil"></i></a> <a target="_blank" href="http://localhost:3000/catalog/2034600">1</a>',
       project_identifier: '67',
-      visibility: 'Private'
+      visibility: 'Private',
+      created_at: po.created_at
     )
     # rubocop:enable Metrics/LineLength
   end


### PR DESCRIPTION
## Summary  
"Date Created" added to Parent Object datatable. Date is searchable and orderable.  
  
## Ticket  
[2441](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=24041369)  
  
## Screenshot:  
<img width="1770" alt="image" src="https://user-images.githubusercontent.com/24666568/229641007-41cacc52-1441-469f-9edb-c1478f109ce7.png">
