### PR TITLE
Reset activity stream log

### DIFF
--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -8,7 +8,7 @@ class ReoccurringJobsController < ApplicationController
       @check_status = true
       @scheduled_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamJob%').exists?
       @manual_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamManualJob%').exists?
-      @run_time = ActivityStreamLog.where(status: "Running").last&.run_time&.to_datetime <= DateTime.current - 12.hours
+      @run_time = true if ActivityStreamLog.last&.status == "Running" && ActivityStreamLog.last&.run_time&.to_datetime <= DateTime.current - 12.hours
     end
     @reoccurring_jobs = ActivityStreamLog.all
     respond_to do |format|

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -6,7 +6,6 @@ class ReoccurringJobsController < ApplicationController
       @check_status = true
       @scheduled_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamJob%').exists?
       @manual_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamManualJob%').exists?
-      byebug
       @run_time = ActivityStreamLog.where(status: "Running").last&.run_time&.to_datetime <= DateTime.now - 12.hours
     end
     @reoccurring_jobs = ActivityStreamLog.all
@@ -31,7 +30,7 @@ class ReoccurringJobsController < ApplicationController
       create_recurring
     elsif params['reset_log']
       logger = ActivityStreamLog.where(status: "Running").last
-      logger.status = "Manual Reset"
+      logger.status = "Manually Reset"
       logger.save
     elsif ActivityStreamLog.where(status: "Running").exists?
       respond_to do |format|

--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -8,7 +8,7 @@ class ReoccurringJobsController < ApplicationController
       @check_status = true
       @scheduled_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamJob%').exists?
       @manual_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamManualJob%').exists?
-      @run_time = true if ActivityStreamLog.last&.status == "Running" && ActivityStreamLog.last&.run_time&.to_datetime <= DateTime.current - 12.hours
+      @expired_logger = true if ActivityStreamLog.last&.status == "Running" && ActivityStreamLog.last&.run_time&.to_datetime <= DateTime.current - 12.hours
     end
     @reoccurring_jobs = ActivityStreamLog.all
     respond_to do |format|

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -14,7 +14,7 @@
         <%= link_to 'Check status of the Recurring Job', reoccurring_jobs_path(check_status:'true'), method: 'get', class: 'btn button secondary-button' %>
       <% end %>
       <% if @check_status %>
-        <% if @run_time %>
+        <% if @expired_logger %>
           <% if current_user.has_role?(:sysadmin)%>
             <%= button_to 'Manually Reset', reoccurring_jobs_path(reset_log: 'true'), method: 'post', class: 'btn button secondary-button' %>
           <% end %>

--- a/app/views/reoccurring_jobs/index.html.erb
+++ b/app/views/reoccurring_jobs/index.html.erb
@@ -13,6 +13,13 @@
       <% else %>
         <%= link_to 'Check status of the Recurring Job', reoccurring_jobs_path(check_status:'true'), method: 'get', class: 'btn button secondary-button' %>
       <% end %>
+      <% if @check_status %>
+        <% if @run_time %>
+          <% if current_user.has_role?(:sysadmin)%>
+            <%= button_to 'Manually Reset', reoccurring_jobs_path(reset_log: 'true'), method: 'post', class: 'btn button secondary-button' %>
+          <% end %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/factories/activity_stream_logs.rb
+++ b/spec/factories/activity_stream_logs.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :activity_stream_log do
-    run_time { "2020-06-12 18:27:44" }
+    run_time { "2023-05-01 18:27:44" }
     activity_stream_items { 673 }
     retrieved_records { 4 }
     status { "Success" }
@@ -11,6 +11,9 @@ FactoryBot.define do
     end
     factory :failed_activity_stream_log do
       status { "Failed" }
+    end
+    factory :running_activity_stream_log do
+      status { "Running" }
     end
   end
 end

--- a/spec/models/activity_stream_log_spec.rb
+++ b/spec/models/activity_stream_log_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ActivityStreamLog, type: :model do
   it "has all expected fields" do
     asl
 
-    expect(asl.run_time).to eq "2020-06-12 18:27:44"
+    expect(asl.run_time).to eq "2023-05-01 18:27:44"
     expect(asl.activity_stream_items).to eq 673
     expect(asl.retrieved_records).to eq 4
     expect(asl.status).to eq "Success"

--- a/spec/system/recurring_job_status_spec.rb
+++ b/spec/system/recurring_job_status_spec.rb
@@ -4,14 +4,13 @@ require 'rails_helper'
 RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
   let(:running_activity_stream_log) { FactoryBot.create(:running_activity_stream_log) }
-  let(:running_activity_stream_log_active) { FactoryBot.create(:running_activity_stream_log, run_time: DateTime.now - 8.hours) }
+  let(:running_activity_stream_log_active) { FactoryBot.create(:running_activity_stream_log, run_time: DateTime.current - 8.hours) }
 
   def queue_adapter_for_test
     ActiveJob::QueueAdapters::DelayedJobAdapter.new
   end
 
   context 'Reoccuring Job page' do
-
     before do
       login_as user
       visit reoccurring_jobs_path

