### PR TITLE
Requires extent of digitization in csv for creating aspace parent

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -235,10 +235,10 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         parent_object.holding = row['holding']
         parent_object.item = row['item']
 
-        if row['aspace_uri'].present? && row['extent_of_digitization'].blank?
+        if metadata_source == 'aspace' && row['extent_of_digitization'].blank?
           batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}.  Parent objects with ASpace as a source must have an Extent of Digitization value.", 'Skipped Row')
           next
-        elsif row['aspace_uri'].present? && row['extent_of_digitization'].present?
+        elsif metadata_source == 'aspace' && row['extent_of_digitization'].present?
           if row['extent_of_digitization'] == 'Completely digitized' || row['extent_of_digitization'] == 'Partially digitized'
             parent_object.extent_of_digitization = row['extent_of_digitization']
           else

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -230,15 +230,22 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
           parent_object = ParentObject.find_or_initialize_by(oid: oid)
         end
 
-        aspace_uri = row['aspace_uri']
-        bib = row['bib']
-        holding = row['holding']
-        item = row['item']
+        parent_object.aspace_uri = row['aspace_uri']
+        parent_object.bib = row['bib']
+        parent_object.holding = row['holding']
+        parent_object.item = row['item']
 
-        parent_object.aspace_uri = aspace_uri
-        parent_object.bib = bib
-        parent_object.holding = holding
-        parent_object.item = item
+        if row['aspace_uri'].present? && row['extent_of_digitization'].blank?
+          batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}.  Parent objects with ASpace as a source must have an Extent of Digitization value.", 'Skipped Row')
+          next
+        elsif row['aspace_uri'].present? && row['extent_of_digitization'].present?
+          if row['extent_of_digitization'] == 'Completely digitized' || row['extent_of_digitization'] == 'Partially digitized'
+            parent_object.extent_of_digitization = row['extent_of_digitization']
+          else
+            batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}.  Extent of Digitization value must be 'Completely digitized' or 'Partially digitized'.", 'Skipped Row')
+            next
+          end
+        end
 
         # Only runs on newly created parent objects
         unless parent_object.new_record?

--- a/public/batch_processes/templates/create_parent_objects.csv
+++ b/public/batch_processes/templates/create_parent_objects.csv
@@ -1,1 +1,1 @@
-oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization

--- a/spec/fixtures/csv/aspace_parent.csv
+++ b/spec/fixtures/csv/aspace_parent.csv
@@ -1,2 +1,2 @@
-oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility
-,brbl,aspace,/repositories/12/archival_objects/781086,4320085,,,39002075038423,Public
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,extent_of_digitization
+,brbl,aspace,/repositories/12/archival_objects/781086,4320085,,,39002075038423,Public,Partially digitized

--- a/spec/fixtures/csv/aspace_parent_no_extent.csv
+++ b/spec/fixtures/csv/aspace_parent_no_extent.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,extent_of_digitization
+,brbl,aspace,/repositories/12/archival_objects/781086,4320085,,,39002075038423,Public,

--- a/spec/fixtures/csv/aspace_parent_typo_extent.csv
+++ b/spec/fixtures/csv/aspace_parent_typo_extent.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,extent_of_digitization
+,brbl,aspace,/repositories/12/archival_objects/781086,4320085,,,39002075038423,Public,Somewhat digitized

--- a/spec/fixtures/csv/parent_no_oid.csv
+++ b/spec/fixtures/csv/parent_no_oid.csv
@@ -1,2 +1,2 @@
-oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
-2019479,brbl,aspace,/repositories/12/archival_objects/2019479,,,,39002042501289,Yale Community Only,,,
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization
+2019479,brbl,aspace,/repositories/12/archival_objects/2019479,,,,39002042501289,Yale Community Only,,,,Partially digitized

--- a/spec/fixtures/csv/short_fixture_ids_with_source.csv
+++ b/spec/fixtures/csv/short_fixture_ids_with_source.csv
@@ -1,4 +1,4 @@
-oid,source,admin_set
+oid,source,admin_set,extent_of_digitization
 2034600,ladybird,sml
 2030006,ils,sml
-2012036,aspace,sml
+2012036,aspace,sml,Partially digitized

--- a/spec/fixtures/csv/update_example_pre_preservica.csv
+++ b/spec/fixtures/csv/update_example_pre_preservica.csv
@@ -1,2 +1,2 @@
 oid,source,admin_set,project_identifier,visibility,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout,digitization_funding_source,digital_object_source,preservica_uri,preservica_representation_type
-200000000,aspace,brbl,,,,,,,,,,/repositories/11/archival_objects/200000000,,,,,,
+200000000,aspace,brbl,,,,Partially digitized,,,,,,/repositories/11/archival_objects/200000000,,,,,,,

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -4,23 +4,25 @@ require 'rails_helper'
 
 RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
   subject(:batch_process) { described_class.new }
-  let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:user) { FactoryBot.create(:user, uid: 'mk2525') }
   let(:admin_set_one) { FactoryBot.create(:admin_set, key: 'jss') }
