### PR TITLE
Adds fields to digital object json

### DIFF
--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -5,7 +5,7 @@ module DigitalObjectManagement
 
   def digital_object_json_available?
     return false unless child_object_count&.positive?
-    return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
+    return false unless authoritative_metadata_source
     return false unless ['Public', 'Yale Community Only', 'Private'].include? visibility
     return false unless digital_object_title
     return false if redirect_to.present?
@@ -20,7 +20,12 @@ module DigitalObjectManagement
         thumbnailOid: representative_child && representative_child.oid || nil,
         thumbnailCaption: representative_child && representative_child.label || nil,
         archivesSpaceUri: aspace_uri,
+        barcode: barcode,
+        bibId: bib,
         childCount: child_object_count,
+        holdingId: holding,
+        itemId: item,
+        source: authoritative_metadata_source.metadata_cloud_name,
         visibility: visibility }.to_json
   end
 

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -4,7 +4,6 @@ module DigitalObjectManagement
   extend ActiveSupport::Concern
 
   def digital_object_json_available?
-    byebug
     return false unless child_object_count&.positive?
     return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
     return false unless ['Public', 'Yale Community Only', 'Private'].include? visibility

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -4,8 +4,9 @@ module DigitalObjectManagement
   extend ActiveSupport::Concern
 
   def digital_object_json_available?
+    byebug
     return false unless child_object_count&.positive?
-    return false unless authoritative_metadata_source
+    return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
     return false unless ['Public', 'Yale Community Only', 'Private'].include? visibility
     return false unless digital_object_title
     return false if redirect_to.present?

--- a/spec/models/concerns/digital_object_management_spec.rb
+++ b/spec/models/concerns/digital_object_management_spec.rb
@@ -3,22 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe DigitalObjectManagement, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
-  let(:ladybird) { 1 }
+  let(:aspace) { 3 }
 
   it "has digital object json with expected fields" do
     full_parent_object = FactoryBot.build(:parent_object,
                                           oid: '45678',
-                                          authoritative_metadata_source_id: ladybird,
+                                          authoritative_metadata_source_id: aspace,
+                                          aspace_uri: '/aspace_uri',
                                           holding: '987654321',
                                           item: '23456789',
                                           child_object_count: 1,
                                           visibility: "Private",
-                                          ladybird_json: { "title": ["test"] })
+                                          aspace_json: { "title": ["test"] })
     full_parent_object.bib = '123456789'
     full_parent_object.barcode = '98765432'
     full_parent_object.save!
+    byebug
     expect(full_parent_object.digital_object_json_available?).to be_truthy
-    expect(JSON.parse(full_parent_object.generate_digital_object_json)["source"]).to eq("ladybird")
+    expect(JSON.parse(full_parent_object.generate_digital_object_json)["source"]).to eq("aspace")
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["bibId"]).to eq("123456789")
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["holdingId"]).to eq("987654321")
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["itemId"]).to eq("23456789")

--- a/spec/models/concerns/digital_object_management_spec.rb
+++ b/spec/models/concerns/digital_object_management_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe DigitalObjectManagement, type: :model, prep_metadata_sources: tru
     full_parent_object.bib = '123456789'
     full_parent_object.barcode = '98765432'
     full_parent_object.save!
-    byebug
     expect(full_parent_object.digital_object_json_available?).to be_truthy
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["source"]).to eq("aspace")
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["bibId"]).to eq("123456789")

--- a/spec/models/concerns/digital_object_management_spec.rb
+++ b/spec/models/concerns/digital_object_management_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DigitalObjectManagement, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  let(:ladybird) { 1 }
+
+  it "has digital object json with expected fields" do
+    full_parent_object = FactoryBot.build(:parent_object,
+                                          oid: '45678',
+                                          authoritative_metadata_source_id: ladybird,
+                                          holding: '987654321',
+                                          item: '23456789',
+                                          child_object_count: 1,
+                                          visibility: "Private",
+                                          ladybird_json: { "title": ["test"] })
+    full_parent_object.bib = '123456789'
+    full_parent_object.barcode = '98765432'
+    full_parent_object.save!
+    expect(full_parent_object.digital_object_json_available?).to be_truthy
+    expect(JSON.parse(full_parent_object.generate_digital_object_json)["source"]).to eq("ladybird")
+    expect(JSON.parse(full_parent_object.generate_digital_object_json)["bibId"]).to eq("123456789")
+    expect(JSON.parse(full_parent_object.generate_digital_object_json)["holdingId"]).to eq("987654321")
+    expect(JSON.parse(full_parent_object.generate_digital_object_json)["itemId"]).to eq("23456789")
+    expect(JSON.parse(full_parent_object.generate_digital_object_json)["barcode"]).to eq("98765432")
+  end
+end


### PR DESCRIPTION
# Summary
Adds five more fields to the digital object json and now allows for aspace and ils as source to construct a digital object.

# Related Ticket
[#2506](https://github.com/yalelibrary/YUL-DC/issues/2506)