### PR TITLE
Allow admin set update in updatable

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -76,7 +76,7 @@ module Updatable
       next unless parent_object
       sets << ', ' + parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
-      admin_set = editable_admin_set(row['admin_set'], oid, index) unless row['admin_set'].blank?
+      admin_set = editable_admin_set(row['admin_set'], oid, index) unless row['admin_set'].nil?
       self.admin_set = split_sets.join(', ')
       save!
       next if redirect.present? && !validate_redirect(redirect)

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -76,7 +76,7 @@ module Updatable
       next unless parent_object
       sets << ', ' + parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
-      admin_set = editable_admin_set(row['admin_set'], oid, index)
+      admin_set = editable_admin_set(row['admin_set'], oid, index) unless row['admin_set'].blank?
       self.admin_set = split_sets.join(', ')
       save!
       next if redirect.present? && !validate_redirect(redirect)
@@ -87,7 +87,7 @@ module Updatable
       metadata_source = row['source'].presence || parent_object.authoritative_metadata_source.metadata_cloud_name
       next unless validate_metadata_source(metadata_source, index)
       setup_for_background_jobs(parent_object, metadata_source)
-      parent_object.admin_set = admin_set
+      parent_object.admin_set = admin_set unless admin_set.nil?
       parent_object.update!(processed_fields)
       trigger_setup_metadata(parent_object)
 

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -77,6 +77,7 @@ module Updatable
       sets << ', ' + parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
       admin_set = editable_admin_set(row['admin_set'], oid, index) unless row['admin_set'].nil?
+      next if admin_set == false
       self.admin_set = split_sets.join(', ')
       save!
       next if redirect.present? && !validate_redirect(redirect)

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -76,7 +76,7 @@ module Updatable
       next unless parent_object
       sets << ', ' + parent_object.admin_set.key
       split_sets = sets.split(',').uniq.reject(&:blank?)
-      admin_set = editable_admin_set(row['admin_set'], oid, index) unless row['admin_set'].nil?
+      admin_set = editable_admin_set(row['admin_set'], oid, index)
       self.admin_set = split_sets.join(', ')
       save!
       next if redirect.present? && !validate_redirect(redirect)

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -99,21 +99,21 @@ module Updatable
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 
-    # CHECKS TO SEE IF USER HAS ABILITY TO EDIT AN ADMIN SET:
-    def editable_admin_set(admin_set_key, oid, index)
-      admin_sets_hash = {}
-      admin_sets_hash[admin_set_key] ||= AdminSet.find_by(key: admin_set_key)
-      admin_set = admin_sets_hash[admin_set_key]
-      if admin_set.blank?
-        batch_processing_event("Skipping row [#{index + 2}] with unknown admin set [#{admin_set_key}] for parent: #{oid}", 'Skipped Row')
-        return false
-      elsif !current_ability.can?(:add_member, admin_set)
-        batch_processing_event("Skipping row [#{index + 2}] because #{user.uid} does not have permission to create or update parent: #{oid}", 'Permission Denied')
-        return false
-      else
-        admin_set
-      end
+  # CHECKS TO SEE IF USER HAS ABILITY TO EDIT AN ADMIN SET:
+  def editable_admin_set(admin_set_key, oid, index)
+    admin_sets_hash = {}
+    admin_sets_hash[admin_set_key] ||= AdminSet.find_by(key: admin_set_key)
+    admin_set = admin_sets_hash[admin_set_key]
+    if admin_set.blank?
+      batch_processing_event("Skipping row [#{index + 2}] with unknown admin set [#{admin_set_key}] for parent: #{oid}", 'Skipped Row')
+      return false
+    elsif !current_ability.can?(:add_member, admin_set)
+      batch_processing_event("Skipping row [#{index + 2}] because #{user.uid} does not have permission to create or update parent: #{oid}", 'Permission Denied')
+      return false
+    else
+      admin_set
     end
+  end
 
   def remove_child_blanks(row, child_object)
     blankable = %w[caption label]

--- a/spec/fixtures/csv/update_example_new_admin_set.csv
+++ b/spec/fixtures/csv/update_example_new_admin_set.csv
@@ -1,0 +1,2 @@
+oid,source,admin_set,project_identifier,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout
+2034600,ladybird,sml,Beinecke,Public,,,,,,,,,,


### PR DESCRIPTION
## Summary  
Users can now update admin set when using Update Parent Objects batch process if they have edit access.  
  
## Ticket  
[2448](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=24650777)