### PR TITLE
Remove children without content uri

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -224,6 +224,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def sync_from_preservica(_local_children_hash, preservica_children_hash)
     # iterate through local hashes and remove any children no longer found on preservica
     child_objects.each do |co|
+      co.destroy if co.preservica_content_object_uri.nil?
       co.destroy unless found_in_preservica(co.preservica_content_object_uri, preservica_children_hash)
     end
     # iterate through preservica and update when local version found


### PR DESCRIPTION
# Summary
During the sync / update process - child objects that were originally associated with the parent were not being removed because they did not have a content uri.  This ensures they will be removed and only child objects found on Preservica will remain.

# Related Ticket
[#2563](https://github.com/yalelibrary/YUL-DC/issues/2563)