### PR TITLE
decrease ptiff generation allocation

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -2,7 +2,7 @@
 
 class SetupMetadataJob < ApplicationJob
   queue_as :metadata
-  ONE_GB = 1_073_741_824
+  FIVE_HUNDRED_MB = 65_536_000
 
   def perform(parent_object, current_batch_process, current_batch_connection = parent_object.current_batch_connection)
     parent_object.current_batch_process = current_batch_process
@@ -65,8 +65,8 @@ class SetupMetadataJob < ApplicationJob
       else
         path = Pathname.new(child.access_master_path)
         file_size = File.exist?(path) ? File.size(path) : 0
-        GeneratePtiffJob.set(queue: :large_ptiff).perform_later(child, current_batch_process) if file_size > ONE_GB
-        GeneratePtiffJob.perform_later(child, current_batch_process) if file_size <= ONE_GB
+        GeneratePtiffJob.set(queue: :large_ptiff).perform_later(child, current_batch_process) if file_size > FIVE_HUNDRED_MB
+        GeneratePtiffJob.perform_later(child, current_batch_process) if file_size <= FIVE_HUNDRED_MB
         child.processing_event("Ptiff Queued", "ptiff-queued")
         ptiff_jobs_queued = true
       end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -363,8 +363,8 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
       next unless user_update_child_permission(child_object, child_object.parent_object)
       path = Pathname.new(child_object.access_master_path)
       file_size = File.exist?(path) ? File.size(path) : 0
-      GeneratePtiffJob.set(queue: :large_ptiff).perform_later(child_object, self) if file_size > SetupMetadataJob::ONE_GB
-      GeneratePtiffJob.perform_later(child_object, self) if file_size <= SetupMetadataJob::ONE_GB
+      GeneratePtiffJob.set(queue: :large_ptiff).perform_later(child_object, self) if file_size > SetupMetadataJob::FIVE_HUNDRED_MB
+      GeneratePtiffJob.perform_later(child_object, self) if file_size <= SetupMetadataJob::FIVE_HUNDRED_MB
       attach_item(child_object)
       child_object.processing_event("Ptiff Queued", "ptiff-queued")
     end


### PR DESCRIPTION
## Summary  
Decreases PTIFF generation disk allocation to 500 MB  
  
## Ticket  
[2462](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=25662694)