### PR TITLE
Adds unique validation to permission set label

### DIFF
--- a/app/models/open_with_permission/permission_set.rb
+++ b/app/models/open_with_permission/permission_set.rb
@@ -5,7 +5,7 @@ class OpenWithPermission::PermissionSet < ApplicationRecord
   has_many :permission_set_terms, class_name: "OpenWithPermission::PermissionSetTerm"
   resourcify
   validates :key, presence: true, uniqueness: true
-  validates :label, presence: true
+  validates :label, presence: true, uniqueness: true
 
   def add_approver(user)
     remove_administrator(user) if user.administrator(self)

--- a/spec/requests/api/permission_sets_spec.rb
+++ b/spec/requests/api/permission_sets_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
       'user_netid': 'netid',
       'user_sub': 'sub',
       'user_full_name': "new",
-      'permission_set_terms_id': '1'
+      'permission_set_terms_id': '555'
     }
   end
   let(:invalid_user_params) do

--- a/spec/system/permission_set_spec.rb
+++ b/spec/system/permission_set_spec.rb
@@ -255,6 +255,14 @@ RSpec.describe 'PermissionSets', type: :system, prep_metadata_sources: true do
         expect(page).to have_content('key example')
         expect(page).to have_content('label example')
       end
+      it 'can validate uniqueness of key and label' do
+        visit new_set_url
+        fill_in('open_with_permission_permission_set_key', with: 'key 1')
+        fill_in('open_with_permission_permission_set_label', with: 'set 1')
+        click_on create_set
+        expect(page).to have_content('Key has already been taken')
+        expect(page).to have_content('Label has already been taken')
+      end
     end
 
     describe 'editing and creating permission sets as an approver' do


### PR DESCRIPTION
# Summary
Ensures that the Label attribute on Permission Sets must be unique.

# Related Ticket
[#2740](https://github.com/yalelibrary/YUL-DC/issues/2740)

# Screenshot

![image](https://github.com/yalelibrary/yul-dc-management/assets/36549923/fa8fdd55-9e61-4084-8650-e1c4183dca1f)
