### PR TITLE
Make OwP testing easier and update attribute

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -445,7 +445,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def assign_values
     self.call_number = authoritative_json["callNumber"].is_a?(Array) ? authoritative_json["callNumber"].first : authoritative_json["callNumber"]
     self.container_grouping = authoritative_json["containerGrouping"].is_a?(Array) ? authoritative_json["containerGrouping"].first : authoritative_json["containerGrouping"]
-    self.visibility = visibility_was && self.permission_set = permission_set_was if visibility_was == 'Open with Permission'
+    self.visibility = visibility_was && self.permission_set_id = permission_set_id_was if visibility_was == 'Open with Permission'
   end
 
   def add_media_type(url)

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -445,7 +445,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def assign_values
     self.call_number = authoritative_json["callNumber"].is_a?(Array) ? authoritative_json["callNumber"].first : authoritative_json["callNumber"]
     self.container_grouping = authoritative_json["containerGrouping"].is_a?(Array) ? authoritative_json["containerGrouping"].first : authoritative_json["containerGrouping"]
-    self.visibility = visibility_was && self.permission_set_id = permission_set_id_was if visibility_was == 'Open with Permission'
+    self.visibility = visibility_was if visibility_was == 'Open with Permission'
+    self.permission_set_id = permission_set_id_was if visibility_was == 'Open with Permission'
   end
 
   def add_media_type(url)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -91,5 +91,9 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.preview_path = Rails.root.join("spec", "mailers", "previews")
   config.action_mailer.deliver_later_queue_name = 'default'
+
+  # for open with permission testing
+  config.hosts << 'yul-dc_management_1'
+  config.hosts << '0.0.0.0'
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
     login_as(:user)
     batch_process.user_id = user.id
     permission_set
-    # permission_set.add_administrator(user)
   end
 
   describe 'with the metadata cloud mocked' do


### PR DESCRIPTION
# Summary
Updates the parent object attribute that we were using for a `was` method and makes working with Open with Permission objects easier in a local development environment.

# Related Ticket
[#2724](https://github.com/yalelibrary/YUL-DC/issues/2724)
