### PR TITLE
adds full_text to datatable and csv export

### DIFF
--- a/app/datatables/child_object_datatable.rb
+++ b/app/datatables/child_object_datatable.rb
@@ -23,6 +23,7 @@ class ChildObjectDatatable < ApplicationDatatable
       order: { source: 'ChildObject.order' },
       parent_object: { source: 'ChildObject.parent_object_oid' },
       original_oid: { source: 'ChildObject.original_oid' },
+      full_text: { source: 'ChildObject.full_text' },
       preservica_content_object_uri: { source: 'ChildObject.preservica_content_object_uri' },
       preservica_generation_uri: { source: 'ChildObject.preservica_generation_uri' },
       preservica_bitstream_uri: { source: 'ChildObject.preservica_bitstream_uri' },
@@ -42,6 +43,7 @@ class ChildObjectDatatable < ApplicationDatatable
         order: child_object.order,
         parent_object: child_object.parent_object_oid,
         original_oid: child_object.original_oid,
+        full_text: full_text_status(child_object).html_safe,
         preservica_content_object_uri: child_object.preservica_content_object_uri,
         preservica_generation_uri: child_object.preservica_generation_uri,
         preservica_bitstream_uri: child_object.preservica_bitstream_uri,
@@ -51,6 +53,10 @@ class ChildObjectDatatable < ApplicationDatatable
     end
   end
   # rubocop:enable Rails/OutputSafety
+
+  def full_text_status(child_object)
+    child_object.full_text == true ? "Yes" : "No"
+  end
 
   def actions(child_object)
     actions = []

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -150,7 +150,7 @@ module CsvExportable
   ########################
 
   def child_headers
-    ['parent_oid', 'child_oid', 'order', 'parent_title', 'call_number', 'label', 'caption', 'viewing_hint']
+    ['parent_oid', 'child_oid', 'order', 'parent_title', 'call_number', 'label', 'caption', 'viewing_hint', 'full_text']
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -167,7 +167,7 @@ module CsvExportable
       split_sets = sets.split(',').uniq.reject(&:blank?)
       self.admin_set = split_sets.join(', ')
       save!
-      row = [co.parent_object.oid, co.oid, co.order, parent_title.presence, co.parent_object.call_number, co.label, co.caption, co.viewing_hint]
+      row = [co.parent_object.oid, co.oid, co.order, parent_title.presence, co.parent_object.call_number, co.label, co.caption, co.viewing_hint, full_text_status(co)]
       csv_rows << row
     end
     add_error_rows(csv_rows)
@@ -181,6 +181,10 @@ module CsvExportable
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
+
+  def full_text_status(child_object)
+    child_object.full_text == true ? "Yes" : "No"
+  end
 
   def lookup_parent_title(co, parent_title_hash)
     parent_title_hash[co.parent_object.oid] ||= co.parent_object.authoritative_json&.[]('title')&.first

--- a/app/views/child_objects/index.html.erb
+++ b/app/views/child_objects/index.html.erb
@@ -23,6 +23,7 @@
           <th scope='col'>Order</th>
           <th scope='col'>Parent Object</th>
           <th scope='col'>Original OID</th>
+          <th scope='col'>Full Text</th>
           <th scope='col'>Preservica Content Object URI</th>
           <th scope='col'>Preservica Generation URI</th>
           <th scope='col'>Preservica Bitstream URI</th>

--- a/spec/datatables/child_object_datatable_spec.rb
+++ b/spec/datatables/child_object_datatable_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ChildObjectDatatable, type: :datatable, prep_metadata_sources: tr
       order: 1,
       parent_object: 2_004_628,
       original_oid: nil,
+      full_text: 'No',
       preservica_content_object_uri: '/content_object_uri',
       preservica_generation_uri: '/generation_uri',
       preservica_bitstream_uri: '/bitstream_uri',


### PR DESCRIPTION
## Summary  
Full Text status is now displayed in the child object datatable and Export Child Objects Batch Process.  
  
## Ticket  
[2478](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=26933114)  
  
## Screenshots:  
<img width="1763" alt="image" src="https://user-images.githubusercontent.com/24666568/235801523-103c56b1-3b30-4d21-95cb-52bc7474e69f.png">
   
CSV Export:  
<img width="984" alt="image" src="https://user-images.githubusercontent.com/24666568/235801623-27aad602-4805-4059-9779-419146be9bee.png">
