### PR TITLE
Ensure parent saves attribute

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -609,6 +609,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
     self.extent_of_full_text = "Partial" if children_with_ft && children_without_ft # if some children have full text and others dont
     self.extent_of_full_text = "None" unless children_with_ft # if none of children have full_text
+    save!
   end
 
   def should_index?

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           solr_document = parent_of_four.to_solr_full_text.first
           expect(solr_document).not_to be_nil
           expect(solr_document[:has_fulltext_ssi].to_s).to eq "Partial"
+          expect(parent_of_four.extent_of_full_text).to eq "Partial"
         end
         it "does not include nil in child records" do
           child_solr_documents = parent_of_four.to_solr_full_text.second
@@ -123,6 +124,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           expect(solr_document).not_to be_nil
           expect(solr_document[:fulltext_tesim].to_s).to include("много трудившейся")
           expect(solr_document[:has_fulltext_ssi].to_s).to eq "Yes"
+          expect(parent_of_four.extent_of_full_text).to eq "Yes"
         end
       end
     end


### PR DESCRIPTION
# Summary
In trying to get the datatables to sort properly an attribute was changed.  This PR ensures that change is saved to the parent.

# Related Ticket
[#2489](https://github.com/yalelibrary/YUL-DC/issues/2489)