### PR TITLE
Non-editable PS Key and unique validation

### DIFF
--- a/app/models/open_with_permission/permission_set.rb
+++ b/app/models/open_with_permission/permission_set.rb
@@ -4,7 +4,7 @@ class OpenWithPermission::PermissionSet < ApplicationRecord
   has_many :parent_objects
   has_many :permission_set_terms, class_name: "OpenWithPermission::PermissionSetTerm"
   resourcify
-  validates :key, presence: true
+  validates :key, presence: true, uniqueness: true
   validates :label, presence: true
 
   def add_approver(user)

--- a/app/views/permission_sets/_form.html.erb
+++ b/app/views/permission_sets/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field form-group">
     <%= form.label :key %>
-    <%= form.text_field(:key, required: true, class: "form-control") %>
+    <%= form.text_field(:key, required: true, class: "form-control", disabled: !form.object.new_record?) %>
   </div>
 
   <div class="field form-group">

--- a/spec/requests/api/permission_sets_spec.rb
+++ b/spec/requests/api/permission_sets_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 
 RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_sources: true, prep_admin_sets: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
-  let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
-  let(:permission_set_2) { FactoryBot.create(:permission_set, label: 'set 2') }
-  let(:permission_set_3) { FactoryBot.create(:permission_set, label: 'set 3') }
+  let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1', key: 'key 1') }
+  let(:permission_set_2) { FactoryBot.create(:permission_set, label: 'set 2', key: 'key 2') }
+  let(:permission_set_3) { FactoryBot.create(:permission_set, label: 'set 3', key: 'key 3') }
   let(:parent_object) { FactoryBot.create(:parent_object, oid: 2_012_036, admin_set: AdminSet.find_by_key('brbl'), permission_set: permission_set, visibility: "Open with Permission") }
   let(:parent_object_no_ps) { FactoryBot.create(:parent_object, oid: 2_012_033, admin_set: AdminSet.find_by_key('brbl')) }
   let(:parent_object_no_terms) { FactoryBot.create(:parent_object, oid: 2_012_037, admin_set: AdminSet.find_by_key('brbl'), permission_set: permission_set_2, visibility: "Open with Permission") }

--- a/spec/system/permission_request_spec.rb
+++ b/spec/system/permission_request_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true 
   let(:user) { FactoryBot.create(:user) }
   let(:admin_set) { FactoryBot.create(:admin_set) }
   let(:request_user_2) { FactoryBot.create(:permission_request_user, sub: "sub 2", name: "name 2", netid: "net id") }
-  let(:permission_set) { FactoryBot.create(:permission_set, label: "set 1") }
-  let(:permission_set_2) { FactoryBot.create(:permission_set, label: "set 2") }
+  let(:permission_set) { FactoryBot.create(:permission_set, label: "set 1", key: 'key 1') }
+  let(:permission_set_2) { FactoryBot.create(:permission_set, label: "set 2", key: 'key 2') }
   let(:parent_object) { FactoryBot.create(:parent_object) }
   let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "12345", admin_set: admin_set) }
   let(:permission_request) { FactoryBot.create(:permission_request, request_status: true) }

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
   let(:user_2) { FactoryBot.create(:user) }
   let(:approver_user) { FactoryBot.create(:user) }
   let(:administrator_user) { FactoryBot.create(:user, uid: 'admin') }
-  let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1') }
-  let(:permission_set_2) { FactoryBot.create(:permission_set, label: 'set 2') }
+  let(:permission_set) { FactoryBot.create(:permission_set, label: 'set 1', key: "key 1") }
+  let(:permission_set_2) { FactoryBot.create(:permission_set, label: 'set 2', key: "key 2") }
   let(:term) { FactoryBot.create(:permission_set_term, activated_at: Time.zone.now, permission_set_id: permission_set.id) }
   let(:edit_set) { 'Editing Permission Set' }
   let(:new_set) { 'New Permission Set' }
@@ -144,7 +144,7 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
       it 'metadata' do
         visit "/permission_sets/#{permission_set.id}"
         expect(page).to have_content('set 1')
-        expect(page).to have_content('Permission Key')
+        expect(page).to have_content('key 1')
         expect(page).to have_content('Max Request Queue Length: 1')
       end
       it 'approvers and administrators' do
@@ -174,14 +174,12 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
       end
       it 'can be edited' do
         visit "/permission_sets/#{permission_set.id}/edit"
-        fill_in('open_with_permission_permission_set_key', with: 'key example')
         fill_in('open_with_permission_permission_set_label', with: 'label example')
         click_on 'Update Permission Set'
         expect(page).to have_content('Permission set was successfully updated.')
       end
       it 'can reject invalid params' do
         visit "/permission_sets/#{permission_set.id}/edit"
-        fill_in('open_with_permission_permission_set_key', with: 'key example')
         # permission set must also have label - this leaves that out making the request invalid and causing a render of the edit page
         fill_in('open_with_permission_permission_set_label', with: '')
         click_on 'Update Permission Set'


### PR DESCRIPTION
## Summary  
PS Keys can no longer be editable. Also adds unique validation for the field.  
  
## Screenshot:  
<img width="818" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/4d768a70-3185-41e4-b831-6f05dda56c0f">
