### PR TITLE
caption and label retain their value

### DIFF
--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -79,9 +79,9 @@ module Reassociatable
         # should not update parent title or call number
       elsif values_to_update.include? h
         if h == 'label'
-          co.label = check_for_blank(row[h]) unless !row[h].present?
+          co.label = check_for_blank(row[h]) if row[h].present?
         elsif h == 'caption'
-          co.caption = check_for_blank(row[h]) unless !row[h].present?
+          co.caption = check_for_blank(row[h]) if row[h].present?
         elsif h == 'order'
           order = extract_order(index, row)
           return false if order == :invalid_order # message says skipping row, returning

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -79,9 +79,9 @@ module Reassociatable
         # should not update parent title or call number
       elsif values_to_update.include? h
         if h == 'label'
-          co.label = check_for_blank(row[h])
+          co.label = check_for_blank(row[h]) unless row[h].nil?
         elsif h == 'caption'
-          co.caption = check_for_blank(row[h])
+          co.caption = check_for_blank(row[h]) unless row[h].nil?
         elsif h == 'order'
           order = extract_order(index, row)
           return false if order == :invalid_order # message says skipping row, returning

--- a/app/models/concerns/reassociatable.rb
+++ b/app/models/concerns/reassociatable.rb
@@ -79,9 +79,9 @@ module Reassociatable
         # should not update parent title or call number
       elsif values_to_update.include? h
         if h == 'label'
-          co.label = check_for_blank(row[h]) unless row[h].nil?
+          co.label = check_for_blank(row[h]) unless !row[h].present?
         elsif h == 'caption'
-          co.caption = check_for_blank(row[h]) unless row[h].nil?
+          co.caption = check_for_blank(row[h]) unless !row[h].present?
         elsif h == 'order'
           order = extract_order(index, row)
           return false if order == :invalid_order # message says skipping row, returning

--- a/spec/fixtures/csv/reassociation_example_child_caption.csv
+++ b/spec/fixtures/csv/reassociation_example_child_caption.csv
@@ -1,0 +1,2 @@
+child_oid,parent_oid,order,parent_title,label,caption,viewing_hint
+123456789,2004550,2,,,,

--- a/spec/fixtures/csv/reassociation_example_child_object_all_columns.csv
+++ b/spec/fixtures/csv/reassociation_example_child_object_all_columns.csv
@@ -1,2 +1,2 @@
 child_oid,parent_oid,order,label,caption,viewing_hint
-1030368,2005512,1,,,,
+1030368,2005512,1,_blank_,_blank_,,

--- a/spec/fixtures/csv/reassociation_example_child_object_counts.csv
+++ b/spec/fixtures/csv/reassociation_example_child_object_counts.csv
@@ -1,4 +1,4 @@
-child_oid,parent_oid,order,parent_title,call_number,label,caption,viewing_hint
+child_oid,parent_oid,order,parent_title,label,caption,viewing_hint
 1011398,2004548,3,Roe,[Portrait of Grace Nail Johnson],,,
-1021925,2004548,1,,,,,
-1021926,2004548,2,,,,,
+1021925,2004548,1,,_blank_,_blank_,
+1021926,2004548,2,,,,


### PR DESCRIPTION
## Summary  
Caption and Label will no longer be overridden on Child Object Reassociation batch processes.  
