### PR TITLE
Reoccuring Jobs Status Page created_at

### DIFF
--- a/app/controllers/reoccurring_jobs_controller.rb
+++ b/app/controllers/reoccurring_jobs_controller.rb
@@ -8,7 +8,7 @@ class ReoccurringJobsController < ApplicationController
       @check_status = true
       @scheduled_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamJob%').exists?
       @manual_job_exists = Delayed::Job.page(params[:page]).where('handler LIKE ?', '%job_class: ActivityStreamManualJob%').exists?
-      @expired_logger = true if ActivityStreamLog.last&.status == "Running" && ActivityStreamLog.last&.run_time&.to_datetime <= DateTime.current - 12.hours
+      @expired_logger = true if ActivityStreamLog.last&.status == "Running" && ActivityStreamLog.last&.created_at&.to_datetime <= DateTime.current - 12.hours
     end
     @reoccurring_jobs = ActivityStreamLog.all
     respond_to do |format|

--- a/spec/system/recurring_job_status_spec.rb
+++ b/spec/system/recurring_job_status_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, prep_admin_sets: true, js: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
-  let(:running_logger) { FactoryBot.create(:running_activity_stream_log) }
+  let(:running_logger) { FactoryBot.create(:running_activity_stream_log, created_at: DateTime.current - 24.hours) }
   let(:running_activity_stream_log_active) { FactoryBot.create(:running_activity_stream_log, run_time: DateTime.current - 8.hours) }
 
   def queue_adapter_for_test
@@ -47,6 +47,8 @@ RSpec.describe 'Recurring Jobs', type: :system, prep_metadata_sources: true, pre
     end
 
     it 'can see the Manually Reset button and manually reset the status if the Log is older than 12 hours with a Running status' do
+      # running_logger.created_at = "2023-07-08 14:59:47.016376000 +0000"
+      # running_logger.save
       expect(running_logger.status).to eq("Running")
       click_on "Check status of the Recurring Job"
       expect(page).to have_button('Manually Reset')


### PR DESCRIPTION
## Summary  
Changed run_time to created_at since jobs dont have a run_time logged when its currently running.  
