### PR TITLE
Update ptiff generation for preservica resync

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -60,7 +60,7 @@ class SetupMetadataJob < ApplicationJob
     ptiff_jobs_queued = false
     parent_object.child_objects.each do |child|
       parent_object.current_batch_process&.setup_for_background_jobs(child, nil)
-      if child.pyramidal_tiff.height_and_width? && S3Service.s3_exists?(child.remote_ptiff_path)
+      if child.pyramidal_tiff.height_and_width? && !child.pyramidal_tiff.force_update && S3Service.s3_exists?(child.remote_ptiff_path)
         child.processing_event("PTIFF exists on S3, not converting: #{child.oid}", 'ptiff-ready-skipped')
       else
         path = Pathname.new(child.access_master_path)

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -230,6 +230,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     preservica_children_hash.each_value do |value|
       co = ChildObject.find_by(parent_object_oid: oid, preservica_content_object_uri: value[:content_uri])
       next if co.nil?
+      co.pyramidal_tiff.force_update = true if co.preservica_generation_uri != value[:generation_uri]
       co.order = value[:order]
       co.preservica_content_object_uri = value[:content_uri]
       co.preservica_generation_uri = value[:generation_uri]

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_no_information_pattern_1
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443) for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e4b.").or eq("Skipping row [2] execution expired for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e4b.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known) for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e4b.")
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443) for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e4b.").or eq("Skipping row [2] execution expired for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e4b.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known) for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e4b.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (execution expired) for /preservica/api/entity/structural-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e4b.")
     end.to change { ChildObject.count }.by(0)
   end
 
@@ -162,7 +162,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.file = preservica_parent_no_information_pattern_2
       batch_process.save
       expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] execution expired for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (getaddrinfo: Temporary failure in name resolution) for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443) for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known) for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.")
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] execution expired for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (getaddrinfo: Temporary failure in name resolution) for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443) for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known) for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.").or eq("Skipping row [2] Failed to open TCP connection to testpreservica:443 (execution expired) for /preservica/api/entity/information-objects/2e42a2bb-8953-41b6-bcc3-1a19c86a5e5c.")
     end.to change { ChildObject.count }.by(0)
   end
 
@@ -208,7 +208,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.save
       po = ParentObject.find(200_000_000)
       expect(po.events_for_batch_process(batch_process).count).to be > 1
-      expect(po.events_for_batch_process(batch_process)[1].reason).to eq("execution expired").or eq("Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443)").or eq("Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known)")
+      expect(po.events_for_batch_process(batch_process)[1].reason).to eq("execution expired").or eq("Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443)").or eq("Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known)").or eq("Failed to open TCP connection to testpreservica:443 (execution expired)")
     end.to change { ChildObject.count }.by(0)
   end
 
@@ -218,7 +218,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       batch_process.save
       po = ParentObject.find(200_000_000)
       expect(po.events_for_batch_process(batch_process).count).to be > 1
-      expect(po.events_for_batch_process(batch_process)[1].reason).to eq("execution expired").or eq("Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443)").or eq("Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known)")
+      expect(po.events_for_batch_process(batch_process)[1].reason).to eq("execution expired").or eq("Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443)").or eq("Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known)").or eq("Failed to open TCP connection to testpreservica:443 (execution expired)")
     end.to change { ChildObject.count }.by(0)
   end
 


### PR DESCRIPTION
# Summary
During a resync with Preservica the values were being updated on the child object but the image was not being replaced when it should have been.  This PR will force the update of the ptiff if the generation uri has been updated - which is the case when a new image is uploaded.

# Related Ticket
[#2400](https://github.com/yalelibrary/YUL-DC/issues/2400)