### PR TITLE
2592 parent object owp views

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -68,12 +68,13 @@ class ParentObjectsController < ApplicationController
     respond_to do |format|
       parent_object = ParentObject.find(params[:id])
       permission_set = parent_object&.permission_set
+      permission_set_param = OpenWithPermission::PermissionSet.find(parent_object_params[:permission_set_id]) if parent_object_params[:permission_set_id].present?
 
       authorize!(:owp_access, permission_set) if parent_object.visibility == "Open with Permission" && parent_object.visibility != parent_object_params[:visibility]
 
-      authorize!(:owp_access, permission_set) if permission_set.present? && parent_object_params[:permission_set_id].nil?
+      authorize!(:owp_access, permission_set) if permission_set.present? && permission_set_param.nil?
 
-      authorize!(:owp_access, OpenWithPermission::PermissionSet) if permission_set.nil? && parent_object_params[:permission_set_id].present?
+      authorize!(:owp_access, permission_set_param) if permission_set_param.present?
 
       invalidate_admin_set_edit unless valid_admin_set_edit?
       invalidate_redirect_to_edit unless valid_redirect_to_edit?

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -3,6 +3,7 @@
 class ParentObjectsController < ApplicationController
   before_action :set_parent_object, only: [:show, :edit, :update, :destroy, :update_metadata, :select_thumbnail, :solr_document]
   before_action :set_paper_trail_whodunnit
+  before_action :set_permission_set, only: [:edit, :update]
   load_and_authorize_resource except: [:solr_document, :new, :create, :update_metadata, :all_metadata, :reindex, :select_thumbnail, :update_manifests]
 
   # GET /parent_objects
@@ -213,6 +214,14 @@ class ParentObjectsController < ApplicationController
       respond_to do |format|
         format.html { redirect_to parent_objects_url, notice: "Parent object, oid: #{params[:id]}, was not found in local database." }
         format.json { head :no_content }
+      end
+    end
+
+    def set_permission_set
+      permission_sets = OpenWithPermission::PermissionSet.all
+      @visible_permission_sets = permission_sets.order('label ASC').select do |sets|
+        User.with_role(:administrator, sets).include?(current_user) ||
+          User.with_role(:sysadmin, sets).include?(current_user)
       end
     end
 

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -62,6 +62,21 @@ class ParentObjectsController < ApplicationController
   # PATCH/PUT /parent_objects/1.json
   def update
     respond_to do |format|
+      parent_object = ParentObject.find(params[:id]) 
+      permission_set = parent_object&.permission_set
+
+      if parent_object.visibility == "Open with Permission" && parent_object.visibility != parent_object_params[:visibility]
+        authorize!(:owp_access, permission_set)
+      end
+
+      if permission_set.present? && parent_object_params[:permission_set_id].nil?
+        authorize!(:owp_access, permission_set)
+      end
+
+      if permission_set.nil? && parent_object_params[:permission_set_id].present?
+        authorize!(:owp_access, OpenWithPermission::PermissionSet)
+      end
+
       invalidate_admin_set_edit unless valid_admin_set_edit?
       invalidate_redirect_to_edit unless valid_redirect_to_edit?
 

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -60,22 +60,20 @@ class ParentObjectsController < ApplicationController
 
   # PATCH/PUT /parent_objects/1
   # PATCH/PUT /parent_objects/1.json
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
   def update
     respond_to do |format|
-      parent_object = ParentObject.find(params[:id]) 
+      parent_object = ParentObject.find(params[:id])
       permission_set = parent_object&.permission_set
 
-      if parent_object.visibility == "Open with Permission" && parent_object.visibility != parent_object_params[:visibility]
-        authorize!(:owp_access, permission_set)
-      end
+      authorize!(:owp_access, permission_set) if parent_object.visibility == "Open with Permission" && parent_object.visibility != parent_object_params[:visibility]
 
-      if permission_set.present? && parent_object_params[:permission_set_id].nil?
-        authorize!(:owp_access, permission_set)
-      end
+      authorize!(:owp_access, permission_set) if permission_set.present? && parent_object_params[:permission_set_id].nil?
 
-      if permission_set.nil? && parent_object_params[:permission_set_id].present?
-        authorize!(:owp_access, OpenWithPermission::PermissionSet)
-      end
+      authorize!(:owp_access, OpenWithPermission::PermissionSet) if permission_set.nil? && parent_object_params[:permission_set_id].present?
 
       invalidate_admin_set_edit unless valid_admin_set_edit?
       invalidate_redirect_to_edit unless valid_redirect_to_edit?
