### PR TITLE
Limit to 3 retries for jobs in all environments

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -10,8 +10,4 @@ Delayed::Worker.max_run_time = 4.hours
 Delayed::Worker.default_queue_name = :default
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.logger = Rails.logger
-Delayed::Worker.max_attempts = if ENV['RAILS_ENV'] == 'development'
-                                 3
-                               else
-                                 15
-                               end
+Delayed::Worker.max_attempts = 3


### PR DESCRIPTION
# Summary
Instead of 15 this PR updates the max retry attempts to 3.

# Related Ticket
[#2620](https://github.com/yalelibrary/YUL-DC/issues/2620)

