### PR TITLE
Apply showpage filtering on page load

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -392,9 +392,11 @@ $( document ).on('turbolinks:load', function() {
     if (value == '') {
       $(this).closest('tr').toggleClass('hidden');
     }
+    $('tr:not(.hidden):odd').css('background-color', '#F2F2F2');
+    $('tr:not(.hidden):even').css('background-color', '#FFFFFF');
   })
   $('#filter-icon').click(function() {
-    $(this).find('svg').toggleClass('fa-filter-circle-xmark fa-filter');
+    $(this).find('svg').toggleClass('fa-filter-circle-xmark fa-filter ');
     var values = $('.table-row').find('td:eq(1)');
     values.each(function() {
       var value = $(this).text()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -394,7 +394,7 @@ $( document ).on('turbolinks:load', function() {
     }
   })
   $('#filter-icon').click(function() {
-    $(this).find('svg').toggleClass('fa-filter fa-filter-circle-xmark');
+    $(this).find('svg').toggleClass('fa-filter-circle-xmark fa-filter');
     var values = $('.table-row').find('td:eq(1)');
     values.each(function() {
       var value = $(this).text()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -386,6 +386,13 @@ $( document ).on('turbolinks:load', function() {
 
 // This will change the filter icon on the parent object show page
 $( document ).on('turbolinks:load', function() {
+  var values = $('.table-row').find('td:eq(1)');
+  values.each(function() {
+    var value = $(this).text()
+    if (value == '') {
+      $(this).closest('tr').toggleClass('hidden');
+    }
+  })
   $('#filter-icon').click(function() {
     $(this).find('svg').toggleClass('fa-filter fa-filter-circle-xmark');
     var values = $('.table-row').find('td:eq(1)');

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -2,7 +2,7 @@
 
 <div id='parent-show'>
   <div id='filter-icon'>
-    <em class='fa fa-filter'></em>
+    <em class='fa fa-filter-circle-xmark'></em>
   </div>
   <table class='metadata-block'>
     <tbody>


### PR DESCRIPTION
## Summary  
Parent Object showpage now loads with metadata filtering applied.  
  
## Ticket  
[1177](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=26209824)  
  
## Screenshot:  
On page load:  
<img width="1737" alt="image" src="https://user-images.githubusercontent.com/24666568/234670845-a0008fee-bb69-4b5d-a8c6-f28cd2e7ec38.png">