@@ -94,6 +92,10 @@ class ParentObjectsController < ApplicationController
       end
     end
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
 
   # DELETE /parent_objects/1
   # DELETE /parent_objects/1.json

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -29,10 +29,9 @@ class ParentObjectsController < ApplicationController
   def edit
     permission_sets = OpenWithPermission::PermissionSet.all
     @visible_permission_sets = permission_sets.order('label ASC').select do |sets|
-        User.with_role(:administrator, sets).include?(current_user) ||
+      User.with_role(:administrator, sets).include?(current_user) ||
         User.with_role(:sysadmin, sets).include?(current_user)
     end
-  
   end
 
   # POST /parent_objects

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -72,7 +72,7 @@ class ParentObjectsController < ApplicationController
 
       authorize!(:owp_access, permission_set) if parent_object.visibility == "Open with Permission" && parent_object.visibility != parent_object_params[:visibility]
 
-      authorize!(:owp_access, permission_set) if permission_set.present? && permission_set_param.nil?
+      authorize!(:owp_access, permission_set) if permission_set.present? &&  permission_set != permission_set_param
 
       authorize!(:owp_access, permission_set_param) if permission_set_param.present?
 

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -26,7 +26,14 @@ class ParentObjectsController < ApplicationController
   end
 
   # GET /parent_objects/1/edit
-  def edit; end
+  def edit
+    permission_sets = OpenWithPermission::PermissionSet.all
+    @visible_permission_sets = permission_sets.order('label ASC').select do |sets|
+        User.with_role(:administrator, sets).include?(current_user) ||
+        User.with_role(:sysadmin, sets).include?(current_user)
+    end
+  
+  end
 
   # POST /parent_objects
   # POST /parent_objects.json

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -27,13 +27,7 @@ class ParentObjectsController < ApplicationController
   end
 
   # GET /parent_objects/1/edit
-  def edit
-    permission_sets = OpenWithPermission::PermissionSet.all
-    @visible_permission_sets = permission_sets.order('label ASC').select do |sets|
-      User.with_role(:administrator, sets).include?(current_user) ||
-        User.with_role(:sysadmin, sets).include?(current_user)
-    end
-  end
+  def edit; end
 
   # POST /parent_objects
   # POST /parent_objects.json

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -407,3 +407,16 @@ $( document ).on('turbolinks:load', function() {
     })
   })
 })
+
+$( document ).on('turbolinks:load', function() {
+  if($('#parent_object_visibility').val() != 'Open with Permission') {
+    $('#parent_object_permission_set_id').prop('disabled', true);
+  }
+  $('#parent_object_visibility').on('input change', function() {
+    if($(this).val() != 'Open with Permission') {
+      $('#parent_object_permission_set_id').prop('disabled', true);
+    } else {
+      $('#parent_object_permission_set_id').prop('disabled', false);
+    }
+  });
+});

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,7 +23,7 @@ class Ability
     can [:view_list], [OpenWithPermission::PermissionSet, OpenWithPermission::PermissionRequest] if user.has_role?(:sysadmin) || user.has_role?(:approver, :any) || user.has_role?(:administrator, :any)
     can [:create_set, :crud], OpenWithPermission::PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
     can [:read, :approve], [OpenWithPermission::PermissionSet, OpenWithPermission::PermissionRequest], roles: { name: approver_roles, users: { id: user.id } }
-    can [:crud, :approve], OpenWithPermission::PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
+    can [:crud, :approve, :owp_access], OpenWithPermission::PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
     can [:create, :read], ProblemReport if user.has_role?(:sysadmin)
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,9 +21,9 @@ class Ability
     can [:crud], ChildObject, parent_object: { admin_set: { roles: { name: editor_roles, users: { id: user.id } } } }
     can [:crud], ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
     can [:view_list], [OpenWithPermission::PermissionSet, OpenWithPermission::PermissionRequest] if user.has_role?(:sysadmin) || user.has_role?(:approver, :any) || user.has_role?(:administrator, :any)
