### PR TITLE
Log select ActiveJob events to Cloudwatch custom metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'activerecord-nulldb-adapter'
 # Reoccurring jobs
 gem 'activejob-scheduler', git: 'https://github.com/yalelibrary/activejob-scheduler', branch: 'main'
 gem 'ajax-datatables-rails'
+gem "aws-sdk-cloudwatch"
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bootstrap', '~> 4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
       execjs
     aws-eventstream (1.1.1)
     aws-partitions (1.349.0)
+    aws-sdk-cloudwatch (1.44.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-core (3.104.4)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -483,6 +486,7 @@ DEPENDENCIES
   activerecord-nulldb-adapter
   ajax-datatables-rails
   amazing_print (>= 1.2.1)
+  aws-sdk-cloudwatch
   aws-sdk-s3
   bixby
   bootsnap (>= 1.4.2)

--- a/app/lib/aws_metrics.rb
+++ b/app/lib/aws_metrics.rb
@@ -9,7 +9,7 @@ class AwsMetrics
   METRIC_DIMENSION_EVENT = 'JobEvent'
   METRIC_FEATURE_FLAG = '|AWS_METRICS|'
   # Class names of jobs allowed to generate metrics
-  LOGGABLE_JOBS = %w[GeneratePdfJob GeneratePtiffJob].freeze
+  LOGGABLE_JOBS = %w[SolrIndexJob SyncFromPreservicaJob GeneratePdfJob GeneratePtiffJob GenerateManifestJob ActivityStreamJob ProblemReportJob].freeze
 
   def initialize
     @cloudwatch_client = Aws::CloudWatch::Client.new

--- a/app/lib/aws_metrics.rb
+++ b/app/lib/aws_metrics.rb
@@ -2,7 +2,6 @@
 
 # Sends metrics to AWS
 class AwsMetrics
-
   METRIC_NAMESPACE = 'DCS'
   METRIC_NAME = 'ActiveJob'
   METRIC_DIMENSION_CLUSTER = 'Cluster'
@@ -10,7 +9,7 @@ class AwsMetrics
   METRIC_DIMENSION_EVENT = 'JobEvent'
   METRIC_FEATURE_FLAG = '|AWS_METRICS|'
   # Class names of jobs allowed to generate metrics
-  LOGGABLE_JOBS = %w[GeneratePdfJob GeneratePtiffJob]
+  LOGGABLE_JOBS = %w[GeneratePdfJob GeneratePtiffJob].freeze
 
   def initialize
     @cloudwatch_client = Aws::CloudWatch::Client.new
@@ -18,6 +17,7 @@ class AwsMetrics
     @cluster_name = ENV['CLUSTER_NAME'] || "unknown"
   end
 
+  # rubocop:disable Metrics/MethodLength
   def publish_active_job_metric_data(job_name, event_name)
     unless @metrics_enabled
       Rails.logger.debug "[AwsMetrics] Cloudwatch logging feature flag is not enabled."
@@ -27,7 +27,7 @@ class AwsMetrics
       Rails.logger.debug "[AwsMetrics] #{job_name} not loggable to Cloudwatch"
       return
     end
-    Rails.logger.debug "[AwsMetrics] #{Time.now} #{job_name} #{event_name}"
+    Rails.logger.debug "[AwsMetrics] #{Time.now.utc} #{job_name} #{event_name}"
     @cloudwatch_client.put_metric_data(
       namespace: METRIC_NAMESPACE,
       metric_data: [
@@ -53,4 +53,5 @@ class AwsMetrics
       ]
     )
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/lib/aws_metrics.rb
+++ b/app/lib/aws_metrics.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Sends metrics to AWS
+class AwsMetrics
+
+  METRIC_NAMESPACE = 'DCS'
+  METRIC_NAME = 'ActiveJob'
+  METRIC_DIMENSION_CLUSTER = 'Cluster'
+  METRIC_DIMENSION_JOB = 'JobName'
+  METRIC_DIMENSION_EVENT = 'JobEvent'
+  METRIC_FEATURE_FLAG = '|AWS_METRICS|'
+  # Class names of jobs allowed to generate metrics
+  LOGGABLE_JOBS = %w[GeneratePdfJob GeneratePtiffJob]
+
+  def initialize
+    @cloudwatch_client = Aws::CloudWatch::Client.new
+    @metrics_enabled = ENV['FEATURE_FLAGS']&.include? METRIC_FEATURE_FLAG
+    @cluster_name = ENV['CLUSTER_NAME'] || "unknown"
+  end
+
+  def publish_active_job_metric_data(job_name, event_name)
+    unless @metrics_enabled
+      Rails.logger.debug "[AwsMetrics] Cloudwatch logging feature flag is not enabled."
+      return
+    end
+    unless LOGGABLE_JOBS.include? job_name
+      Rails.logger.debug "[AwsMetrics] #{job_name} not loggable to Cloudwatch"
+      return
+    end
+    Rails.logger.debug "[AwsMetrics] #{Time.now} #{job_name} #{event_name}"
+    @cloudwatch_client.put_metric_data(
+      namespace: METRIC_NAMESPACE,
+      metric_data: [
+        {
+          metric_name: METRIC_NAME,
+          dimensions: [
+            {
+              name: METRIC_DIMENSION_CLUSTER,
+              value: @cluster_name
+            },
+            {
+              name: METRIC_DIMENSION_JOB,
+              value: job_name
+            },
+            {
+              name: METRIC_DIMENSION_EVENT,
+              value: event_name
+            }
+          ],
+          value: 1,
+          unit: 'Count'
+        }
+      ]
+    )
+  end
+end

--- a/config/initializers/events.rb
+++ b/config/initializers/events.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require './app/lib/aws_metrics'
+
+# Monitors ActiveJob events.  Events of interest:
+# perform_start.active_job  ALWAYS FIRED
+# enqueue_retry.active_job
+# discard.active_job
+# perform.active_job        ALWAYS FIRED
+ActiveSupport::Notifications.subscribe /active_job/ do |event|
+  logger = Rails.logger
+  begin
+    job_name = event.payload[:job].class.to_s
+    executions = event.payload[:job].executions
+    metrics = AwsMetrics.new
+    case event.name
+    when 'perform.active_job'
+      if executions == 1
+        metrics.publish_active_job_metric_data(job_name, 'perform')
+      else
+        metrics.publish_active_job_metric_data(job_name, 'perform-retry')
+      end
+    when 'discard.active_job'
+      metrics.publish_active_job_metric_data(job_name, 'discard')
+    when 'enqueue_retry.active_job'
+      metrics.publish_active_job_metric_data(job_name, 'enqueue-retry')
+    else
+      logger.debug "Not publishing metrics for #{event.name}"
+    end
+  rescue StandardError => e
+    logger.warn "Error handling event #{event&.name} #{event&.payload&.[](:job)&.class&.to_s} #{event} #{e}"
+  end
+end

--- a/config/initializers/events.rb
+++ b/config/initializers/events.rb
@@ -6,7 +6,7 @@ require './app/lib/aws_metrics'
 # enqueue_retry.active_job
 # discard.active_job
 # perform.active_job        ALWAYS FIRED
-ActiveSupport::Notifications.subscribe /active_job/ do |event|
+ActiveSupport::Notifications.subscribe(/active_job/) do |event|
   logger = Rails.logger
   begin
     job_name = event.payload[:job].class.to_s


### PR DESCRIPTION
Logs custom metrics.  
* Fixed namespace `DCS`
* Requires that the FEATURE_FLAG environment variable includes `|AWS_METRICS|`
* Needs appropriate permission; will log a minimal warning message if permission is denied, but jobs will be processed normally. 
* Only job classes in LOGGABLE_JOBS will be logged.   We should add to this list with caution since it will increase costs (cost will scale with clusters * jobs) 