### PR TITLE
Contributor to uv

### DIFF
--- a/app/models/concerns/solr_indexable.rb
+++ b/app/models/concerns/solr_indexable.rb
@@ -78,6 +78,16 @@ module SolrIndexable
     all_creators.presence
   end
 
+  def all_contributors
+    return unless authoritative_json
+    contributors = authoritative_json["contributor"] || []
+    if authoritative_json["source"] == "aspace"
+      contributors&.map { |v| "<i>From the Collection:</i> #{v}" } || []
+    else
+      contributors.presence
+    end
+  end
+
   def to_solr(json_to_index = nil)
     if redirect_to.present?
       {

--- a/config/initializers/metadata_fields.rb
+++ b/config/initializers/metadata_fields.rb
@@ -15,6 +15,13 @@ METADATA_FIELDS = {
     ],
     digital_only: true
   },
+  all_contributors: {
+    label: 'Contributor',
+    solr_fields: [
+      'contributor_tsim'
+    ],
+    digital_only: true
+  },
   date: {
     label: 'Published/Created Date',
     solr_fields: [


### PR DESCRIPTION
## Summary  
Adds Contributor to Universal Viewer.  
Aspace records have the "From the Collection:" prefix  
  
## Screenshots:  
Aspace record with the prefix:  
<img width="267" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/67fcc71f-dca6-4c71-8da7-7a38630281c5">
  
Ladybird object with 6 contributors (no prefix):  
<img width="288" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/5dcc218a-7c10-4566-8329-6ce9c9a6b212">
