### PR TITLE
Reorder more information panel

### DIFF
--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -70,12 +70,6 @@ METADATA_FIELDS = {
       'extent_ssim'
     ]
   },
-  extentOfDigitization: {
-    label: 'Extent of Digitization',
-    solr_fields: [
-      'extentOfDigitization_ssim'
-    ]
-  },
   projection: {
     label: 'Projection',
     solr_fields: [
@@ -165,6 +159,12 @@ METADATA_FIELDS = {
       'containerGrouping_ssim'
     ],
     digital_only: true
+  },
+  extentOfDigitization: {
+    label: 'Extent of Digitization',
+    solr_fields: [
+      'extentOfDigitization_ssim'
+    ]
   },
   findingAid: {
     label: 'Finding Aid',


### PR DESCRIPTION
# Summary
Desire to add extent of digitization to More Information UV panel below the 'Container / Volume Information' field.

# Related Ticket
[#2455](https://github.com/yalelibrary/YUL-DC/issues/2455)