### PR TITLE
Wait for manifest to be saved

### DIFF
--- a/spec/system/structure_editor_spec.rb
+++ b/spec/system/structure_editor_spec.rb
@@ -103,9 +103,8 @@ RSpec.describe "Structure Editor", type: :system, prep_metadata_sources: true, p
 
     it 'can submit structure back to management' do
       click_on 'Range +'
-      page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
-      expect(page).to have_content('Manifest Saved')
       click_on 'Submit'
+      expect(page).to have_content('Manifest Saved')
       visit '/parent_objects/16172421/manifest.json'
       expect(page).to have_content('New Range')
     end

--- a/spec/system/structure_editor_spec.rb
+++ b/spec/system/structure_editor_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe "Structure Editor", type: :system, prep_metadata_sources: true, p
 
     it 'can submit structure back to management' do
       click_on 'Range +'
+      expect(page).to have_content('Manifest Saved')
       click_on 'Submit'
       visit '/parent_objects/16172421/manifest.json'
       expect(page).to have_content('New Range')

--- a/spec/system/structure_editor_spec.rb
+++ b/spec/system/structure_editor_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe "Structure Editor", type: :system, prep_metadata_sources: true, p
 
     it 'can submit structure back to management' do
       click_on 'Range +'
+      page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
       expect(page).to have_content('Manifest Saved')
       click_on 'Submit'
       visit '/parent_objects/16172421/manifest.json'


### PR DESCRIPTION
# Summary
Structure editor spec on line 104 would occasionally fail.  This MR will force the test to wait on the manifest being saved before visiting the new manifest.

# Related Ticket
n/a