-    can [:create_set, :crud], OpenWithPermission::PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
+    can [:create_set, :crud, :owp_access], OpenWithPermission::PermissionSet if user.has_role?(:sysadmin) || user.has_role?(:administrator, :any)
     can [:read, :approve], [OpenWithPermission::PermissionSet, OpenWithPermission::PermissionRequest], roles: { name: approver_roles, users: { id: user.id } }
-    can [:crud, :approve, :owp_access], OpenWithPermission::PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
+    can [:crud, :approve], OpenWithPermission::PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
     can [:create, :read], ProblemReport if user.has_role?(:sysadmin)
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -65,7 +65,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.visibilities
-    ['Private', 'Public', 'Redirect', 'Yale Community Only']
+    ['Open with Permission', 'Private', 'Public', 'Redirect', 'Yale Community Only']
   end
 
   # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewingdirection

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -65,7 +65,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.visibilities
-    ['Open with Permission', 'Private', 'Public', 'Redirect', 'Yale Community Only']
+    ['Private', 'Public', 'Redirect', 'Yale Community Only']
   end
 
   # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewingdirection

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -57,23 +57,35 @@
         <%= form.label :visibility %>
         <%= form.select(:visibility, ParentObject.visibilities) %>
       </div>
+    <% elsif current_ability.can?(:owp_access, parent_object.permission_set) || current_user.has_role?(:sysadmin) %>
+      <div class="col-med-3">
+        <%= form.label :visibility %>
+        <%= form.select(:visibility, ["Open with Permission", "Private", "Public", "Yale Community Only"],
+        {},
+        disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin) ) %>
+      </div>
     <% else %>
       <div class="col-med-3">
         <%= form.label :visibility %>
-        <%= form.select(:visibility, ["Open with Permission", "Private", "Public", "Yale Community Only"]) %>
+        <%= form.select(:visibility, ["Private", "Public", "Yale Community Only"],
+        {},
+        disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin) ) %>
       </div>
     <% end %>
-    <div class="col-med-3">
-      <%= form.label "Permission Set" %>
-      <%= form.select(:permission_set_id,
-                  OpenWithPermission::PermissionSet.all.map { |permission_set|
-                    [permission_set.label, permission_set.id]
-                  } << ["None",nil],
-                  selected: parent_object.permission_set_id || ["None", nil],
-                  required: false
-          )
-       %>
-    </div>
+      <div class="col-med-3">
+        <%= form.label "Permission Set" %>
+        <%= form.select(:permission_set_id,
+                    @visible_permission_sets.map { |permission_set|
+                      [permission_set.label, permission_set.id]
+                    } << ["None",nil],
+                    {
+                    selected: parent_object.permission_set_id || ["None", nil],
+                    required: false
+                    },
+                    disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin) 
+            )
+        %>
+      </div>
   </div>
   <br>
 

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -51,25 +51,30 @@
       <%= form.label "Metadata Source" %>
       <%= form.select(:authoritative_metadata_source_id, [['Ladybird', 1], ['Voyager', 2], ['ArchivesSpace', 3]]) %>
     </div>
-
+    <%= current_ability.can?(:owp_access, OpenWithPermission::PermissionSet) %>
     <% if parent_object.child_object_ids.count == 0 %>
       <div class="col-med-3">
         <%= form.label :visibility %>
         <%= form.select(:visibility, ParentObject.visibilities) %>
       </div>
-    <% elsif current_ability.can?(:owp_access, parent_object.permission_set) || current_user.has_role?(:sysadmin) %>
+    <% elsif current_ability.can?(:owp_access, OpenWithPermission::PermissionSet) || current_user.has_role?(:sysadmin) %>
       <div class="col-med-3">
         <%= form.label :visibility %>
         <%= form.select(:visibility, ["Open with Permission", "Private", "Public", "Yale Community Only"],
         {},
-        disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin) ) %>
+        disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin)) %>
+      </div>
+    <% elsif parent_object.visibility == "Open with Permission" %>
+      <div class="col-med-3">
+        <%= form.label :visibility %>
+        <%= form.select(:visibility, ["Open with Permission"],
+        {},
+        disabled: parent_object.visibility == "Open with Permission" ) %>
       </div>
     <% else %>
       <div class="col-med-3">
         <%= form.label :visibility %>
-        <%= form.select(:visibility, ["Private", "Public", "Yale Community Only"],
-        {},
-        disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin) ) %>
+        <%= form.select(:visibility, ["Private", "Public", "Yale Community Only"]) %>
       </div>
     <% end %>
       <div class="col-med-3">

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -78,7 +78,7 @@
       </div>
     <% end %>
       <div class="col-med-3">
