### PR TITLE
Include aspace ancestor creators in IIIF manifest and PDFs

### DIFF
--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -7,7 +7,7 @@ module PdfRepresentable
 
   NORMALIZED_COVER_FIELDS = %w[
     callNumber
-    creator
+    all_creators
     date
     sourceTitle
     rights
@@ -133,7 +133,7 @@ module PdfRepresentable
       # for normalized fields
       NORMALIZED_COVER_FIELDS.each do |field|
         hash = METADATA_FIELDS[field.to_sym]
-        properties = add_field_if_present(authoritative_json, field, hash[:label], properties)
+        properties = add_field_if_present(authoritative_json, field, hash, properties)
       end
 
       container_information = extract_container_information(authoritative_json)
@@ -146,11 +146,17 @@ module PdfRepresentable
       properties
     end
 
-    def add_field_if_present(json, field_name, hash_field, hash)
-      value = extract_flat_field_value(json, field_name, nil)
-      hash[hash_field] = value if value
+    def add_field_if_present(json, field_name, hash, properties)
+      if hash[:digital_only]
+        value = send(field_name)
+        value = Array(value).reject { |v| !keep_value?(v) }.join(", ")
+      else
+        value = extract_flat_field_value(json, field_name, nil)
+      end
+      value = ActionController::Base.helpers.sanitize(value, tags: [], attributes: []) if value
+      properties[hash[:label]] = value if value
 
-      hash
+      properties
     end
 
     def extract_flat_field_value(json, field_name, default)

--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -70,6 +70,14 @@ module SolrIndexable
     from_the_collections&.uniq
   end
 
+  # Putting this here since it uses from_the_collection from this concern
+  def all_creators
+    return unless authoritative_json
+    all_creators = authoritative_json["creator"] || []
+    all_creators += from_the_collections(authoritative_json)&.map { |v| "<em>From the Collection:</em> #{v}" } || []
+    all_creators.presence
+  end
+
   def to_solr(json_to_index = nil)
     if redirect_to.present?
       {

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -7,12 +7,13 @@ METADATA_FIELDS = {
       'alternativeTitle_tesim'
     ]
   },
-  creator: {
+  all_creators: {
     label: 'Creator',
     solr_fields: [
       'creator_ssim',
       'creator_tesim'
-    ]
+    ],
+    digital_only: true
   },
   date: {
     label: 'Published/Created Date',

--- a/spec/fixtures/aspace/AS-2005512.json
+++ b/spec/fixtures/aspace/AS-2005512.json
@@ -55,6 +55,9 @@
     "/aspace/repositories/11/resources/640",
     "/aspace/repositories/11"
   ],
+  "ancestorCreator": [
+    "The Parent Creator"
+  ],
   "repository": "Beinecke Rare Book and Manuscript Library",
   "createdBeginDate": [
 

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -90,6 +90,11 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["label"]["none"]).to eq ["Strawberry Thief fabric, made by Morris and Company "]
     end
 
+    it "includes all creators" do
+      creator = aspace_iiif_presentation.manifest["metadata"].select { |v| v["label"]["en"] == ["Creator"] }.first["value"]["none"]
+      expect(creator.find { |c| c.include? "<em>From the Collection:</em> The Parent Creator" })
+    end
+
     it "has a requiredStatement" do
       expect(iiif_presentation.manifest["requiredStatement"].class).to eq Hash
       expect(iiif_presentation.manifest["requiredStatement"]["label"]["en"].first).to eq "Provider"

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -91,8 +91,9 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
     end
 
     it "includes all creators" do
-      creator = aspace_iiif_presentation.manifest["metadata"].select { |v| v["label"]["en"] == ["Creator"] }.first["value"]["none"]
-      expect(creator.find { |c| c.include? "<em>From the Collection:</em> The Parent Creator" })
+      creators = aspace_iiif_presentation.manifest["metadata"].select { |v| v["label"]["en"] == ["Creator"] }.first["value"]["none"]
+      expect(creators.length).to eq(2)
+      expect(creators.find { |c| c.include? "<em>From the Collection:</em> The Parent Creator" })
     end
 
     it "has a requiredStatement" do


### PR DESCRIPTION
Include aspace ancestor creators in IIIF manifest and PDFs.