### PR TITLE
Export Parents by Source re-work

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -66,8 +66,7 @@ class BatchProcessesController < ApplicationController
 
   def export_parent_sources
     sources = params[:metadata_source_ids]
-    admin_set = params.dig(:admin_set_id)
-    redirect_to admin_set_path(admin_set), notice: "CSV is being generated. Please visit the Batch Process page to download."
+    redirect_to admin_sets_url, notice: "CSV is being generated. Please visit the Batch Process page to download."
     batch_process = BatchProcess.new(batch_action: 'export all parents by source', user: current_user, file_name: "exported_parent_objects_source.csv")
     batch_process.save!
     ExportAllParentSourcesCsvJob.perform_later(batch_process, sources)

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -15,10 +15,6 @@ module CsvExportable
      'extent_of_digitization', 'digitization_note', 'digitization_funding_source', 'project_identifier', 'full_text']
   end
 
-  def parent_source_headers
-    ['oid', 'archives_space_uri', 'bib_id', 'holding_id', 'item_id', 'barcode', 'visibility']
-  end
-
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
   def parent_output_csv(*admin_set_id)

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -169,12 +169,16 @@ module CsvExportable
   def export_all_parents_source_csv(sources)
     return nil unless batch_action == 'export all parents by source'
     output_csv = CSV.generate do |csv|
-      csv << parent_source_headers
+      csv << parent_headers
       find_parent_by_source(sources) do |po|
         case po
         when ParentObject
-          csv << [po.oid, po.aspace_uri, po.bib,
-                  po.holding, po.item, po.barcode, po.visibility]
+          csv << [po.oid, po.admin_set.key, po.source_name,
+            po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
+            po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
+            po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
+            po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
+            po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
         else
           csv << [po[:id], po[:row2], '-', po[:csv_message], '', '']
           batch_processing_event(po[:batch_message], 'Skipped Row') unless batch_ingest_events_count.positive?

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -8,11 +8,11 @@ module CsvExportable
   # Parent Object Export
   ########################
   def parent_headers
-    ['oid', 'admin_set', 'authoritative_source', 'child_object_count', 'call_number',
+    ['oid', 'admin_set', 'authoritative_source', 'child_object_count', 'title', 'call_number',
      'container_grouping', 'bib', 'holding', 'item', 'barcode', 'aspace_uri',
      'digital_object_source', 'preservica_uri', 'last_ladybird_update',
      'last_voyager_update', 'last_sierra_update', 'last_aspace_update', 'last_id_update', 'visibility', 'permission_set_key',
-     'extent_of_digitization', 'digitization_note', 'digitization_funding_source', 'project_identifier', 'full_text']
+     'extent_of_digitization', 'digitization_note', 'digitization_funding_source', 'rights_statement', 'project_identifier', 'full_text']
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -25,11 +25,11 @@ module CsvExportable
         case po
         when ParentObject
           csv << [po.oid, po.admin_set.key, po.source_name,
-                  po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
+                  po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
                   po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
                   po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
                   po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
-                  po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
+                  po.digitization_note, po.digitization_funding_source, po.rights_statement, po.project_identifier, extent_of_full_text(po)]
         else
           csv << [po[:id], po[:row2], '-', po[:csv_message], '', '']
           batch_processing_event(po[:batch_message], 'Skipped Row') unless batch_ingest_events_count.positive?
@@ -125,11 +125,11 @@ module CsvExportable
       self.admin_set = split_sets.join(', ')
       save!
       row = [po.oid, po.admin_set.key, po.source_name,
-             po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
-             po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
-             po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
-             po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
-             po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
+        po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
+        po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
+        po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
+        po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
+        po.digitization_note, po.digitization_funding_source, po.rights_statement, po.project_identifier, extent_of_full_text(po)]
       csv_rows << row
     end
     add_error_rows(csv_rows)
@@ -150,11 +150,11 @@ module CsvExportable
         case po
         when ParentObject
           csv << [po.oid, po.admin_set.key, po.source_name,
-                  po.child_object_count, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
-                  po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
-                  po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
-                  po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
-                  po.digitization_note, po.digitization_funding_source, po.project_identifier, extent_of_full_text(po)]
+            po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
+            po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
+            po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
+            po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
+            po.digitization_note, po.digitization_funding_source, po.rights_statement, po.project_identifier, extent_of_full_text(po)]
         else
           csv << [po[:id], po[:row2], '-', po[:csv_message], '', '']
           batch_processing_event(po[:batch_message], 'Skipped Row') unless batch_ingest_events_count.positive?