-        <% if @visible_permission_sets.present? %>
+        <% if @visible_permission_sets.present? && (current_user.has_role?(:administrator, parent_object.permission_set) || parent_object.permission_set.nil?) %>
           <%= form.label "Permission Set" %>
           <%= form.select(:permission_set_id,
             @visible_permission_sets.map { |permission_set|

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -92,7 +92,7 @@
           %>
         <% else %>
           <%= form.label "Permission Set" %>
-          <%= form.select(:permission_set_id, [@parent_object.permission_set.label],
+          <%= form.select(:permission_set_id, [@parent_object&.permission_set&.label || "None"],
             {
             required: false
             },

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -55,7 +55,7 @@
     <% if parent_object.child_object_ids.count == 0 %>
       <div class="col-med-3">
         <%= form.label :visibility %>
-        <%= form.select(:visibility, ParentObject.visibilities) %>
+        <%= form.select(:visibility, ['Private', 'Public', 'Redirect', 'Yale Community Only']) %>
       </div>
     <% elsif current_ability.can?(:owp_access, OpenWithPermission::PermissionSet) || current_user.has_role?(:sysadmin) %>
       <div class="col-med-3">

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -78,7 +78,7 @@
       </div>
     <% end %>
       <div class="col-med-3">
-        <% if @visible_permission_sets %>
+        <% if @visible_permission_sets.present? %>
           <%= form.label "Permission Set" %>
           <%= form.select(:permission_set_id,
             @visible_permission_sets.map { |permission_set|
@@ -92,11 +92,11 @@
           %>
         <% else %>
           <%= form.label "Permission Set" %>
-          <%= form.select(:permission_set_id, ["None", nil],
+          <%= form.select(:permission_set_id, [@parent_object.permission_set.label],
             {
-            selected: parent_object.permission_set_id || ["None", nil],
             required: false
-            }) 
+            },
+            disabled: true) 
           %>
         <% end %>
       </div>

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -78,8 +78,7 @@
       </div>
     <% end %>
       <div class="col-med-3">
-        <%= form.label "Permission Set" %>
-        <% if @visible_permission_sets %>
+          <%= form.label "Permission Set" %>
           <%= form.select(:permission_set_id,
             @visible_permission_sets.map { |permission_set|
               [permission_set.label, permission_set.id]
@@ -90,14 +89,6 @@
             },
             disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin))
           %>
-        <% else %>
-          <%= form.select(:permission_set_id, ["None", nil],
-            {
-            selected: parent_object.permission_set_id || ["None", nil],
-            required: false
-            }) 
-          %>
-        <% end %>
       </div>
   </div>
   <br>

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -78,6 +78,7 @@
       </div>
     <% end %>
       <div class="col-med-3">
+        <% if @visible_permission_sets %>
           <%= form.label "Permission Set" %>
           <%= form.select(:permission_set_id,
             @visible_permission_sets.map { |permission_set|
@@ -89,6 +90,15 @@
             },
             disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin))
           %>
+        <% else %>
+          <%= form.label "Permission Set" %>
+          <%= form.select(:permission_set_id, ["None", nil],
+            {
+            selected: parent_object.permission_set_id || ["None", nil],
+            required: false
+            }) 
+          %>
+        <% end %>
       </div>
   </div>
   <br>

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -51,7 +51,7 @@
       <%= form.label "Metadata Source" %>
       <%= form.select(:authoritative_metadata_source_id, [['Ladybird', 1], ['Voyager', 2], ['ArchivesSpace', 3]]) %>
     </div>
-    <%= current_ability.can?(:owp_access, OpenWithPermission::PermissionSet) %>
+
     <% if parent_object.child_object_ids.count == 0 %>
       <div class="col-med-3">
         <%= form.label :visibility %>
@@ -62,7 +62,7 @@
         <%= form.label :visibility %>
         <%= form.select(:visibility, ["Open with Permission", "Private", "Public", "Yale Community Only"],
         {},
-        disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin)) %>
+        disabled: parent_object.permission_set ? !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin) : false) %>
       </div>
     <% elsif parent_object.visibility == "Open with Permission" %>
       <div class="col-med-3">
