### PR TITLE
check for OwP visibility instead of ps_key presence

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -108,7 +108,7 @@ module Updatable
           next
         end
       elsif row['visibility'] == "Open with Permission" && row['permission_set_key'].blank?
-        batch_processing_event("Skipping row [#{index + 2}] because Open with Permission objects must have a Permission Set Key assigned.", 'Skipped Row')
+        batch_processing_event("Skipping row [#{index + 2}]. Process failed. Permission Set missing.", 'Skipped Row')
         next
       end
 

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -65,6 +65,7 @@ module Updatable
     end
   end
 
+  # rubocop:disable Metrics/BlockLength
   def update_parent_objects
     self.admin_set = ''
     sets = admin_set
@@ -108,7 +109,7 @@ module Updatable
         end
       elsif row['visibility'] == "Open with Permission" && row['permission_set_key'].blank?
         batch_processing_event("Skipping row [#{index + 2}] because Open with Permission objects must have a Permission Set Key assigned.", 'Skipped Row')
-          next
+        next
       end
 
       parent_object.update!(processed_fields)
@@ -121,6 +122,7 @@ module Updatable
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/BlockLength
   # rubocop:enable Metrics/MethodLength
 
   # CHECKS TO SEE IF USER HAS ABILITY TO EDIT AN ADMIN SET:

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -106,6 +106,9 @@ module Updatable
           batch_processing_event("Skipping row [#{index + 2}] because user does not have edit permissions for this Permission Set: #{permission_set.key}", 'Permission Denied')
           next
         end
+      elsif row['visibility'] == "Open with Permission" && row['permission_set_key'].blank?
+        batch_processing_event("Skipping row [#{index + 2}] because Open with Permission objects must have a Permission Set Key assigned.", 'Skipped Row')
+          next
       end
 
       parent_object.update!(processed_fields)

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -90,7 +90,7 @@ module Updatable
       setup_for_background_jobs(parent_object, metadata_source)
       parent_object.admin_set = admin_set unless admin_set.nil?
 
-      if row['permission_set_key'].present? && row['permission_set_key'] != parent_object&.permission_set&.key
+      if row['visibility'] == "Open with Permission" && row['permission_set_key'] != parent_object&.permission_set&.key
         permission_set = OpenWithPermission::PermissionSet.find_by(key: row['permission_set_key'])
         if permission_set.nil?
           batch_processing_event("Skipping row [#{index + 2}]. Process failed. Permission Set missing or nonexistent.", 'Skipped Row')

--- a/spec/fixtures/csv/update_example_blank_ps.csv
+++ b/spec/fixtures/csv/update_example_blank_ps.csv
@@ -1,0 +1,2 @@
+oid,source,admin_set,project_identifier,visibility,permission_set_key,rights_statement,extent_of_digitization,digitization_note,bib,holding,item,barcode,aspace_uri,viewing_direction,display_layout,digital_object_source,preservica_uri,preservica_representation_type
+2034600,ladybird,brbl,Beinecke,Open with Permission,,The use of this image may be subject to the copyright law of the United States,Completely digitized,5678,12307100,temporary,reel,39002102340669,/repositories/11/archival_objects/515305,left-to-right,paged,,,

--- a/spec/models/batch_process_update_parent_spec.rb
+++ b/spec/models/batch_process_update_parent_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(po_updated.rights_statement).to be_nil
       expect(po_updated.viewing_direction).to be_nil
       expect(po_updated.visibility).to eq "Private"
-      expect(update_batch_process.batch_ingest_events.first.reason).to eq "Skipping row [2]. Process failed. Permission Set missing."
+      expect(update_batch_process.batch_ingest_events.first.reason).to eq "Skipping row [2]. Process failed. Permission Set missing from CSV."
       expect(update_batch_process.batch_ingest_events_count).to eq 1
     end
 

--- a/spec/models/batch_process_update_parent_spec.rb
+++ b/spec/models/batch_process_update_parent_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(po_updated.rights_statement).to be_nil
       expect(po_updated.viewing_direction).to be_nil
       expect(po_updated.visibility).to eq "Private"
-      expect(update_batch_process.batch_ingest_events.first.reason).to eq "Skipping row [2] because Open with Permission objects must have a Permission Set Key assigned."
+      expect(update_batch_process.batch_ingest_events.first.reason).to eq "Skipping row [2]. Process failed. Permission Set missing."
       expect(update_batch_process.batch_ingest_events_count).to eq 1
     end
 


### PR DESCRIPTION
Batch Update was not triggering OwP validations if PS Key was blank in CSV. We should be checking for OwP visibility and then validate PS Key.  
  
Also adds a check/batch processing event if the PS_Key is blank