### PR TITLE
alter route and add initialize user for Terms

### DIFF
--- a/app/controllers/api/permission_sets_controller.rb
+++ b/app/controllers/api/permission_sets_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::PermissionSetsController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_before_action :verify_authenticity_token
 
   def terms_api
     # check for valid parent object
@@ -30,7 +31,7 @@ class Api::PermissionSetsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render(json: { "title": "Term not found." }, status: 400) && (return false)
     end
-    request_user = find_or_create_user(params)
+    request_user = find_or_create_user(params) unless params['user_netid'].nil?
     if request_user.nil?
       render(json: { "title": "User not found." }, status: 400) && (return false)
     else

--- a/app/controllers/api/permission_sets_controller.rb
+++ b/app/controllers/api/permission_sets_controller.rb
@@ -30,7 +30,7 @@ class Api::PermissionSetsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render(json: { "title": "Term not found." }, status: 400) && (return false)
     end
-    request_user = OpenWithPermission::PermissionRequestUser.where(sub: params[:sub]).first
+    request_user = find_or_create_user(params)
     if request_user.nil?
       render(json: { "title": "User not found." }, status: 400) && (return false)
     else
@@ -77,4 +77,15 @@ class Api::PermissionSetsController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
+  def find_or_create_user(request)
+    pr_user = OpenWithPermission::PermissionRequestUser.find_or_initialize_by(sub: request['user_sub'])
+    pr_user.name = request['user_full_name']
+    pr_user.email = request['user_email']
+    pr_user.netid = request['user_netid']
+    pr_user.email_verified = true
+    pr_user.oidc_updated_at = Time.zone.now
+    pr_user.save!
+    pr_user
+  end
+
 end

--- a/app/controllers/api/permission_sets_controller.rb
+++ b/app/controllers/api/permission_sets_controller.rb
@@ -75,6 +75,7 @@ class Api::PermissionSetsController < ApplicationController
 
     render(json: { "timestamp": timestamp, "user": { "sub": request_user.sub }, "permission_set_terms_agreed": terms_agreed, "permissions": set.reverse })
   end
+
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
   def find_or_create_user(request)
@@ -87,5 +88,4 @@ class Api::PermissionSetsController < ApplicationController
     pr_user.save!
     pr_user
   end
-
 end

--- a/app/controllers/api/permission_sets_controller.rb
+++ b/app/controllers/api/permission_sets_controller.rb
@@ -31,17 +31,17 @@ class Api::PermissionSetsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render(json: { "title": "Term not found." }, status: 400) && (return false)
     end
-    request_user = find_or_create_user(params) unless params['user_netid'].nil?
-    if request_user.nil?
+    begin
+      request_user = find_or_create_user(params)
+    rescue ActiveRecord::RecordInvalid
       render(json: { "title": "User not found." }, status: 400) && (return false)
-    else
-      begin
-        term_agreement = OpenWithPermission::TermsAgreement.new(permission_set_term: term, permission_request_user: request_user, agreement_ts: Time.zone.now)
-        term_agreement.save!
-        render json: { "title": "Success." }, status: 201
-      rescue StandardError => e
-        render json: { "title": e.to_s }, status: 500
-      end
+    end
+    begin
+      term_agreement = OpenWithPermission::TermsAgreement.new(permission_set_term: term, permission_request_user: request_user, agreement_ts: Time.zone.now)
+      term_agreement.save!
+      render json: { "title": "Success." }, status: 201
+    rescue StandardError => e
+      render json: { "title": e.to_s }, status: 500
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,8 +71,6 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   get 'api/permission_sets/:sub', to: 'api/permission_sets#retrieve_permissions_data', as: :retrieve_permissions_data
 
-  # get 'api/permission_sets/:permission_set_id/permission_set_terms/:permission_set_terms_id/agree/:sub', to: 'api/permission_sets#agreement_term', as: :agreement_term
-
   post 'agreement_term', to: 'api/permission_sets#agreement_term'
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   get 'api/permission_sets/:sub', to: 'api/permission_sets#retrieve_permissions_data', as: :retrieve_permissions_data
 
