### PR TITLE
Refactor logic for role removal after user deactivation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,11 +29,14 @@ class User < ApplicationRecord
 
   def deactivate
     self.deactivated = true
-    remove_role :administrator
-    remove_role :approver
-    remove_role :editor
-    remove_role :sysadmin
-    remove_role :viewer
+    # roles = self.roles
+    roles.each do |role|
+      if role.name == 'sysadmin'
+        remove_role :sysadmin
+      else
+        remove_role(role.name, role.resource_type == 'AdminSet' ? AdminSet.find(role.resource_id) : PermissionSet.find(role.resource_id))
+      end
+    end
   end
 
   def token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
   has_many :users_roles
   has_many :permission_requests
 
+  after_update :remove_roles
+
   def self.system_user
     system_user = User.find_by_uid('System')
     unless system_user
@@ -29,7 +31,10 @@ class User < ApplicationRecord
 
   def deactivate
     self.deactivated = true
-    # roles = self.roles
+  end
+
+  def remove_roles
+    return unless deactivated
     roles.each do |role|
       if role.name == 'sysadmin'
         remove_role :sysadmin

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,14 +29,14 @@
 <table class='table table-striped user-roles-table table-bordered' aria-label='User Details'>
   <thead class='thead-dark'>
     <tr>
-      <th scope='col'> Admin Set </th>
+      <th scope='col'> Set </th>
       <th scope='col'> Role </th>
     </tr>
   </thead>
   <tbody>
     <% @user.roles.excluding(@user.roles.where(name: 'sysadmin')).each do |role| %>
       <tr>
-        <td><%= link_to role.resource.label, admin_set_path(role.resource)  %></td>
+        <td><%= link_to role.resource.label, role.resource_type == 'AdminSet' ? admin_set_path(role.resource) : permission_set_path(role.resource) %></td>
         <td><%= role.name %></td>
       </tr>
     <% end %>

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Users', type: :system, js: true do
     it 'displays the users roles' do
       expect(page).to have_content('User Details')
 
-      within('table', text: 'Admin Set') do
+      within('table', text: 'Set') do
         expect(page).to have_css('td', text: admin_set.label.to_s)
         expect(page).to have_css('td', text: "editor")
       end


### PR DESCRIPTION
# Summary
This PR aims to refactor the deactivation of a user to remove them from all roles held.

# Related Ticket 
[#2467](https://github.com/yalelibrary/YUL-DC/issues/2467)

# Notes
Also includes a change to display and properly link to permission sets as well as admin sets on the user show page.