--- a/spec/system/recurring_job_status_spec.rb
+++ b/spec/system/recurring_job_status_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, pre
   let(:user) { FactoryBot.create(:sysadmin_user) }
   let(:running_logger) { FactoryBot.create(:running_activity_stream_log) }
   let(:running_activity_stream_log_active) { FactoryBot.create(:running_activity_stream_log, run_time: DateTime.current - 8.hours) }
-  # let(:running_logger) { FactoryBot.build(:running_activity_stream_log, status: 'Running') }
 
   def queue_adapter_for_test
     ActiveJob::QueueAdapters::DelayedJobAdapter.new

--- a/spec/system/recurring_job_status_spec.rb
+++ b/spec/system/recurring_job_status_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 
 RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
-  let(:running_activity_stream_log) { FactoryBot.create(:running_activity_stream_log) }
+  let(:running_logger) { FactoryBot.create(:running_activity_stream_log) }
   let(:running_activity_stream_log_active) { FactoryBot.create(:running_activity_stream_log, run_time: DateTime.current - 8.hours) }
+  # let(:running_logger) { FactoryBot.build(:running_activity_stream_log, status: 'Running') }
 
   def queue_adapter_for_test
     ActiveJob::QueueAdapters::DelayedJobAdapter.new
@@ -14,10 +15,6 @@ RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, pre
     before do
       login_as user
       visit reoccurring_jobs_path
-    end
-
-    it 'cannot Manually Reset if the user is not a system admin' do
-      expect(page).to have_button('Manually Reset')
     end
 
     it 'has a button to check the status' do
@@ -41,14 +38,22 @@ RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, pre
       page.driver.browser.switch_to.alert.accept
       expect(page).to have_content('The manual job has been queued.')
     end
+  end
 
-    it 'can see the Manually Reset button if the Logs is older than 12 hours with a Running status' do
-      running_activity_stream_log
-      expect(running_activity_stream_log.status).to eq("Running")
+  context 'Resetting the Logger status' do
+    before do
+      running_logger
+      login_as user
+      visit reoccurring_jobs_path
+    end
+
+    it 'can see the Manually Reset button and manually reset the status if the Log is older than 12 hours with a Running status' do
+      expect(running_logger.status).to eq("Running")
       click_on "Check status of the Recurring Job"
       expect(page).to have_button('Manually Reset')
       click_on "Manually Reset"
-      expect(running_activity_stream_log.status).to eq("Manually Reset")
+      running_logger.reload
+      expect(running_logger.status).to eq("Manually Reset")
     end
 
     it 'cannot see the Manually Reset button if the Logs is not older than 12 hours with a Running status' do
@@ -66,6 +71,7 @@ RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, pre
     end
 
     it 'cannot Manually Reset if the user is not a system admin' do
+      running_activity_stream_log_active
       click_on "Check status of the Recurring Job"
       expect(page).not_to have_button('Manually Reset')
     end

--- a/spec/system/recurring_job_status_spec.rb
+++ b/spec/system/recurring_job_status_spec.rb
@@ -3,18 +3,35 @@ require 'rails_helper'
 
 RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
+  let(:running_activity_stream_log) { FactoryBot.create(:running_activity_stream_log) }
 
   def queue_adapter_for_test
     ActiveJob::QueueAdapters::DelayedJobAdapter.new
   end
 
-  before do
-    login_as user
-  end
+  # around do |example|
+  #   perform_enqueued_jobs do
+  #     original_path_ocr = ENV['OCR_DOWNLOAD_BUCKET']
+  #     ENV['OCR_DOWNLOAD_BUCKET'] = "yul-dc-ocr-test"
+  #     example.run
+  #     ENV['OCR_DOWNLOAD_BUCKET'] = original_path_ocr
+  #   end
+  # end
 
   context 'Reoccuring Job page' do
+    # around do |example|
+    #   perform_enqueued_jobs do
+    #     example.run
+    #   end
+    # end
     before do
+      running_activity_stream_log
+      login_as user
       visit reoccurring_jobs_path
+    end
+
+    it 'cannot Manually Reset if the user is not a system admin' do
+      expect(page).to have_button('Manually Reset')
     end
 
     it 'has a button to check the status' do
@@ -37,6 +54,24 @@ RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, pre
       click_on('Trigger Job Manually')
       page.driver.browser.switch_to.alert.accept
       expect(page).to have_content('The manual job has been queued.')
+    end
+
+    it 'can Manually Reset as a system admin' do
+      click_on "Check status of the Recurring Job"
+      expect(page).to have_button('Manually Reset')
+    end
+  end
+
+  context 'Reoccuring Job page' do
+    before do
+      login_as user
+      user.remove_role(:sysadmin)
+      visit reoccurring_jobs_path
+    end
+
+    it 'cannot Manually Reset if the user is not a system admin' do
+      click_on "Check status of the Recurring Job"
+      expect(page).not_to have_button('Manually Reset')
     end
   end
 end


### PR DESCRIPTION
## Summary  
Adds a Reset button to the Reoccurring Jobs if the logger has a running status longer than 12 hours old.  
  
## Ticket  
[2446](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=24512491)