### PR TITLE
ILS Feature_Flag for Digital Object Updates

### DIFF
--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -3,14 +3,22 @@
 module DigitalObjectManagement
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def digital_object_json_available?
+    if ENV["VPN"] == "true" && ENV["FEATURE_FLAGS"]&.include?("|DO-ENABLE-ILS|")
+      return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "ils"
+    else
+      return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
+    end
     return false unless child_object_count&.positive?
-    return false unless authoritative_metadata_source && authoritative_metadata_source.metadata_cloud_name == "aspace"
     return false unless ['Public', 'Yale Community Only', 'Private'].include? visibility
     return false unless digital_object_title
     return false if redirect_to.present?
     true
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def generate_digital_object_json
     return nil unless digital_object_json_available?

--- a/app/models/concerns/digital_object_management.rb
+++ b/app/models/concerns/digital_object_management.rb
@@ -85,7 +85,7 @@ module DigitalObjectManagement
   end
 
   def send_digital_object_update(digital_object_update)
-    return false unless ENV["VPN"] == "true" && ENV["FEATURE_FLAGS"]&.include?("|DO-SEND|")
+    return false unless ENV["VPN"] == "true" && (ENV["FEATURE_FLAGS"]&.include?("|DO-SEND|") || ENV["FEATURE_FLAGS"]&.include?("|DO-ENABLE-ILS|"))
     full_response = mc_post("https://#{MetadataSource.metadata_cloud_host}/metadatacloud/api/digital_object_updates", digital_object_update)
     case full_response.status
     when 200

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -477,8 +477,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def voyager_json=(v_record)
     super(v_record)
     return v_record if v_record.blank?
-    self.holding = v_record["holdingId"] unless v_record["holdingId"].zero?
-    self.item = v_record["itemId"] unless v_record["itemId"].zero?
+    self.holding = v_record["holdingId"] unless v_record["holdingId"].nil?
+    self.item = v_record["itemId"] unless v_record["itemId"].nil?
     self.last_id_update = DateTime.current
     self.last_voyager_update = DateTime.current
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -477,8 +477,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def voyager_json=(v_record)
     super(v_record)
     return v_record if v_record.blank?
-    self.holding = v_record["holdingId"] unless v_record["holdingId"].zero?
-    self.item = v_record["itemId"] unless v_record["itemId"].zero?
+    self.holding = v_record["holdingId"] unless v_record["holdingId"]&.zero?
+    self.item = v_record["itemId"] unless v_record["itemId"]&.zero?
     self.last_id_update = DateTime.current
     self.last_voyager_update = DateTime.current
   end

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -477,8 +477,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def voyager_json=(v_record)
     super(v_record)
     return v_record if v_record.blank?
-    self.holding = v_record["holdingId"] unless v_record["holdingId"].nil?
-    self.item = v_record["itemId"] unless v_record["itemId"].nil?
+    self.holding = v_record["holdingId"] unless v_record["holdingId"].zero?
+    self.item = v_record["itemId"] unless v_record["itemId"].zero?
     self.last_id_update = DateTime.current
     self.last_voyager_update = DateTime.current
   end

--- a/spec/models/concerns/digital_object_management_spec.rb
+++ b/spec/models/concerns/digital_object_management_spec.rb
@@ -28,9 +28,14 @@ RSpec.describe DigitalObjectManagement, type: :model, prep_metadata_sources: tru
   end
 
   describe "with VPN true and FEATURE_FLAG enabled for ILS/Voyager" do
-    before do
+    around do |example|
+      original_vpn = ENV['VPN']
       ENV['VPN'] = "true"
-      ENV['FEATURE_FLAGS'] = "#{ENV['FEATURE_FLAGS']}|DO-ENABLE-ILS|"
+      original_flags = ENV['FEATURE_FLAGS']
+      ENV['FEATURE_FLAGS'] = "#{ENV['FEATURE_FLAGS']}|DO-ENABLE-ILS|" unless original_flags&.include?("|DO-ENABLE-ILS|")
+      example.run
+      ENV['VPN'] = original_vpn
+      ENV['FEATURE_FLAGS'] = original_flags
     end
 
     it "can send digital object updates" do

--- a/spec/models/concerns/digital_object_management_spec.rb
+++ b/spec/models/concerns/digital_object_management_spec.rb
@@ -42,13 +42,13 @@ RSpec.describe DigitalObjectManagement, type: :model, prep_metadata_sources: tru
       full_parent_object = FactoryBot.build(:parent_object,
                                             oid: '45678',
                                             authoritative_metadata_source_id: voyager,
-                                            holding: '987654321',
-                                            item: '23456789',
                                             child_object_count: 1,
                                             visibility: "Private",
                                             voyager_json: { "title": ["test"] })
       full_parent_object.bib = '123456789'
       full_parent_object.barcode = '98765432'
+      full_parent_object.holding = '987654321'
+      full_parent_object.item = '23456789'
       full_parent_object.save!
       expect(full_parent_object.digital_object_json_available?).to be_truthy
       expect(JSON.parse(full_parent_object.generate_digital_object_json)["source"]).to eq("ils")

--- a/spec/models/concerns/digital_object_management_spec.rb
+++ b/spec/models/concerns/digital_object_management_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe DigitalObjectManagement, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
   let(:aspace) { 3 }
+  let(:voyager) { 2 }
 
   it "has digital object json with expected fields" do
     full_parent_object = FactoryBot.build(:parent_object,
@@ -24,5 +25,32 @@ RSpec.describe DigitalObjectManagement, type: :model, prep_metadata_sources: tru
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["holdingId"]).to eq("987654321")
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["itemId"]).to eq("23456789")
     expect(JSON.parse(full_parent_object.generate_digital_object_json)["barcode"]).to eq("98765432")
+  end
+
+  describe "with VPN true and FEATURE_FLAG enabled for ILS/Voyager" do
+    before do
+      ENV['VPN'] = "true"
+      ENV['FEATURE_FLAGS'] = "#{ENV['FEATURE_FLAGS']}|DO-ENABLE-ILS|"
+    end
+
+    it "can send digital object updates" do
+      full_parent_object = FactoryBot.build(:parent_object,
+                                            oid: '45678',
+                                            authoritative_metadata_source_id: voyager,
+                                            holding: '987654321',
+                                            item: '23456789',
+                                            child_object_count: 1,
+                                            visibility: "Private",
+                                            voyager_json: { "title": ["test"] })
+      full_parent_object.bib = '123456789'
+      full_parent_object.barcode = '98765432'
+      full_parent_object.save!
+      expect(full_parent_object.digital_object_json_available?).to be_truthy
+      expect(JSON.parse(full_parent_object.generate_digital_object_json)["source"]).to eq("ils")
+      expect(JSON.parse(full_parent_object.generate_digital_object_json)["bibId"]).to eq("123456789")
+      expect(JSON.parse(full_parent_object.generate_digital_object_json)["holdingId"]).to eq("987654321")
+      expect(JSON.parse(full_parent_object.generate_digital_object_json)["itemId"]).to eq("23456789")
+      expect(JSON.parse(full_parent_object.generate_digital_object_json)["barcode"]).to eq("98765432")
+    end
   end
 end


### PR DESCRIPTION
## Summary  
Adds a FEATURE_FLAG check for DO-ENABLE-ILS that allows ILS objects to send digital object updates.   
  
DO-ENABLE-ILS has been added to the UAT FEATURE_FLAGS