### PR TITLE
Sync From Preservica increase priority 

### DIFF
--- a/app/jobs/sync_from_preservica_job.rb
+++ b/app/jobs/sync_from_preservica_job.rb
@@ -4,7 +4,7 @@ class SyncFromPreservicaJob < ApplicationJob
   queue_as :default
 
   def default_priority
-    50
+    0
   end
 
   def perform(batch_process)


### PR DESCRIPTION
## Summary  
Sync From Preservica priority increased to be prioritized over PDF and PTIFF generation jobs.  
  
Original:  
Generate PTIFF Priority: 10
Sync From Preservica priority: 50
Generate PDF Priority: 50  
  
After PR:  
Sync From Preservica priority: 0  
Generate PTIFF Priority: 10
Generate PDF Priority: 50