### PR TITLE
last_sierra_update added to batch process exports

### DIFF
--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -11,7 +11,7 @@ module CsvExportable
     ['oid', 'admin_set', 'authoritative_source', 'child_object_count', 'call_number',
      'container_grouping', 'bib', 'holding', 'item', 'barcode', 'aspace_uri',
      'digital_object_source', 'preservica_uri', 'last_ladybird_update',
-     'last_voyager_update', 'last_aspace_update', 'last_id_update', 'visibility',
+     'last_voyager_update', 'last_sierra_update', 'last_aspace_update', 'last_id_update', 'visibility',
      'extent_of_digitization', 'digitization_note', 'digitization_funding_source', 'project_identifier', 'full_text']
   end
 
@@ -38,7 +38,7 @@ module CsvExportable
       [po.oid, po.admin_set.key, po.source_name,
        po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
        po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
-       po.last_ladybird_update, po.last_voyager_update,
+       po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
        po.last_aspace_update, po.last_id_update, po.visibility, po.extent_of_digitization,
        po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
     end
@@ -129,7 +129,7 @@ module CsvExportable
       row = [po.oid, po.admin_set.key, po.source_name,
              po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
              po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
-             po.last_ladybird_update, po.last_voyager_update,
+             po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
              po.last_aspace_update, po.last_id_update, po.visibility, po.extent_of_digitization,
              po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
       csv_rows << row

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -198,6 +198,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.export_parent_metadata).to include "/preservica_uri"
         expect(BatchProcess.last.export_parent_metadata).to include "brbl"
         expect(BatchProcess.last.export_parent_metadata).to include "full_text"
+        expect(BatchProcess.last.export_parent_metadata).to include "last_sierra_update"
       end
 
       it "uploads a CSV of parent objects in order to create export of parent objects metadata fails 2005512 row due to admin set permissions" do
@@ -227,6 +228,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
         expect(BatchProcess.last.parent_output_csv).to include "/preservica_uri"
         expect(BatchProcess.last.parent_output_csv).to include "brbl"
         expect(BatchProcess.last.parent_output_csv).to include "full_text"
+        expect(BatchProcess.last.parent_output_csv).to include "last_sierra_update"
         expect(BatchProcess.last.parent_output_csv).not_to include "2005512"
       end
 


### PR DESCRIPTION
## Summary  
last_sierra_update added to batch process exports  
   
## Screenshots:  
Export Parent Metadata:  
<img width="1612" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/ef773698-1642-418d-8f46-5d079c443805">
  
Export Parent Objects by Admin Set:  
<img width="1603" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/e5244615-68da-4051-b05d-1b4f18c4ec0d">
