### PR TITLE
Make uids unique before adding index

### DIFF
--- a/db/migrate/20230418211745_add_unique_to_uid.rb
+++ b/db/migrate/20230418211745_add_unique_to_uid.rb
@@ -1,5 +1,6 @@
 class AddUniqueToUid < ActiveRecord::Migration[6.1]
   def change
+    User.where.not(id:User.select("MAX(id) as id").group(:uid).map(&:id)).each { |u| u.uid = "#{u.uid}__"; u.save }
     add_index :users, :uid, unique: true
   end
 end


### PR DESCRIPTION
This will make the uids unique if there are duplicates.
(It only works if there are 2 or fewer with the same id, but will eventually work if it's run multiple times.)