### PR TITLE
Remove holding from Sierra URL

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -517,8 +517,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     raise StandardError, "Bib id required to build Sierra url" unless bib.present?
     identifier_block = if barcode.present?
                          "/barcode/#{barcode}?bib=#{bib}"
-                       elsif holding.present?
-                         "/holding/#{holding}?bib=#{bib}"
                        elsif item.present?
                          "/item/#{item}?bib=#{bib}"
                        else


### PR DESCRIPTION
## Summary  
Holding will no longer be used when building a Sierra URL.