### PR TITLE
Export Parent Objects full text update

### DIFF
--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -38,6 +38,7 @@ class ParentObjectDatatable < ApplicationDatatable
       extent_of_digitization: { source: "ParentObject.extent_of_digitization", cond: :string_eq, searchable: true, options: ["Completely digitized", "Partially digitized"], orderable: true },
       digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true },
       digitization_funding_source: { source: "ParentObject.digitization_funding_source", cond: :like, searchable: true, orderable: true },
+      full_text: { source: "ParentObject.full_text", searchable: true, orderable: true },
       project_identifier: { source: "ParentObject.project_identifier", searchable: true, orderable: true },
       created_at: { source: "ParentObject.created_at", searchable: true, orderable: true }
     }
@@ -70,12 +71,32 @@ class ParentObjectDatatable < ApplicationDatatable
         digitization_note: parent_object.digitization_note,
         digitization_funding_source: parent_object.digitization_funding_source,
         DT_RowId: parent_object.oid,
+        full_text: extent_of_full_text(parent_object),
         project_identifier: parent_object.project_identifier,
         created_at: parent_object.created_at
       }
     end
   end
   # rubocop:enable Rails/OutputSafety,Metrics/MethodLength
+
+  def extent_of_full_text(parent_object)
+    children_with_ft = false
+    children_without_ft = false
+
+    parent_object.child_objects.each do |object|
+      if object.full_text
+        children_with_ft = true
+      else
+        children_without_ft = true
+      end
+
+      break if children_with_ft && children_without_ft
+    end
+
+    return "Partial" if children_with_ft && children_without_ft # if some children have full text and others dont
+    return "None" unless children_with_ft # if none of children have full_text
+    "Yes"
+  end
 
   def oid_column(parent_object)
     result = []

--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -38,7 +38,7 @@ class ParentObjectDatatable < ApplicationDatatable
       extent_of_digitization: { source: "ParentObject.extent_of_digitization", cond: :string_eq, searchable: true, options: ["Completely digitized", "Partially digitized"], orderable: true },
       digitization_note: { source: "ParentObject.digitization_note", cond: :like, searchable: true, orderable: true },
       digitization_funding_source: { source: "ParentObject.digitization_funding_source", cond: :like, searchable: true, orderable: true },
-      full_text: { source: "ParentObject.full_text", searchable: true, orderable: true },
+      full_text: { source: "ChildObject.full_text", searchable: true, orderable: true },
       project_identifier: { source: "ParentObject.project_identifier", searchable: true, orderable: true },
       created_at: { source: "ParentObject.created_at", searchable: true, orderable: true }
     }
@@ -115,6 +115,6 @@ class ParentObjectDatatable < ApplicationDatatable
   end
 
   def get_raw_records # rubocop:disable Naming/AccessorMethodName
-    ParentObject.accessible_by(@current_ability, :read).joins(:authoritative_metadata_source, :admin_set).where("visibility != 'Redirect'")
+    ParentObject.includes(:child_objects).accessible_by(@current_ability, :read).joins(:authoritative_metadata_source, :admin_set).where("visibility != 'Redirect'").references(:child_objects)
   end
 end

--- a/app/datatables/parent_object_datatable.rb
+++ b/app/datatables/parent_object_datatable.rb
@@ -45,6 +45,7 @@ class ParentObjectDatatable < ApplicationDatatable
   end
   # rubocop: enable Metrics/MethodLength
 
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Rails/OutputSafety,Metrics/MethodLength
   def data
     records.map do |parent_object|
@@ -78,6 +79,7 @@ class ParentObjectDatatable < ApplicationDatatable
     end
   end
   # rubocop:enable Rails/OutputSafety,Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   def extent_of_full_text(parent_object)
     children_with_ft = false

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -12,7 +12,7 @@ module CsvExportable
      'container_grouping', 'bib', 'holding', 'item', 'barcode', 'aspace_uri',
      'digital_object_source', 'preservica_uri', 'last_ladybird_update',
      'last_voyager_update', 'last_aspace_update', 'last_id_update', 'visibility',
-     'extent_of_digitization', 'digitization_note', 'digitization_funding_source', 'project_identifier']
+     'extent_of_digitization', 'digitization_note', 'digitization_funding_source', 'project_identifier', 'full_text']
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -40,8 +40,27 @@ module CsvExportable
        po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
        po.last_ladybird_update, po.last_voyager_update,
        po.last_aspace_update, po.last_id_update, po.visibility, po.extent_of_digitization,
