### PR TITLE
Parent View Updates

### DIFF
--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -28,18 +28,6 @@
        %>
     </div>
 
-    <div class="col-med-3">
-      <%= form.label "Permission Set" %>
-      <%= form.select(:permission_set_id,
-                  PermissionSet.all.map { |permission_set|
-                    [permission_set.label, permission_set.id]
-                  } << ["None",nil],
-                  selected: parent_object.permission_set&.key || ["None", nil],
-                  required: false
-          )
-       %>
-    </div>
-
     <div class="col-med-9">
       <%= form.label :project_identifier, "Project ID" %>
       <%= form.text_field :project_identifier %>
@@ -75,6 +63,17 @@
         <%= form.select(:visibility, ["Private", "Public", "Yale Community Only"]) %>
       </div>
     <% end %>
+    <div class="col-med-3">
+      <%= form.label "Permission Set" %>
+      <%= form.select(:permission_set_id,
+                  PermissionSet.all.map { |permission_set|
+                    [permission_set.label, permission_set.id]
+                  } << ["None",nil],
+                  selected: parent_object.permission_set&.key || ["None", nil],
+                  required: false
+          )
+       %>
+    </div>
   </div>
   <br>
 

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -83,6 +83,10 @@
         <td><%= @parent_object.visibility %></td>
       </tr>
       <tr class='table-row'>
+        <td class="key">Permission Set:</td>
+        <td><%= @parent_object&.permission_set&.label %></td>
+      </tr>
+      <tr class='table-row'>
         <td class="key">Rights Statement:</td>
         <td><%= sanitize @parent_object.rights_statement, tags: %w(a), attributes: %w(href) %></td>
       </tr>


### PR DESCRIPTION
## Summary  
Adds Permission Set label to Parent Object showpage and moved Permission Set dropdown on edit view.  
  
## Screenshots:  
<img width="1197" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/07c3a773-4fbb-47ee-9214-9def6e55dcca">
  
<img width="1535" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/5e1bb899-6029-41ea-9864-0172c5c409a1">
