### PR TITLE
NetID added to Permission Request Users

### DIFF
--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -52,7 +52,6 @@ class Api::PermissionRequestsController < ApplicationController
     pr_user = OpenWithPermission::PermissionRequestUser.find_or_initialize_by(sub: request['user']['sub'])
     pr_user.name = request['user']['name']
     pr_user.email = request['user']['email']
-    pr_user.netid = request['user']['netid']
     pr_user.email_verified = request['user']['email_verified']
     pr_user.oidc_updated_at = request['user']['oidc_updated_at']
     pr_user.save!

--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -52,6 +52,7 @@ class Api::PermissionRequestsController < ApplicationController
     pr_user = OpenWithPermission::PermissionRequestUser.find_or_initialize_by(sub: request['user']['sub'])
     pr_user.name = request['user']['name']
     pr_user.email = request['user']['email']
+    pr_user.netid = request['user']['netid']
     pr_user.email_verified = request['user']['email_verified']
     pr_user.oidc_updated_at = request['user']['oidc_updated_at']
     pr_user.save!

--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -15,6 +15,7 @@
       <th scope='col'> OID </th>
       <th scope='col'> User name </th>
       <th scope='col'> User ID </th>
+      <th scope='col'> Net ID </th>
       <th scope='col'> Request Status </th>
       <th scope='col'> Approver </th>
     </tr>
@@ -28,6 +29,7 @@
         <td class='permission-set-label'><%= permission_request.parent_object.oid %></td>
         <td class='permission-set-label'><%= permission_request.permission_request_user.name %></td>
         <td class='permission-set-label'><%= permission_request.permission_request_user.sub %></td>
+        <td class='permission-set-label'><%= permission_request.permission_request_user.netid %></td>
         <td class='permission-set-label'><%= permission_request.request_status %></td>
         <td class='permission-set-label'><%= "TODO" %></td>
       </tr>

--- a/db/migrate/20230918173349_add_net_id_to_permission_request_user.rb
+++ b/db/migrate/20230918173349_add_net_id_to_permission_request_user.rb
@@ -1,0 +1,5 @@
+class AddNetIdToPermissionRequestUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :permission_request_users, :netid, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_05_201604) do
+ActiveRecord::Schema.define(version: 2023_09_18_173349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -220,6 +220,7 @@ ActiveRecord::Schema.define(version: 2023_07_05_201604) do
     t.datetime "oidc_updated_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "netid"
   end
 
   create_table "permission_requests", force: :cascade do |t|

--- a/spec/factories/permission_request_user.rb
+++ b/spec/factories/permission_request_user.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :permission_request_user, class: OpenWithPermission::PermissionRequestUser do
     sub { "id123" }
     name { "User Name" }
-    netid { "User Net ID" }
+    netid { "net_id" }
     email { "user@example.com" }
     email_verified { true }
     oidc_updated_at { "2022-11-08 15:33:30" }

--- a/spec/factories/permission_request_user.rb
+++ b/spec/factories/permission_request_user.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :permission_request_user, class: OpenWithPermission::PermissionRequestUser do
     sub { "id123" }
     name { "User Name" }
+    netid { "User Net ID" }
     email { "user@example.com" }
     email_verified { true }
     oidc_updated_at { "2022-11-08 15:33:30" }

--- a/spec/system/permission_request_spec.rb
+++ b/spec/system/permission_request_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true 
       expect(page).to have_content(permission_request.created_at.to_s)
       expect(page).to have_content(permission_request.parent_object.oid.to_s)
       expect(page).to have_content(permission_request.permission_request_user.sub.to_s)
+      expect(page).to have_content(permission_request.permission_request_user.netid.to_s)
       expect(page).to have_content(permission_request.permission_request_user.name.to_s)
       expect(page).to have_content(permission_request.request_status.to_s)
     end
@@ -63,6 +64,7 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true 
       expect(page).not_to have_content(permission_request.permission_set.label.to_s)
       expect(page).not_to have_content(permission_request.parent_object.oid.to_s)
       expect(page).not_to have_content(permission_request.permission_request_user.sub.to_s)
+      # expect(page).not_to have_content(permission_request.permission_request_user.netid.to_s)
       expect(page).not_to have_content(permission_request.permission_request_user.name.to_s)
     end
   end

--- a/spec/system/permission_request_spec.rb
+++ b/spec/system/permission_request_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true 
   let(:sysadmin) { FactoryBot.create(:sysadmin_user) }
   let(:user) { FactoryBot.create(:user) }
   let(:admin_set) { FactoryBot.create(:admin_set) }
-  let(:request_user) { FactoryBot.create(:permission_request_user) }
-  let(:request_user_2) { FactoryBot.create(:permission_request_user, sub: "sub 2", name: "name 2") }
+  let(:request_user_2) { FactoryBot.create(:permission_request_user, sub: "sub 2", name: "name 2", netid: "net id") }
   let(:permission_set) { FactoryBot.create(:permission_set, label: "set 1") }
   let(:permission_set_2) { FactoryBot.create(:permission_set, label: "set 2") }
   let(:parent_object) { FactoryBot.create(:parent_object) }
@@ -64,7 +63,7 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true 
       expect(page).not_to have_content(permission_request.permission_set.label.to_s)
       expect(page).not_to have_content(permission_request.parent_object.oid.to_s)
       expect(page).not_to have_content(permission_request.permission_request_user.sub.to_s)
-      # expect(page).not_to have_content(permission_request.permission_request_user.netid.to_s)
+      expect(page).not_to have_content(permission_request.permission_request_user.netid.to_s)
       expect(page).not_to have_content(permission_request.permission_request_user.name.to_s)
     end
   end
@@ -85,11 +84,13 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true 
       expect(page).to have_content(permission_request_2.parent_object.oid.to_s)
       expect(page).to have_content(permission_request_2.permission_request_user.sub.to_s)
       expect(page).to have_content(permission_request_2.permission_request_user.name.to_s)
+      expect(page).to have_content(permission_request_2.permission_request_user.netid.to_s)
       expect(page).to have_content(permission_request_2.request_status.to_s)
 
       expect(page).not_to have_content(permission_request.permission_set.label.to_s)
       expect(page).not_to have_content(permission_request.parent_object.oid.to_s)
       expect(page).not_to have_content(permission_request.permission_request_user.sub.to_s)
+      expect(page).not_to have_content(permission_request.permission_request_user.netid.to_s)
       expect(page).not_to have_content(permission_request.permission_request_user.name.to_s)
     end
   end


### PR DESCRIPTION
## Summary  
Adds a 'NetID' column to Permission Request User.  
Net ID added to requests index.  
Net ID added to find_or_create_user api request.