### PR TITLE
Add methods to SolrService to add and remove copyfields

### DIFF
--- a/app/services/solr_service.rb
+++ b/app/services/solr_service.rb
@@ -102,6 +102,30 @@ class SolrService
     )
   end
 
+  # Creates a new copy field type to update managed schema
+  def self.add_copy_field(source, dest)
+    post_to_schema(
+      "add-copy-field": {
+        "source": source,
+        "dest": dest
+      }
+    )
+  end
+
+  # Deletes a copy field type to update managed schema
+  def self.delete_copy_field(source, dest)
+    post_to_schema(
+      "delete-copy-field": {
+        "source": source,
+        "dest": dest
+      }
+    )
+  end
+
+  def self.get_file(file)
+    connection.connection.get("admin/file?file=#{file}")
+  end
+
   def self.post_to_schema(data)
     connection.connection.post('schema') do |req|
       req.body = data.to_json

--- a/spec/services/solr_service_spec.rb
+++ b/spec/services/solr_service_spec.rb
@@ -36,4 +36,36 @@ RSpec.describe SolrService, solr: true do
   it 'can replace a dynamic field type' do
     expect(SolrService.replace_dynamic_field('*_wstsim', 'text_ocr', true, true, true).success?).to eq true
   end
+
+  context 'copy field add remove' do
+    around do |example|
+      begin
+        SolrService.delete_copy_field("test_field_tesim", "test_ssim")
+      rescue
+        nil # do nothing
+      end
+      example.run
+      begin
+        SolrService.delete_copy_field("test_field_tesim", "test_ssim")
+      rescue
+        nil # do nothing
+      end
+    end
+
+    it 'can trigger an error when deleting a copy field that does not exist' do
+      expect do
+        SolrService.delete_copy_field("test_field_tesim", "test_ssim")
+      end.to raise_error(Faraday::BadRequestError)
+    end
+    it 'can add a copy field' do
+      expect(SolrService.get_file("managed-schema").body.include?('<copyField source="test_field_tesim" dest="test_ssim"/>')).to be_falsy
+      expect(SolrService.add_copy_field("test_field_tesim", "test_ssim").success?).to eq true
+      expect(SolrService.get_file("managed-schema").body.include?('<copyField source="test_field_tesim" dest="test_ssim"/>')).to be_truthy
+      SolrService.delete_copy_field("test_field_tesim", "test_ssim")
+    end
+    it 'can delete a copy field after adding it' do
+      SolrService.add_copy_field("test_field_tesim", "test_ssim")
+      expect(SolrService.delete_copy_field("test_field_tesim", "test_ssim").success?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
Add the method, but does not use it for now.

Test by using rails c.
```
SolrService.add_copy_field("title_tsim", "title_spell")
puts SolrService.get_file("managed-schema").body.include?('<copyField source="title_tsim" dest="title_spell"/>')
SolrService.delete_copy_field("title_tsim", "title_spell")
puts SolrService.get_file("managed-schema").body.include?('<copyField source="title_tsim" dest="title_spell"/>')
```

It should output true and then false.