### PR TITLE
Increase save to s3 job priority

### DIFF
--- a/app/jobs/save_original_to_s3_job.rb
+++ b/app/jobs/save_original_to_s3_job.rb
@@ -4,7 +4,7 @@ class SaveOriginalToS3Job < ApplicationJob
   queue_as :default
 
   def default_priority
-    100
+    -125
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/spec/jobs/save_original_to_s3_job_spec.rb
+++ b/spec/jobs/save_original_to_s3_job_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SaveOriginalToS3Job, type: :job do
         .with("Not copying image. Child object #{child_object_without_width.oid} does not have a valid width or height.")
     end
     it 'has correct priority' do
-      expect(save_to_s3_job.default_priority).to eq(100)
+      expect(save_to_s3_job.default_priority).to eq(-125)
     end
     it 'can save a file to S3' do
       parent_object_private.visibility = 'Public'


### PR DESCRIPTION
# Summary
Users were unable to download large tiffs in a timely manner because of all the jobs in the queue.  This MR increases the save original to s3 job priority to the highest in the application. (Lower the number the higher the priority)

# Related Ticket
[#2682](https://github.com/yalelibrary/YUL-DC/issues/2682)