-  get 'api/permission_sets/:permission_set_id/permission_set_terms/:permission_set_terms_id/agree/:sub', to: 'api/permission_sets#agreement_term', as: :agreement_term
+  # get 'api/permission_sets/:permission_set_id/permission_set_terms/:permission_set_terms_id/agree/:sub', to: 'api/permission_sets#agreement_term', as: :agreement_term
+
+  post 'agreement_term', to: 'api/permission_sets#agreement_term'
 
   namespace :api do
     resources :permission_requests, only: [:create]

--- a/spec/requests/api/permission_sets_spec.rb
+++ b/spec/requests/api/permission_sets_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
     {
       'oid': '123',
       'user_email': 'email',
-      'user_sub': 'sub',
       'user_full_name': "new",
       'permission_set_terms_id': terms.id
     }

--- a/spec/requests/api/permission_sets_spec.rb
+++ b/spec/requests/api/permission_sets_spec.rb
@@ -13,6 +13,35 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
   let(:term_agreement) { FactoryBot.create(:term_agreement, permission_request_user: request_user, permission_set_term: terms) }
   let(:terms) { FactoryBot.create(:permission_set_term, activated_by: user, activated_at: Time.zone.now, permission_set: permission_set) }
   let(:request_user) { FactoryBot.create(:permission_request_user, sub: '1234') }
+  let(:params) do
+    {
+      'oid': '123',
+      'user_email': 'email',
+      'user_netid': 'netid',
+      'user_sub': 'sub',
+      'user_full_name': "new",
+      'permission_set_terms_id': terms.id
+    }
+  end
+  let(:invalid_term_params) do
+    {
+      'oid': '123',
+      'user_email': 'email',
+      'user_netid': 'netid',
+      'user_sub': 'sub',
+      'user_full_name': "new",
+      'permission_set_terms_id': '1'
+    }
+  end
+  let(:invalid_user_params) do
+    {
+      'oid': '123',
+      'user_email': 'email',
+      'user_sub': 'sub',
+      'user_full_name': "new",
+      'permission_set_terms_id': terms.id
+    }
+  end
 
   before do
     login_as user
@@ -49,10 +78,10 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
     end
   end
 
-  describe 'GET /api/permission_sets/id/permission_set_terms/id/agree/sub' do
-    it 'can GET and create a user agreement' do
+  describe 'POST /agreement_term' do
+    it 'can POST and create a user agreement' do
       expect(OpenWithPermission::TermsAgreement.count).to eq 1
-      get "/api/permission_sets/#{permission_set.id}/permission_set_terms/#{terms.id}/agree/#{request_user.sub}"
+      post agreement_term_url(params)
       expect(response).to have_http_status(201)
       term = OpenWithPermission::TermsAgreement.first
       expect(OpenWithPermission::TermsAgreement.count).to eq 2
@@ -60,12 +89,12 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
       expect(term.permission_set_term).to eq terms
     end
     it 'throws error if user not found' do
-      get "/api/permission_sets/#{permission_set.id}/permission_set_terms/#{terms.id}/agree/123"
+      post agreement_term_url(invalid_user_params)
       expect(response).to have_http_status(400)
       expect(response.body).to eq("{\"title\":\"User not found.\"}")
     end
     it 'throws error if permission set term not found' do
-      get "/api/permission_sets/#{permission_set.id}/permission_set_terms/123/agree/#{request_user.sub}"
+      post agreement_term_url(invalid_term_params)
       expect(response).to have_http_status(400)
       expect(response.body).to eq("{\"title\":\"Term not found.\"}")
     end


### PR DESCRIPTION
Route changes to accept a POST from blacklight. Adds find or initialize user in terms agreement in order to create a request user if the request user does not exist yet.