### PR TITLE
Adds fields to Creat Parent Batch Process

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -238,6 +238,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         parent_object.digitization_funding_source = row['digitization_funding_source']
         parent_object.rights_statement = row['rights_statement']
 
+        # rubocop:disable Metrics/LineLength
         if valid_viewing_directions.include?(row['viewing_direction'])
           parent_object.viewing_direction = row['viewing_direction']
         else
@@ -249,6 +250,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         else
           batch_processing_event("Parent #{oid} did not update value for Display Layout. Value: #{row['display_layout']} is invalid. For field Display Layout / Viewing Hint please use: individuals, paged, continuous, or leave column empty", 'Invalid Vocabulary')
         end
+        # rubocop:enable Metrics/LineLength
 
         if metadata_source == 'aspace' && row['extent_of_digitization'].blank?
           batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}.  Parent objects with ASpace as a source must have an Extent of Digitization value.", 'Skipped Row')

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -234,6 +234,11 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         parent_object.bib = row['bib']
         parent_object.holding = row['holding']
         parent_object.item = row['item']
+        parent_object.digitization_note = row['digitization_note']
+        parent_object.digitization_funding_source = row['digitization_funding_source']
+        parent_object.rights_statement = row['rights_statement']
+        parent_object.viewing_direction = row['viewing_direction']
+        parent_object.display_layout = row['display_layout']
 
         if metadata_source == 'aspace' && row['extent_of_digitization'].blank?
           batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}.  Parent objects with ASpace as a source must have an Extent of Digitization value.", 'Skipped Row')

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -239,13 +239,13 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         parent_object.rights_statement = row['rights_statement']
 
         # rubocop:disable Metrics/LineLength
-        if valid_viewing_directions.include?(row['viewing_direction'])
+        if ParentObject.viewing_directions.include?(row['viewing_direction'])
           parent_object.viewing_direction = row['viewing_direction']
         else
           batch_processing_event("Parent #{oid} did not update value for Viewing Directions. Value: #{row['viewing_direction']} is invalid. For field Viewing Direction please use: left-to-right, right-to-left, top-to-bottom, bottom-to-top, or leave column empty", 'Invalid Vocabulary')
         end
 
-        if valid_display_layouts.include?(row['display_layout'])
+        if ParentObject.viewing_hints.include?(row['display_layout'])
           parent_object.display_layout = row['display_layout']
         else
           batch_processing_event("Parent #{oid} did not update value for Display Layout. Value: #{row['display_layout']} is invalid. For field Display Layout / Viewing Hint please use: individuals, paged, continuous, or leave column empty", 'Invalid Vocabulary')
@@ -288,14 +288,6 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:enable  Metrics/PerceivedComplexity
   # rubocop:enable  Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/BlockLength
-
-  def valid_viewing_directions
-    ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top', nil]
-  end
-
-  def valid_display_layouts
-    ['individuals', 'paged', 'continuous', nil]
-  end
 
   # CHECKS TO SEE IF USER HAS ABILITY TO EDIT AN ADMIN SET:
   def editable_admin_set(admin_set_key, oid, index)

--- a/public/batch_processes/templates/create_parent_objects.csv
+++ b/public/batch_processes/templates/create_parent_objects.csv
@@ -1,1 +1,1 @@
-oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization,digitization_note,digitization_funding_source,rights_statement,viewing_direction,display_layout

--- a/spec/fixtures/csv/create_parent.csv
+++ b/spec/fixtures/csv/create_parent.csv
@@ -1,2 +1,2 @@
 oid,admin_set,source,extent_of_digitization,digitization_note,digitization_funding_source,rights_statement,viewing_direction,display_layout
-112233,brbl,aspace,Completely digitized,dig note,dig funding source,rights statement,viewing direction,display layout
+112233,brbl,aspace,Completely digitized,dig note,dig funding source,rights statement,left-to-right,paged

--- a/spec/fixtures/csv/create_parent.csv
+++ b/spec/fixtures/csv/create_parent.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,extent_of_digitization,digitization_note,digitization_funding_source,rights_statement,viewing_direction,display_layout
+112233,brbl,aspace,Completely digitized,dig note,dig funding source,rights statement,viewing direction,display layout

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
   let(:admin_set_two) { FactoryBot.create(:admin_set) }
   let(:admin_set_three) { FactoryBot.create(:admin_set) }
   let(:csv_upload) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "shorter_fixture_ids.csv")) }
+  let(:create_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "create_parent.csv")) }
   let(:csv_upload_with_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "short_fixture_ids_with_source.csv")) }
   let(:delete_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "delete_parent_fixture_ids.csv")) }
   let(:preservica_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent.csv")) }
@@ -595,6 +596,18 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           expect(IngestEvent.count).to eq(11)
         end
 
+        it "succeeds if the user is an editor on the admin set of the parent object" do
+          batch_process.file = create_parent
+          batch_process.save
+          expect(ParentObject.count).to eq(1)
+          parent_object = ParentObject.first
+          expect(parent_object.digitization_note).to eq "dig note"
+          expect(parent_object.digitization_funding_source).to eq "dig funding source"
+          expect(parent_object.rights_statement).to eq "rights statement"
+          expect(parent_object.viewing_direction).to eq "viewing direction"
+          expect(parent_object.display_layout).to eq "display layout"
+        end
+        
         it "fails if the user is not an editor on the admin set of the parent object" do
           user.remove_role(:editor, admin_set_upload)
 

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -596,7 +596,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           expect(IngestEvent.count).to eq(11)
         end
 
-        it "succeeds if the user is an editor on the admin set of the parent object" do
+        it "creates a Parent Object with added fields digitization_note, digitization_funding_source, rights_statement, viewing_direction, and display_layout" do
           batch_process.file = create_parent
           batch_process.save
           expect(ParentObject.count).to eq(1)
@@ -607,7 +607,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           expect(parent_object.viewing_direction).to eq "viewing direction"
           expect(parent_object.display_layout).to eq "display layout"
         end
-        
+
         it "fails if the user is not an editor on the admin set of the parent object" do
           user.remove_role(:editor, admin_set_upload)
 

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -604,8 +604,8 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           expect(parent_object.digitization_note).to eq "dig note"
           expect(parent_object.digitization_funding_source).to eq "dig funding source"
           expect(parent_object.rights_statement).to eq "rights statement"
-          expect(parent_object.viewing_direction).to eq "viewing direction"
-          expect(parent_object.display_layout).to eq "display layout"
+          expect(parent_object.viewing_direction).to eq "left-to-right"
+          expect(parent_object.display_layout).to eq "paged"
         end
 
         it "fails if the user is not an editor on the admin set of the parent object" do

--- a/spec/requests/batch_processes_request_spec.rb
+++ b/spec/requests/batch_processes_request_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
       get download_template_batch_processes_url(batch_action: "create parent objects")
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("text/csv; charset=utf-8")
-      expect(response.body.to_s).to eq("\xEF\xBB\xBFoid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization")
+      expect(response.body.to_s).to eq("\xEF\xBB\xBFoid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization,digitization_note,digitization_funding_source,rights_statement,viewing_direction,display_layout")
     end
     # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
## Summary  
Adds digitization_note, digitization_funding_source, rights_statement, viewing_direction, and display_layout to the Create Parent Objects Batch Process.  
  
## Screenshot:  
<img width="1094" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/3c3ada7a-a867-42f8-b52b-0dffc658b9ff">
