### PR TITLE
Aspace update

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -207,6 +207,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         oid = row['oid']
         metadata_source = row['source']
         set = row['admin_set']
+
         if metadata_source.blank? && (set.present? && row.count > 2)
           batch_processing_event("Skipping row [#{index + 2}]. Source cannot be blank.", 'Skipped Row')
           next
@@ -225,6 +226,16 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         else
           parent_object = ParentObject.find_or_initialize_by(oid: oid)
         end
+
+        aspace_uri = row['aspace_uri']
+        bib = row['bib']
+        holding = row['holding']
+        item = row['item']
+
+        parent_object.aspace_uri = aspace_uri
+        parent_object.bib = bib
+        parent_object.holding = holding
+        parent_object.item = item
 
         # Only runs on newly created parent objects
         unless parent_object.new_record?

--- a/spec/fixtures/csv/aspace_parent.csv
+++ b/spec/fixtures/csv/aspace_parent.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility
+,brbl,aspace,/repositories/12/archival_objects/781086,3435140,,,39002075038423,Public

--- a/spec/fixtures/csv/aspace_parent.csv
+++ b/spec/fixtures/csv/aspace_parent.csv
@@ -1,2 +1,2 @@
 oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility
-,brbl,aspace,/repositories/12/archival_objects/781086,3435140,,,39002075038423,Public
+,brbl,aspace,/repositories/12/archival_objects/781086,4320085,,,39002075038423,Public

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
   let(:no_oid_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "parent_no_oid.csv")) }
   let(:no_admin_set) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "parent_no_admin_set.csv")) }
   let(:no_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "parent_no_source.csv")) }
+  let(:aspace_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "aspace_parent.csv")) }
 
   around do |example|
     original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
@@ -34,6 +35,14 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
     end
 
     context "Create Parent Object batch process with a csv" do
+      it "can create a parent object from aspace" do
+        expect do
+          batch_process.file = aspace_parent
+          batch_process.save
+        end.to change { ParentObject.count }.from(0).to(1)
+        po = ParentObject.first
+        expect(po.bib).to eq('3435140')
+      end
       it "can create a parent_object" do
         expect do
           batch_process.file = no_oid_parent

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.save
         end.to change { ParentObject.count }.from(0).to(1)
         po = ParentObject.first
-        expect(po.bib).to eq('3435140')
+        expect(po.bib).to eq('4320085')
+        expect(po.aspace_uri).to eq('/repositories/12/archival_objects/781086')
       end
       it "can create a parent_object" do
         expect do


### PR DESCRIPTION
## Summary  
ASpace objects can now be created through the Create Parent Objects Batch Process  
  
## Ticket  
[2436](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=23863856)