### PR TITLE
adds terms warning for sets without an active term

### DIFF
--- a/app/models/open_with_permission/permission_set.rb
+++ b/app/models/open_with_permission/permission_set.rb
@@ -39,4 +39,8 @@ class OpenWithPermission::PermissionSet < ApplicationRecord
     new_terms.activate_by!(user)
     new_terms
   end
+
+  def terms_and_conditions_warning
+    active_permission_set_terms.present? ? true : false
+  end
 end

--- a/app/views/permission_sets/show.html.erb
+++ b/app/views/permission_sets/show.html.erb
@@ -1,4 +1,11 @@
 <%= render partial: "/management/flash_messages" %>
+
+<% unless @permission_set.terms_and_conditions_warning %> 
+  <p>
+    <p class="alert alert-warning"><%= "No Terms and Conditions are applied. Please select ‘Manage Terms and Conditions’ to apply Terms and Conditions to this Permission Set." %></p>
+  </p>
+<% end %>
+
 <div class="bottom-spacer">
 
   <p>

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -338,10 +338,11 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
         end
       end
 
-      it "show page displays None when terms are inactivated" do
+      it "show page displays None and terms warning message when terms are inactivated" do
         permission_set.inactivate_terms_by!(administrator_user)
         visit "/permission_sets/#{permission_set.id}"
         expect(page).to have_content(permission_set.label)
+        expect(page).to have_content("No Terms and Conditions are applied. Please select ‘Manage Terms and Conditions’ to apply Terms and Conditions to this Permission Set.")
         within(permission_set_terms_element) do
           expect(page).to have_content("None")
           expect(page).not_to have_content(terms.activated_at.to_s)

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
         expect(page).not_to have_link('X')
         expect(page).not_to have_content('NetID')
         expect(page).not_to have_content('Save')
-        expect(page).not_to have_content('Manage Terms and Conditions')
+        expect(page).not_to have_link('Manage Terms and Conditions')
       end
       it 'cannot be accessed' do
         visit "/permission_sets/#{permission_set.id}/edit"


### PR DESCRIPTION
## Summary  
Management users will see a Terms warning message whenever a Permission Set does not have any active terms associated with it.  
  
## Screenshot:  
<img width="1784" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/cc92657e-1530-4d5f-a26f-37b0a3ea732f">
