### PR TITLE
Adds logic to prevent sorting mishap

### DIFF
--- a/app/models/preservica/generation.rb
+++ b/app/models/preservica/generation.rb
@@ -35,15 +35,16 @@ class Preservica::Generation
 
   private
 
+    # rubocop:disable Metrics/AbcSize
     def load_bitstreams
       xml.xpath('/GenerationResponse/Bitstreams/Bitstream').map do |bitstream|
         last_section = bitstream['filename'].split('_').last
         if last_section.include?('.pdf')
-          last_numbers = bitstream['filename'].split('_').last.tr('.pdf','')
+          last_numbers = bitstream['filename'].split('_').last.tr('.pdf', '')
         elsif last_section.include?('.tif')
-          last_numbers = bitstream['filename'].split('_').last.tr('.tif','')
+          last_numbers = bitstream['filename'].split('_').last.tr('.tif', '')
         elsif last_section.include?('.tiff')
-          last_numbers = bitstream['filename'].split('_').last.tr('.tiff','')
+          last_numbers = bitstream['filename'].split('_').last.tr('.tiff', '')
         end
         # if the last section is a single integer
         if last_numbers.to_i < 10
@@ -55,6 +56,7 @@ class Preservica::Generation
         Preservica::Bitstream.new(@preservica_client, @content_id, @id, bitstream.content.split('/').last.strip, file_name)
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def load_formats
       xml.xpath('/GenerationResponse/Generation/Formats/Format/FormatName').map(&:content)

--- a/app/models/preservica/generation.rb
+++ b/app/models/preservica/generation.rb
@@ -37,7 +37,22 @@ class Preservica::Generation
 
     def load_bitstreams
       xml.xpath('/GenerationResponse/Bitstreams/Bitstream').map do |bitstream|
-        Preservica::Bitstream.new(@preservica_client, @content_id, @id, bitstream.content.split('/').last.strip, bitstream['filename'])
+        last_section = bitstream['filename'].split('_').last
+        if last_section.include?('.pdf')
+          last_numbers = bitstream['filename'].split('_').last.tr('.pdf','')
+        elsif last_section.include?('.tif')
+          last_numbers = bitstream['filename'].split('_').last.tr('.tif','')
+        elsif last_section.include?('.tiff')
+          last_numbers = bitstream['filename'].split('_').last.tr('.tiff','')
+        end
+        # if the last section is a single integer
+        if last_numbers.to_i < 10
+          first_section = bitstream['filename'].split('_')[0...-1]
+          file_name = first_section.join('_') + '_' + last_section.prepend('0')
+        else
+          file_name = bitstream['filename']
+        end
+        Preservica::Bitstream.new(@preservica_client, @content_id, @id, bitstream.content.split('/').last.strip, file_name)
       end
     end
 

--- a/spec/models/preservica/preservica_import_spec.rb
+++ b/spec/models/preservica/preservica_import_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1"
     expect(co_first.preservica_bitstream_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"
     expect(co_first.sha512_checksum).to eq "1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7"
-    expect(co_first.caption).to eq "mss_29_s03_b092_f0019.TIF"
+    expect(co_first.caption).to eq "mss_29_s03_b092_0f0019.TIF"
     expect(File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")).to be true
     expect(File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")).to be true
     expect(File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")).to be true


### PR DESCRIPTION
# Summary
During testing it was found if a file name ended in a single integer like 1 the child images would be sorted incorrectly.  This PR adds some logic to prevent the incorrect sorting in the future.

# Related Ticket
[#2465](https://github.com/yalelibrary/YUL-DC/issues/2465)

# Before Screenshot

![image](https://github.com/yalelibrary/yul-dc-management/assets/36549923/56897662-8604-4552-97dc-ca8eefd95afa)