--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -125,11 +125,11 @@ module CsvExportable
       self.admin_set = split_sets.join(', ')
       save!
       row = [po.oid, po.admin_set.key, po.source_name,
-        po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
-        po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
-        po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
-        po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
-        po.digitization_note, po.digitization_funding_source, po.rights_statement, po.project_identifier, extent_of_full_text(po)]
+             po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
+             po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
+             po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
+             po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
+             po.digitization_note, po.digitization_funding_source, po.rights_statement, po.project_identifier, extent_of_full_text(po)]
       csv_rows << row
     end
     add_error_rows(csv_rows)
@@ -150,11 +150,11 @@ module CsvExportable
         case po
         when ParentObject
           csv << [po.oid, po.admin_set.key, po.source_name,
-            po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
-            po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
-            po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
-            po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
-            po.digitization_note, po.digitization_funding_source, po.rights_statement, po.project_identifier, extent_of_full_text(po)]
+                  po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
+                  po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri,
+                  po.last_ladybird_update, po.last_voyager_update, po.last_sierra_update,
+                  po.last_aspace_update, po.last_id_update, po.visibility, po&.permission_set&.key, po.extent_of_digitization,
+                  po.digitization_note, po.digitization_funding_source, po.rights_statement, po.project_identifier, extent_of_full_text(po)]
         else
           csv << [po[:id], po[:row2], '-', po[:csv_message], '', '']
           batch_processing_event(po[:batch_message], 'Skipped Row') unless batch_ingest_events_count.positive?

--- a/app/views/admin_sets/_export_all_parents_dialog.html.erb
+++ b/app/views/admin_sets/_export_all_parents_dialog.html.erb
@@ -8,7 +8,6 @@
       <div class="modal-body update-metadata-form">
         <%= form_with url: export_parent_sources_batch_processes_path do |form| %>
           <div class="form-group">
-            <%= form.hidden_field :admin_set_id, value: @admin_set.id %>
             <%= form.label(:metadata_source_ids, "Metadata Sources:") %>
             <%= link_to('Select All', "#", {class: 'select-all-btn', data: { target_select:'#metadata_source_ids'}}) %>
             <br />

--- a/app/views/admin_sets/index.html.erb
+++ b/app/views/admin_sets/index.html.erb
@@ -1,4 +1,5 @@
 <%= render partial: "/management/flash_messages" %>
+<%= render partial: "export_all_parents_dialog" %>
 
 <div class='row datatable-heading'>
   <div class='col'>
@@ -6,6 +7,9 @@
   </div>
   <div class='col'>
     <div class='float-right button-list'>
+    <% if current_user&.sysadmin %>
+      <a href="#ExportAllParents" role="button" class="export-parents-source btn btn-large btn-secondary" data-toggle="modal">Export all parents</a>
+    <% end %>
       <%= link_to 'New Admin Set', new_admin_set_path, class: "btn button primary-button" %>
     </div>
   </div>

--- a/app/views/admin_sets/show.html.erb
+++ b/app/views/admin_sets/show.html.erb
@@ -12,7 +12,6 @@
   <%= button_to "Update IIIF Manifests", update_manifests_parent_objects_url(admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary update_manifest", data: { confirm: 'Are you sure you want to update the IIIF manifests for this entire set?' } %>
   <% if current_user&.sysadmin %>
     <%= button_to "Resend Digital Objects", update_digital_objects_parent_objects_url(admin_set_id: @admin_set.id), method: :post, class: "btn btn-large btn-secondary update_manifest", data: { confirm: 'Are you sure you want to resend the digital objects to ILS and ArchivesSpace for this entire set?' } %>
-    <a href="#ExportAllParents" role="button" class="export-parents-source btn btn-large btn-secondary" data-toggle="modal">Export all parents</a>
   <% end %>
 </div>
 
@@ -46,4 +45,3 @@
 </p>
 
 <%= render partial: "update_metadata_dialog" %>
-<%= render partial: "export_all_parents_dialog" %>

--- a/spec/views/admin_sets/index.html.erb_spec.rb
+++ b/spec/views/admin_sets/index.html.erb_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe "admin_sets/index", type: :view do
+  include Devise::Test::ControllerHelpers
   it "renders admin_sets table" do
     render
     assert_select "tr>th", text: "Key".to_s, count: 1


### PR DESCRIPTION
## Summary  
Export All Parents button moved to Admin Sets index page.  
Also adds headers and column data to csv.  
  
This also includes the high priority ticket: https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=43806676