@@ -79,17 +79,25 @@
     <% end %>
       <div class="col-med-3">
         <%= form.label "Permission Set" %>
-        <%= form.select(:permission_set_id,
-                    @visible_permission_sets.map { |permission_set|
-                      [permission_set.label, permission_set.id]
-                    } << ["None",nil],
-                    {
-                    selected: parent_object.permission_set_id || ["None", nil],
-                    required: false
-                    },
-                    disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin) 
-            )
-        %>
+        <% if @visible_permission_sets %>
+          <%= form.select(:permission_set_id,
+            @visible_permission_sets.map { |permission_set|
+              [permission_set.label, permission_set.id]
+            } << ["None",nil],
+            {
+            selected: parent_object.permission_set_id || ["None", nil],
+            required: false
+            },
+            disabled: !current_user.has_role?(:administrator, parent_object.permission_set) && !current_user.has_role?(:sysadmin))
+          %>
+        <% else %>
+          <%= form.select(:permission_set_id, ["None", nil],
+            {
+            selected: parent_object.permission_set_id || ["None", nil],
+            required: false
+            }) 
+          %>
+        <% end %>
       </div>
   </div>
   <br>

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -155,11 +155,111 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
     end
 
     context "with invalid parameters" do
+      let(:regular_user) { FactoryBot.create(:user) }
+      let(:parent_object_owp) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
+      let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
+      let(:invalid_owp_visibility) do
+        {
+          oid: "12345",
+          authoritative_metadata_source_id: 1,
+          admin_set: 'brbl',
+          visibility: "Private"
+        }
+      end
+      let(:invalid_owp_permission_set) do
+        {
+          oid: "12345",
+          authoritative_metadata_source_id: 1,
+          admin_set: 'brbl',
+          permission_set_id: nil
+        }
+      end
+
       it "renders a successful response (i.e. to display the 'edit' template)" do
         parent_object = ParentObject.create! valid_attributes
         patch parent_object_url(parent_object), params: { parent_object: invalid_params }
         expect(response).to be_successful
       end
+
+      it "renders Access Denied if user does not have permission to change object away from OwP" do
+        login_as regular_user
+        patch parent_object_url(parent_object_owp), params: { parent_object: invalid_owp_visibility }
+        parent_object_owp.reload
+        expect(parent_object_owp.visibility).to eq "Open with Permission"
+        expect(response).to have_http_status(401)
+      end
+
+      it "renders Access Denied if user does not have permission to change object away from a Permission Set" do
+        login_as regular_user
+        patch parent_object_url(parent_object_owp), params: { parent_object: invalid_owp_permission_set }
+        parent_object_owp.reload
+        expect(parent_object_owp.permission_set.label).to eq "set 1"
+        expect(response).to have_http_status(401)
+      end
+
+      it "renders Access Denied if user does not have permission to change object into a Permission Set" do
+        login_as regular_user
+        patch parent_object_url(parent_object_owp), params: { parent_object: invalid_owp_permission_set }
+        parent_object_owp.reload
+        expect(parent_object_owp.permission_set.label).to eq "set 1"
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'with valid parameters' do
+      let(:regular_user) { FactoryBot.create(:user) }
+      let(:parent_object_owp) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
+      let(:child_object) { FactoryBot.create(:child_object, oid: "456789", parent_object: parent_object_owp) }
+      let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
+      let(:valid_owp_visibility) do
+        {
+          oid: "2012036",
+          authoritative_metadata_source_id: 1,
+          admin_set: 'brbl',
+          visibility: "Public"
+        }
+      end
+      let(:valid_permission_set) do
+        {
+          oid: "12345",
+          authoritative_metadata_source_id: 1,
+          admin_set: 'brbl',
+          visibility: "Open with Permission",
+          permission_set: permission_set
+        }
+      end
+      let(:invalid_owp_permission_set) do
+        {
+          oid: "12345",
+          authoritative_metadata_source_id: 1,
+          admin_set: 'brbl',
+          permission_set: nil
+        }
+      end
+
+      it "can change parent visibility away from OwP as a permission_set admin" do
+        login_as regular_user
+        regular_user.add_role(:administrator, permission_set)
+        patch parent_object_url(parent_object), params: { parent_object: valid_owp_visibility }
+        byebug
+        expect(response).to be_successful
+      end
+
+      it "can change a parent away from a permission set as a permission_set admin" do
+        login_as regular_user
+        regular_user.add_role(:administrator, permission_set)
+        patch parent_object_url(parent_object_owp), params: { parent_object: valid_owp_visibility }
+        expect(response).to be_successful
+      end
+
+      it "can change a parent into a permission set as a permission_set admin" do
+        login_as regular_user
+        regular_user.add_role(:administrator, permission_set)
+        patch parent_object_url(parent_object), params: { parent_object: valid_permission_set }
+        expect(response).to be_successful
+      end
+    
     end
   end
 

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -211,10 +211,10 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
       let(:parent_object_owp) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
       let(:child_object) { FactoryBot.create(:child_object, oid: "456789", parent_object: parent_object_owp) }
       let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
