### PR TITLE
Child object list numbers

### DIFF
--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -13,8 +13,13 @@ DEFAULT DESKTOP STYLING
   overflow-x: auto;
 }
 
-.child-list ol {
-  margin-left: -22px;
+.child-list-ol{
+  list-style-position: inside;
+}
+
+.child-list-ol li {
+  position: relative;
+  margin-left: -40px;
 }
 
 .delete-item-container,

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -73,7 +73,7 @@
           <div class="child-list">
             <ol class="child-list-ol">
               <% @parent_object.child_objects.map do |child| %>
-                <p><li><%= link_to( "#{child.label || 'no label'} / #{child.caption || 'no caption'} (#{child.width}, #{child.height})", "#{child_objects_path}/#{child.oid}") %></li></p>
+                <li><%= link_to( "#{child.label || 'no label'} / #{child.caption || 'no caption'} (#{child.width}, #{child.height})", "#{child_objects_path}/#{child.oid}") %></li><br />
               <% end %>
             </ol>
           </div>


### PR DESCRIPTION
## Summary  
Child Objects list numbers are now listed correctly on the Parent Object showpage.  
  
## Ticket  
[2453](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=25247038)  
  
## Screenshot:  
<img width="1762" alt="image" src="https://user-images.githubusercontent.com/24666568/231291245-9ebb4924-bfb1-4c40-b732-b362c1e6749e.png">
