### PR TITLE
Aspace extent of digitization

### DIFF
--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -11,7 +11,7 @@ module PdfRepresentable
     date
     sourceTitle
     rights
-    extentOfDigitization
+    extent_of_digitization
   ].freeze
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -160,11 +160,12 @@ METADATA_FIELDS = {
     ],
     digital_only: true
   },
-  extentOfDigitization: {
+  extent_of_digitization: {
     label: 'Extent of Digitization',
     solr_fields: [
       'extentOfDigitization_ssim'
-    ]
+    ],
+    digital_only: true
   },
   findingAid: {
     label: 'Finding Aid',


### PR DESCRIPTION
## Summary  
Adds a digital_only tag to extent of digitization metadata field to ensure extent gets logged for aspace records  
  
## Ticket  
[2488](https://github.com/yalelibrary/YUL-DC/issues/2488)