-      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
-      let(:valid_owp_visibility) do
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Public") }
+      let(:public_visibility) do
         {
-          oid: "2012036",
+          oid: "12345",
           authoritative_metadata_source_id: 1,
           admin_set: 'brbl',
           visibility: "Public"
@@ -241,15 +241,14 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
       it "can change parent visibility away from OwP as a permission_set admin" do
         login_as regular_user
         regular_user.add_role(:administrator, permission_set)
-        patch parent_object_url(parent_object), params: { parent_object: valid_owp_visibility }
-        byebug
+        patch parent_object_url(parent_object_owp), params: { parent_object: public_visibility }
         expect(response).to be_successful
       end
 
       it "can change a parent away from a permission set as a permission_set admin" do
         login_as regular_user
         regular_user.add_role(:administrator, permission_set)
-        patch parent_object_url(parent_object_owp), params: { parent_object: valid_owp_visibility }
+        patch parent_object_url(parent_object_owp), params: { parent_object: public_visibility }
         expect(response).to be_successful
       end
 
@@ -257,6 +256,7 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
         login_as regular_user
         regular_user.add_role(:administrator, permission_set)
         patch parent_object_url(parent_object), params: { parent_object: valid_permission_set }
+        parent_object.reload
         expect(response).to be_successful
       end
     

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -499,7 +499,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       let(:user) { FactoryBot.create(:user) }
       let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), permission_set: permission_set) }
       let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
-      
+
       before do
         stub_metadata_cloud("2012036")
         parent_object

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -461,14 +461,16 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   end
 
   describe "editing a ParentObject with a Permission Set" do
-    context "as a non-admin user", js: true do
+    context "as a non-admin user" do
       let(:user) { FactoryBot.create(:user) }
       let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Public") }
+      let(:child_object) { FactoryBot.create(:child_object, oid: "456789", parent_object: parent_object_owp) }
       let(:parent_object_owp) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
       let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
       before do
         login_as user
         stub_metadata_cloud("2012036")
+        child_object
         parent_object
         parent_object_owp
         permission_set
@@ -481,12 +483,12 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
 
       it "cannot edit visibility or permission set if Parent Object is an OwP object" do
         visit edit_parent_object_path(12_345)
-        expect(page).to have_select("parent_object_visibility", options: ["Open with Permission", "Public", "Yale Community Only", "Private", "Redirect"], disabled: true)
+        expect(page).to have_select("parent_object_visibility", disabled: true)
       end
 
       it "has the permission set disabled if the visibility is not Open with Permission" do
         visit edit_parent_object_path(2_012_036)
-        expect(page).to have_select("parent_object_permission_set_id", options: ["None"], disabled: true)
+        expect(page).to have_select("parent_object_permission_set_id", disabled: true)
       end
     end
 

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   end
 
   context "editing a ParentObject" do
-    let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Public") }
+    let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl')) }
     let(:parent_object_no_children) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl')) }
     before do
       stub_metadata_cloud("2012036")
@@ -457,11 +457,6 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
       select('Redirect')
       click_on("Save Parent Object And Update Metadata")
       expect(page).to have_content 'Redirect to in incorrect format. Please enter DCS url https://collections.library.yale.edu/catalog/123'
-    end
-
-    it "has the permission set disabled if the visibility is not Open with Permission" do
-      visit edit_parent_object_path(2_012_036)
-      expect(page).to have_select("parent_object_permission_set_id", options: ["None"])
     end
   end
 

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
   end
 
   describe "editing a ParentObject with a Permission Set" do
-    context "as a non-admin user" do
+    context "as a non-admin user", js: true do
       let(:user) { FactoryBot.create(:user) }
       let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Public") }
       let(:parent_object_owp) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -465,32 +465,54 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
     end
   end
 
