### PR TITLE
Enable new config for rerunning only failed tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,8 @@ jobs:
           name: rspec
           # ~vpn_only:true - excludes tests that require Yale VPN access
           command: |
-            mkdir /tmp/test-results | cd /home/app/webapp | circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
+            mkdir /tmp/test-results
+            cd /home/app/webapp && circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,7 @@ jobs:
           # ~vpn_only:true - excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
-            git config --global --add safe.directory /home/app/webapp
-            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings)
+            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="--format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings)
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           # Excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
-            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings)
+            cd /home/app/webapp && circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
           # Excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
+            git config --global --add safe.directory /home/app/webapp
             cd /home/app/webapp && circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
       - run:
           name: Stash Coverage Results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: |
             mkdir /tmp/test-results
             git config --global --add safe.directory /home/app/webapp
-            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=name)
+            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings)
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,8 @@ jobs:
           command: |
             mkdir /tmp/test-results
             cd /home/app/webapp && circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
+      - store_test_results:
+          path: /tmp/test-results
       - run:
           name: Stash Coverage Results
           command: |
@@ -72,8 +74,6 @@ jobs:
           root: .
           paths:
             - coverage_results
-      - store_test_results:
-          path: /tmp/test-results
   coverage:
     docker:
       - image: yalelibraryit/dc-management:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           # Excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
-            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
+            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings)
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           # Excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
-            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
       - run:
           name: Stash Coverage Results
           command: |
@@ -72,6 +72,8 @@ jobs:
           root: .
           paths:
             - coverage_results
+      - store_test_results:
+          path: /tmp/test-results
   coverage:
     docker:
       - image: yalelibraryit/dc-management:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,7 @@ jobs:
           name: rspec
           # ~vpn_only:true - excludes tests that require Yale VPN access
           command: |
-            mkdir /tmp/test-results
-            cd /home/app/webapp 
-            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
+            mkdir /tmp/test-results | cd /home/app/webapp | circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,8 @@ jobs:
           # ~vpn_only:true - excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
-            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="--format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings)
+            cd /home/app/webapp 
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,7 @@ jobs:
           command: |
             mkdir /tmp/test-results
             git config --global --add safe.directory /home/app/webapp
-            cd /home/app/webapp
-            circleci tests glob "spec/**/*_spec.rb" 
-            circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=name
+            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=name)
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
           # ~vpn_only:true - excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
+            git config --global --add safe.directory /home/app/webapp
             cd /home/app/webapp && circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,13 @@ jobs:
             cd /home/app/webapp && bundle exec rubocop --parallel
       - run:
           name: rspec
-          # Excludes tests that require Yale VPN access
+          # ~vpn_only:true - excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
             git config --global --add safe.directory /home/app/webapp
-            cd /home/app/webapp && circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=timings
+            cd /home/app/webapp
+            circleci tests glob "spec/**/*_spec.rb" 
+            circleci tests run --command="xargs bundle exec rspec --tag ~vpn_only:true --format RspecJunitFormatter -o ~/tmp/test-results/rspec.xml" --verbose --split-by=name
       - run:
           name: Stash Coverage Results
           command: |

--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'coveralls_reborn', require: false
   gem 'ffaker'
+  gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.0'
   gem 'timecop'

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
         end.to change { ParentObject.count }.from(0).to(1)
         po = ParentObject.first
         expect(po.bib).to eq('4320085')
-        expect(po.aspace_uri).to eq('/repositories/12/archival_objects/781086')
+        expect(po.aspace_uri).to eq('/repositories/12/archival_objects/781086qqqqqqqqqqqqqqq')
       end
       it 'can create a parent_object' do
         expect do


### PR DESCRIPTION
# Summary

CircleCI has a new functionality to only re run failed tests when some fail.  This PR enables that functionality.

# Related Ticket
[#2734](https://github.com/yalelibrary/YUL-DC/issues/2734)