### PR TITLE
allow TIF file extentions for preservica sync

### DIFF
--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -72,7 +72,7 @@ class PreservicaImageService
         raise PreservicaImageServiceError.new("No matching bitstreams found in Preservica", content_object.active_generations[0].id.to_s) if content_object.active_generations[0].bitstreams.empty?
         next unless content_object.active_generations[0].formats.include? "Tagged Image File Format"
         tif_bitstream = content_object.active_generations[0].bitstreams.find do |bitstream|
-          bitstream.filename.ends_with?("tif", "tiff")
+          bitstream.filename.ends_with?("tif", "TIF", "tiff")
         end
         next unless tif_bitstream.present?
         raise PreservicaImageServiceError.new("SHA mismatch found in Preservica", "bitstream: #{content_object.active_generations[0].bitstreams[0].id}") if tif_bitstream.sha512_checksum.nil?

--- a/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1.xml
@@ -45,7 +45,7 @@
     <Bitstream filename="mss_29_s03_b092_f0019.pdf">
       /home/app/webapp/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/2
     </Bitstream>
-    <Bitstream filename="mss_29_s03_b092_f0019.tif">
+    <Bitstream filename="mss_29_s03_b092_f0019.TIF">
       /home/app/webapp/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1
     </Bitstream>
   </Bitstreams>

--- a/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
   <xip:Bitstream>
-    <xip:Filename>mss_29_s03_b092_f0019.tif</xip:Filename>
+    <xip:Filename>mss_29_s03_b092_f0019.TIF</xip:Filename>
     <xip:FileSize>310202</xip:FileSize>
     <xip:Fixities>
       <xip:Fixity>

--- a/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/2.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/2.xml
@@ -35,7 +35,7 @@
     </xip:Properties>
   </xip:Generation>
   <Bitstreams>
-    <Bitstream filename="mss_29_s03_b092_f0019.tif">
+    <Bitstream filename="mss_29_s03_b092_f0019.TIF">
       /home/app/webapp/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/2/bitstreams/1
     </Bitstream>
   </Bitstreams>

--- a/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/2/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/2/bitstreams/1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
   <xip:Bitstream>
-    <xip:Filename>mss_29_s03_b092_f0019.tif</xip:Filename>
+    <xip:Filename>mss_29_s03_b092_f0019.TIF</xip:Filename>
     <xip:FileSize>310202</xip:FileSize>
     <xip:Fixities>
       <xip:Fixity>

--- a/spec/models/preservica/preservica_import_spec.rb
+++ b/spec/models/preservica/preservica_import_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1"
     expect(co_first.preservica_bitstream_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"
     expect(co_first.sha512_checksum).to eq "1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7"
-    expect(co_first.caption).to eq "mss_29_s03_b092_f0019.tif"
+    expect(co_first.caption).to eq "mss_29_s03_b092_f0019.TIF"
     expect(File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")).to be true
     expect(File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")).to be true
     expect(File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")).to be true


### PR DESCRIPTION
## Summary  
TIF extensions are now allowed for preservica resync  
  
## Ticket  
[2516](https://github.com/orgs/yalelibrary/projects/1/views/1?filterQuery=&pane=issue&itemId=30831469)