### PR TITLE
adds confirmation alert for updating manifests

### DIFF
--- a/app/views/admin_sets/show.html.erb
+++ b/app/views/admin_sets/show.html.erb
@@ -9,7 +9,7 @@
 <div id="admin_set_button_row">
   <a href="#BatchUpdateMetadata" role="button" class="btn btn-large btn-secondary" data-toggle="modal">Batch Update Metadata</a>
   <%= button_to "Export Parent Objects", export_parent_objects_batch_processes_url(admin_set: @admin_set.key, admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary export_button" %>
-  <%= button_to "Update IIIF Manifests", update_manifests_parent_objects_url(admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary update_manifest" %>
+  <%= button_to "Update IIIF Manifests", update_manifests_parent_objects_url(admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary update_manifest", data: { confirm: 'Are you sure you want to update the IIIF manifests for this entire set?' } %>
 </div>
 
 <p>

--- a/spec/system/admin_set_spec.rb
+++ b/spec/system/admin_set_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       visit admin_sets_path
       click_link(admin_set.key.to_s)
       click_on("Update IIIF Manifests")
+      page.driver.browser.switch_to.alert.accept
       expect(page).to have_content "IIIF Manifests queued for update. Please check Delayed Job dashboard for status"
     end
 
@@ -85,6 +86,7 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       visit admin_sets_path
       click_link(admin_set.key.to_s)
       click_on("Update IIIF Manifests")
+      page.driver.browser.switch_to.alert.accept
       expect(page).to have_content "User does not have permission to update Admin Set."
     end
 
@@ -244,6 +246,7 @@ RSpec.describe 'Admin Sets', type: :system, js: true do
       visit admin_sets_path
       click_link(admin_set.key.to_s)
       click_on("Update IIIF Manifests")
+      page.driver.browser.switch_to.alert.accept
       expect(page).to have_content "User does not have permission to update Admin Set."
     end
   end


### PR DESCRIPTION
## Summary  
Clicking "Update IIIF Manifests" button now prompts an alert to confirm.  
  
Screenshot:  
<img width="1786" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/a9e831ab-6cdd-435a-8213-b205c2dfd5fb">
