### PR TITLE
Reverting CMYK changes

### DIFF
--- a/app/lib/tiff_to_pyramid.bash
+++ b/app/lib/tiff_to_pyramid.bash
@@ -42,13 +42,11 @@ outfile=$3
 savefiles=$4
 pid=$$;
 tmpprefix=${tmpdir}/stripped_srgb_${pid}
-tmpcmykprefix=${tmpdir}/cmyk_srgb_${pid}
 outprefix=${tmpdir}/srgb_${pid}
 tmpfix=${tmpdir}/$(basename $input).fixed.tif
 
 # cleanup temp files that might already exist
 if [ -z "${savefiles}" ]; then rm -f $tmpprefix*; fi
-if [ -z "${savefiles}" ]; then rm -f $tmpcmykprefix*; fi
 if [ -z "${savefiles}" ]; then rm -f $outprefix*; fi
 
 # first, use vipsheader to read the bands
@@ -60,15 +58,11 @@ set -e
 [ $status -ne 0 ] && CHANNELS=$(identify -format "%[channels]\n" ${input}[0] 2>/dev/null)
 echo "channels: ${CHANNELS}"
 if [ ${CHANNELS} = "srgba" ]; then
-    # we have to flatten the image to remove the alpha channel / transparency before proceeding
+    # we have to flatten the image to remove the alpha channel / trasparency before proceeding
     echo "removing alpha channel from $input"
     vips im_extract_bands $input ${input}.noalpha.tif 0 3   2>&1
     if [ -z "${savefiles}" ]; then rm $input; fi
     mv ${input}.noalpha.tif $input
-elif [ ${CHANNELS} = "cmyk" ]; then
-    vips icc_transform $input  ${tmpcmykprefix}.tif[compression=none,strip] app/lib/sRGB.icc --input-profile=cmyk
-    if [ -z "${savefiles}" ]; then rm $input; fi
-    mv ${tmpcmykprefix}.tif $input
 elif [[ ${CHANNELS} != "srgb" && ${CHANNELS} != "gray" && ${CHANNELS} != "cmyk" ]]; then
     echo "Image ${input} has color channels ${CHANNELS} which is not supported at this time."
     exit 1;


### PR DESCRIPTION
Fixing the color profile in the initial conversion is not sufficient.  Resulting PTIFF still reports CMYK and odd color profile information appears in thumbnail created by `vipsthumbnail`