-  let(:no_oid_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "parent_no_oid.csv")) }
-  let(:no_admin_set) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "parent_no_admin_set.csv")) }
-  let(:no_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "parent_no_source.csv")) }
-  let(:aspace_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "aspace_parent.csv")) }
+  let(:no_oid_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'csv', 'parent_no_oid.csv')) }
+  let(:no_admin_set) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'csv', 'parent_no_admin_set.csv')) }
+  let(:no_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'csv', 'parent_no_source.csv')) }
+  let(:no_extent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'csv', 'aspace_parent_no_extent.csv')) }
+  let(:typo_extent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'csv', 'aspace_parent_typo_extent.csv')) }
+  let(:aspace_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, 'csv', 'aspace_parent.csv')) }
 
   around do |example|
-    original_image_bucket = ENV["S3_SOURCE_BUCKET_NAME"]
-    original_access_master_mount = ENV["ACCESS_MASTER_MOUNT"]
-    ENV["S3_SOURCE_BUCKET_NAME"] = "yale-test-image-samples"
-    ENV['ACCESS_MASTER_MOUNT'] = File.join("spec", "fixtures", "images", "access_masters")
+    original_image_bucket = ENV['S3_SOURCE_BUCKET_NAME']
+    original_access_master_mount = ENV['ACCESS_MASTER_MOUNT']
+    ENV['S3_SOURCE_BUCKET_NAME'] = 'yale-test-image-samples'
+    ENV['ACCESS_MASTER_MOUNT'] = File.join('spec', 'fixtures', 'images', 'access_masters')
     perform_enqueued_jobs do
       example.run
     end
-    ENV["S3_SOURCE_BUCKET_NAME"] = original_image_bucket
-    ENV["ACCESS_MASTER_MOUNT"] = original_access_master_mount
+    ENV['S3_SOURCE_BUCKET_NAME'] = original_image_bucket
+    ENV['ACCESS_MASTER_MOUNT'] = original_access_master_mount
   end
 
   before do
@@ -29,13 +31,13 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
     batch_process.user_id = user.id
   end
 
-  describe "with the metadata cloud mocked" do
+  describe 'with the metadata cloud mocked' do
     before do
-      stub_metadata_cloud("AS-781086", "aspace")
+      stub_metadata_cloud('AS-781086', 'aspace')
     end
 
-    context "Create Parent Object batch process with a csv" do
-      it "can create a parent object from aspace" do
+    context 'Create Parent Object batch process with a csv' do
+      it 'can create a parent object from aspace' do
         expect do
           batch_process.file = aspace_parent
           batch_process.save
@@ -44,7 +46,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
         expect(po.bib).to eq('4320085')
         expect(po.aspace_uri).to eq('/repositories/12/archival_objects/781086')
       end
-      it "can create a parent_object" do
+      it 'can create a parent_object' do
         expect do
           batch_process.file = no_oid_parent
           batch_process.save
@@ -52,19 +54,33 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
         po = ParentObject.first
         expect(po.oid).not_to be_nil
       end
-      it "can fails when csv has no admin set" do
+      it 'can fail when csv has no admin set' do
         expect do
           batch_process.file = no_admin_set
           batch_process.save
         end.not_to change { ParentObject.count }
-        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown admin set [] for parent: ")
+        expect(batch_process.batch_ingest_events[0].reason).to eq('Skipping row [2] with unknown admin set [] for parent: ')
       end
-      it "can fails when csv has no source" do
+      it 'can fail when csv has no source' do
         expect do
           batch_process.file = no_source
           batch_process.save
         end.not_to change { ParentObject.count }
-        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2]. Source cannot be blank.")
+        expect(batch_process.batch_ingest_events[0].reason).to eq('Skipping row [2]. Source cannot be blank.')
+      end
+      it 'can fail when aspace is source but no extent of digitization is provided' do
+        expect do
+          batch_process.file = no_extent
+          batch_process.save
+        end.not_to change { ParentObject.count }
+        expect(batch_process.batch_ingest_events[0].reason).to eq('Skipping row [2] with parent oid: 200000000.  Parent objects with ASpace as a source must have an Extent of Digitization value.')
+      end
+      it 'can fail when aspace is source but extent of digitization is not an accepted value' do
+        expect do
+          batch_process.file = typo_extent
+          batch_process.save
+        end.not_to change { ParentObject.count }
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with parent oid: 200000000.  Extent of Digitization value must be 'Completely digitized' or 'Partially digitized'.")
       end
     end
   end

--- a/spec/requests/batch_processes_request_spec.rb
+++ b/spec/requests/batch_processes_request_spec.rb
@@ -168,12 +168,14 @@ RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
       login_as user
     end
 
+    # rubocop:disable Metrics/LineLength
     it "downloads template for parent objects" do
       get download_template_batch_processes_url(batch_action: "create parent objects")
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("text/csv; charset=utf-8")
-      expect(response.body.to_s).to eq("\xEF\xBB\xBFoid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type")
+      expect(response.body.to_s).to eq("\xEF\xBB\xBFoid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization")
     end
+    # rubocop:enable Metrics/LineLength
 
     it "downloads template for delete child objects" do
       get download_template_batch_processes_url(batch_action: "delete child objects")


### PR DESCRIPTION
# Summary
When creating a parent object with Aspace as a source the process now requires that the extent of digitization field be included in the csv.

# Related Ticket 
[#2495](https://github.com/yalelibrary/YUL-DC/issues/2495)