-  context "editing a ParentObject with a Permission Set as a non-admin user", js: true do
-    let(:user) { FactoryBot.create(:user) }
-    let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Public") }
-    let(:parent_object_owp) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
-    let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
-    before do
-      login_as user
-      stub_metadata_cloud("2012036")
-      parent_object
-      parent_object_owp
-      permission_set
+  describe "editing a ParentObject with a Permission Set" do
+    context "as a non-admin user" do
+      let(:user) { FactoryBot.create(:user) }
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), visibility: "Public") }
+      let(:parent_object_owp) { FactoryBot.create(:parent_object, oid: "12345", admin_set: AdminSet.find_by_key('brbl'), visibility: "Open with Permission", permission_set: permission_set) }
+      let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
+      before do
+        login_as user
+        stub_metadata_cloud("2012036")
+        parent_object
+        parent_object_owp
+        permission_set
+      end
+
+      it "cannot see OwP visibility if not an admin of a permission set" do
+        visit edit_parent_object_path(2_012_036)
+        expect(page).to have_select("parent_object_visibility", options: ["Public", "Yale Community Only", "Private"])
+      end
+
+      it "cannot edit visibility or permission set if Parent Object is an OwP object" do
+        visit edit_parent_object_path(12_345)
+        expect(page).to have_select("parent_object_visibility", options: ["Open with Permission", "Public", "Yale Community Only", "Private", "Redirect"], disabled: true)
+      end
+
+      it "has the permission set disabled if the visibility is not Open with Permission" do
+        visit edit_parent_object_path(2_012_036)
+        expect(page).to have_select("parent_object_permission_set_id", options: ["None"], disabled: true)
+      end
     end
 
-    it "cannot see OwP visibility if not an admin of a permission set" do
-      visit edit_parent_object_path(2_012_036)
-      expect(page).to have_select("parent_object_visibility", options: ["Public", "Yale Community Only", "Private"])
-    end
+    context "as a permission set admin" do
+      let(:user) { FactoryBot.create(:user) }
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), permission_set: permission_set) }
+      let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
+      
+      before do
+        stub_metadata_cloud("2012036")
+        parent_object
+        permission_set
+        login_as user
+        user.add_role(:administrator, parent_object.permission_set)
+      end
 
-    it "cannot edit visibility or permission set if Parent Object is an OwP object" do
-      visit edit_parent_object_path(12_345)
-      expect(page).to have_select("parent_object_visibility", options: ["Open with Permission", "Public", "Yale Community Only", "Private", "Redirect"], disabled: true)
-    end
-
-    it "has the permission set disabled if the visibility is not Open with Permission" do
-      visit edit_parent_object_path(2_012_036)
-      expect(page).to have_select("parent_object_permission_set_id", options: ["None"], disabled: true)
+      it "can set the parent objects visibility to OwP" do
+        visit edit_parent_object_path(2_012_036)
+        expect(page).to have_select("parent_object_visibility", options: ["Open with Permission", "Public", "Yale Community Only", "Private"])
+        expect(page).to have_select("parent_object_permission_set_id", options: ["set 1", "None"])
+      end
     end
   end
 


### PR DESCRIPTION
## Summary  
Visibility/Permission Set controls are now based on Permission Set admin access controls.  
  
 ## Screenshots:  
**_As a non-admin_**:  
  
OwP not an option, Permission Set select disabled:  
<img width="1038" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/5197e186-3dbd-4b2f-83ea-1fb43c01d91a">
  
OwP already assigned (visibility and permission set disabled):  
<img width="1041" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/8a61b5e8-c832-4cb4-b467-365b8ea9307a">
  
**_As an Admin:_**  
Can assign OwP as a visibility:  
<img width="1178" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/cd7de52a-aa82-4a4f-bd5b-8abdf9b6d93e">
  
Can assign a Permission Set (filtered based on which permission sets the user is an admin of):  
<img width="1092" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/a3edaf5e-24b5-4f62-91e1-fd69d9c4f46c">  
  
Permission Set becomes enabled only after OwP is selected:  
<img width="996" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/b376aed4-f0b3-4457-98c4-4c79fed0eee5">
  
<img width="1031" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/a7db6f05-7523-483e-8cb1-dcd97aeacf0e">


