### PR TITLE
Add show page and fix user note saving for permission requests

### DIFF
--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -4,6 +4,7 @@ class Api::PermissionRequestsController < ApplicationController
   skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
 
+  # rubocop:disable Metrics/MethodLength
   def create
     request = params
     begin
@@ -19,11 +20,17 @@ class Api::PermissionRequestsController < ApplicationController
     if current_requests_count >= permission_set.max_queue_length
       render json: { "title": "Too many pending requests" }, status: 403
     else
-      new_request = OpenWithPermission::PermissionRequest.new(permission_set: permission_set, permission_request_user: pr_user, parent_object: parent_object, user_note: request['user_note'])
+      new_request = OpenWithPermission::PermissionRequest.new(
+        permission_set: permission_set,
+        permission_request_user: pr_user,
+        parent_object: parent_object,
+        user_note: request['permission_request']['user_note']
+      )
       new_request.save!
       render json: { "title": "New request created" }, status: 201
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def check_parent_visibility(parent_object)
     if parent_object.visibility == "Private"

--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<table class='table table-striped permission-set-index-table' aria-label='Label Permission Set'>
+<table class='table table-striped permission-set-index-table' aria-label='Permission Set Table'>
   <thead class='thead-dark'>
     <tr>
       <th scope='col'> Request ID </th>
@@ -23,7 +23,7 @@
   <tbody>
     <% @visible_permission_requests.each do |permission_request| %>
       <tr>
-        <td class='permission-set-label'><%= permission_request.id %></td>
+        <td class='permission-set-label'><%= link_to(permission_request.id, permission_request_path(permission_request.id)) %></td>
         <td class='permission-set-label'><%= permission_request.permission_set.label %></td>
         <td class='permission-set-label'><%= permission_request.created_at %></td>
         <td class='permission-set-label'><%= permission_request.parent_object.oid %></td>

--- a/app/views/permission_requests/show.html.erb
+++ b/app/views/permission_requests/show.html.erb
@@ -1,0 +1,30 @@
+<h1>Permission Request</h1>
+
+<dl>
+  <dt>Request ID:</dt>
+  <dd><%= @permission_request.id %></dd>
+
+  <dt>Permission Set Label:</dt>
+  <dd><%= @permission_request.permission_set.label %></dd>
+
+  <dt>Request Date:</dt>
+  <dd><%= @permission_request.created_at %></dd>
+
+  <dt>OID:</dt>
+  <dd><%= @permission_request.parent_object.oid %></dd>
+
+  <dt>User Name:</dt>
+  <dd><%= @permission_request.permission_request_user.name %></dd>
+  
+  <dt>User ID:</dt>
+  <dd><%= @permission_request.permission_request_user.sub %></dd>
+  
+  <dt>User Note:</dt>
+  <dd><%= @permission_request.user_note %></dd>
+  
+  <dt>Request Status:</dt>
+  <dd><%= @permission_request.request_status %></dd>
+  
+  <dt>Approver:</dt>
+  <dd><%= "#{@permission_request.user&.first_name} #{@permission_request.user&.last_name}" %></dd>
+</dl>

--- a/spec/requests/permission_requests_spec.rb
+++ b/spec/requests/permission_requests_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: tru
       post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
       expect(response).to have_http_status(:created)
       expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
+      pr = OpenWithPermission::PermissionRequest.first
+      expect(pr.user_note).not_to be nil
     end
 
     it 'errors if requests go over max' do


### PR DESCRIPTION
# Summary
The user note from the form submitted from blacklight was not being picked up by the API.  This PR resolves the correct name for the user note and adds a show page for Permission Requests.

# Related Ticket
[#2656](https://github.com/yalelibrary/YUL-DC/issues/2656)