-       po.digitization_note, po.digitization_funding_source, po.project_identifier]
+       po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
     end
+  end
+
+  def extent_of_full_text(parent_object)
+    children_with_ft = false
+    children_without_ft = false
+
+    parent_object.child_objects.each do |object|
+      if object.full_text
+        children_with_ft = true
+      else
+        children_without_ft = true
+      end
+
+      break if children_with_ft && children_without_ft
+    end
+
+    return "Partial" if children_with_ft && children_without_ft # if some children have full text and others dont
+    return "None" unless children_with_ft # if none of children have full_text
+    "Yes"
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -112,7 +131,7 @@ module CsvExportable
              po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
              po.last_ladybird_update, po.last_voyager_update,
              po.last_aspace_update, po.last_id_update, po.visibility, po.extent_of_digitization,
-             po.digitization_note, po.digitization_funding_source, po.project_identifier]
+             po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
       csv_rows << row
     end
     add_error_rows(csv_rows)

--- a/app/views/parent_objects/index.html.erb
+++ b/app/views/parent_objects/index.html.erb
@@ -42,6 +42,7 @@
           <th scope='col'>Extent of Digitization</th>
           <th scope='col'>Digitization Note</th>
           <th scope='col'>Digitization Funding Source</th>
+          <th scope='col'>Full Text</th>
           <th scope='col'>Project Identifier</th>
           <th scope='col'>Date Created</th>
 

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
       last_ladybird_update: nil,
       last_voyager_update: nil,
       oid: '<a href="/parent_objects/2034600">2034600</a> <a href="/management/parent_objects/2034600/edit"><i class="fa fa-pencil"></i></a> <a target="_blank" href="http://localhost:3000/catalog/2034600">1</a>',
+      full_text: 'None',
       project_identifier: '67',
       visibility: 'Private',
       created_at: po.created_at

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.export_parent_metadata).to include "Preservica"
         expect(BatchProcess.last.export_parent_metadata).to include "/preservica_uri"
         expect(BatchProcess.last.export_parent_metadata).to include "brbl"
+        expect(BatchProcess.last.export_parent_metadata).to include "full_text"
       end
 
       it "uploads a CSV of parent objects in order to create export of parent objects metadata fails 2005512 row due to admin set permissions" do
@@ -225,6 +226,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.parent_output_csv).to include "Preservica"
         expect(BatchProcess.last.parent_output_csv).to include "/preservica_uri"
         expect(BatchProcess.last.parent_output_csv).to include "brbl"
+        expect(BatchProcess.last.parent_output_csv).to include "full_text"
         expect(BatchProcess.last.parent_output_csv).not_to include "2005512"
       end
 

--- a/spec/system/parent_object_list_spec.rb
+++ b/spec/system/parent_object_list_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       find("input[placeholder='OID']").set("2002")
       expect(page).to have_content("2002826")
       expect(page).not_to have_content("2004548")
-      # click_on("Clear Filters")
-      # expect(page).to have_content("2002826")
-      # expect(page).to have_content("2004548")
+      click_on("Clear Filters")
+      expect(page).to have_content("2002826")
+      expect(page).to have_content("2004548")
     end
   end
 end

--- a/spec/system/parent_object_list_spec.rb
+++ b/spec/system/parent_object_list_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       find("input[placeholder='OID']").set("2002")
       expect(page).to have_content("2002826")
       expect(page).not_to have_content("2004548")
-      click_on("Clear Filters")
-      expect(page).to have_content("2002826")
-      expect(page).to have_content("2004548")
+      # click_on("Clear Filters")
+      # expect(page).to have_content("2002826")
+      # expect(page).to have_content("2004548")
     end
   end
 end


### PR DESCRIPTION
## Summary  
Parent Objects full text status is now displayed on parent object datatable, export parent objects batch process, and export parent objects metadata batch process.  
  
## Ticket  
[2477](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=26933022)  
  
## Screenshots:  
<img width="1753" alt="image" src="https://user-images.githubusercontent.com/24666568/235980848-c81c1d8b-fff8-4500-8439-9535919bbb0a.png">
  
Export Metadata:  
<img width="986" alt="image" src="https://user-images.githubusercontent.com/24666568/235981228-258b2a9d-c2bc-4cf1-81f3-b8b570fb0e35.png">
  
Export by Admin Set:  
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/24666568/235981085-5862072f-c364-4b7b-9545-c88fa1141c90.png">

