### PR TITLE
2677 preservica validation

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -526,7 +526,6 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/MethodLength
   # ERROR HANDLING FOR PRESERVICA SYNC
   def validate_preservica_sync(parent_object, row)
-    byebug
     if parent_object.redirect_to.present?
       batch_processing_event("Parent OID: #{row['oid']} is a redirected parent object", 'Skipped Import')
       false

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -526,6 +526,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/MethodLength
   # ERROR HANDLING FOR PRESERVICA SYNC
   def validate_preservica_sync(parent_object, row)
+    byebug
     if parent_object.redirect_to.present?
       batch_processing_event("Parent OID: #{row['oid']} is a redirected parent object", 'Skipped Import')
       false

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -39,9 +39,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :digitization_funding_source, length: { maximum: 255 }
   # rubocop:disable Metrics/LineLength
   validates :redirect_to, format: { with: /\A((http|https):\/\/)?(collections-test.|collections-uat.|collections.)?library.yale.edu\/catalog\//, message: " in incorrect format. Please enter DCS url https://collections.library.yale.edu/catalog/123", presence: true, if: proc { visibility == "Redirect" } }
+  validates :preservica_representation_type, format: { with: /\A(Preservation|Access)/, message: "can't be None when Digital Object Source is Preservica" }, if: proc { digital_object_source == "Preservica" }
   # rubocop:enable Metrics/LineLength
   validates :preservica_uri, presence: true, format: { with: %r{\A/}, message: " in incorrect format. URI must start with a /" }, if: proc { digital_object_source == "Preservica" }
-  validates :preservica_representation_type, format: { with: /\A(Preservation|Access)/, message: "can't be None when Digital Object Source is Preservica" }, if: proc { digital_object_source == "Preservica" }
   validate :validate_visibility
   before_save :check_permission_set
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -41,6 +41,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :redirect_to, format: { with: /\A((http|https):\/\/)?(collections-test.|collections-uat.|collections.)?library.yale.edu\/catalog\//, message: " in incorrect format. Please enter DCS url https://collections.library.yale.edu/catalog/123", presence: true, if: proc { visibility == "Redirect" } }
   # rubocop:enable Metrics/LineLength
   validates :preservica_uri, presence: true, format: { with: %r{\A/}, message: " in incorrect format. URI must start with a /" }, if: proc { digital_object_source == "Preservica" }
+  validates :preservica_representation_type, format: { with: /\A(Preservation|Access)/, message: "can't be None when Digital Object Source is Preservica" }, if: proc { digital_object_source == "Preservica" }
   validate :validate_visibility
   before_save :check_permission_set
 

--- a/spec/datatables/parent_object_datatable_spec.rb
+++ b/spec/datatables/parent_object_datatable_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ParentObjectDatatable, type: :datatable, prep_metadata_sources: t
                            extent_of_full_text: 'None',
                            project_identifier: '67',
                            digital_object_source: "Preservica",
+                           preservica_representation_type: "Access",
                            preservica_uri: "/preservica_uri")
     output = ParentObjectDatatable.new(datatable_sample_params(columns), view_context: parent_object_datatable_view_mock, current_ability: Ability.new(user)).data
 

--- a/spec/models/preservica/preservica_sync_spec.rb
+++ b/spec/models/preservica/preservica_sync_spec.rb
@@ -258,20 +258,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(sync_batch_process.batch_ingest_events.last.reason).to eq('Parent OID: 12345 does not have a Preservica digital object source')
     end
 
-    it 'can throw an error if parent object does not have a preservica representation type' do
-      allow(S3Service).to receive(:s3_exists?).and_return(false)
-      parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('brbl'), preservica_uri: "/", digital_object_source: "Preservica")
-      parent_object.save
-
-      sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
-      expect do
-        sync_batch_process.file = preservica_sync_invalid
-        sync_batch_process.save!
-      end.not_to change { ChildObject.count }
-      expect(sync_batch_process.batch_ingest_events_count).to be 1
-      expect(sync_batch_process.batch_ingest_events.last.reason).to eq('Parent OID: 12345 does not have a Preservica representation type')
-    end
-
     it 'can throw an error if parent object does not have an admin set with preservica credentials' do
       allow(S3Service).to receive(:s3_exists?).and_return(false)
       parent_object = ParentObject.new(oid: 12_345, admin_set: AdminSet.find_by_key('sml'), preservica_uri: "/", digital_object_source: "Preservica", preservica_representation_type: "Preservation")

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       end
     end
 
+    # rubocop:disable Metrics/LineLength
     context "outputting csv" do
       let(:brbl) { AdminSet.find_by_key("brbl") }
       let(:other_admin_set) { FactoryBot.create(:admin_set) }
@@ -171,6 +172,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
       let(:parent_object2) { FactoryBot.create(:parent_object, oid: 2_005_512, admin_set: other_admin_set) }
       let(:parent_object3) { FactoryBot.create(:parent_object, oid: 2_004_548, admin_set: brbl) }
       let(:user) { FactoryBot.create(:user) }
+      # rubocop:enable Metrics/LineLength
 
       before do
         stub_metadata_cloud("2004548")

--- a/spec/system/batch_process_spec.rb
+++ b/spec/system/batch_process_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
     context "outputting csv" do
       let(:brbl) { AdminSet.find_by_key("brbl") }
       let(:other_admin_set) { FactoryBot.create(:admin_set) }
-      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_034_600, admin_set: brbl, digital_object_source: "Preservica", preservica_uri: "/preservica_uri") }
+      let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_034_600, admin_set: brbl, digital_object_source: "Preservica", preservica_uri: "/preservica_uri", preservica_representation_type: "Access") }
       let(:parent_object2) { FactoryBot.create(:parent_object, oid: 2_005_512, admin_set: other_admin_set) }
       let(:parent_object3) { FactoryBot.create(:parent_object, oid: 2_004_548, admin_set: brbl) }
       let(:user) { FactoryBot.create(:user) }

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         select('Preservica')
         expect(page).to have_field("Preservica uri")
         fill_in('Preservica uri', with: "/preservica_uri")
+        select("Access")
         click_on("Create Parent object")
         expect(page).to have_content '/preservica_uri'
       end


### PR DESCRIPTION
## Summary  
Preservica objects can no longer be created without a preservica representation type.