### PR TITLE
Set up access change request mailer

### DIFF
--- a/app/assets/stylesheets/permission_requests.scss
+++ b/app/assets/stylesheets/permission_requests.scss
@@ -1,13 +1,62 @@
-#permission-requests-show {
+@import 'theme/colors', 'theme/typography', 'theme/breakpoints';
+
+#permission-request-header {
+  margin-top: 1%;
+  margin-bottom: 2%;
+}
+
+.permission-requests-show {
   width: 100%;
   padding-top: 3%;
   display: flex;
 }
 
-.permission-request-buttons {
-  padding-top: 20px;
+.permission-requests-show table {
+  border: none;
 }
 
-.request-false {
-  margin-left: 30px;
+.permission-requests-show td {
+  font-size: 1rem;
+}
+
+.permission-requests-show .key {
+  text-align: right;
+  background-color: $white;
+  border: none;
+}
+
+.permission-requests-show td:nth-of-type(even) {
+  border: 1px solid $medium_grey;
+}
+
+.interior {
+  border-top: none;
+  border-bottom: none;
+  border-left: 1px solid $medium_grey;
+  border-right: 1px solid $medium_grey;
+}
+
+.second-radio {
+  margin-left: 2rem;
+}
+
+#access-type-header {
+  margin-top: 4%;
+  margin-bottom: 2%;
+}
+
+#new-type {
+  background-color: $white;
+}
+
+#permission-request-buttons {
+  padding-top: 1%;
+  border-bottom: none;
+  border-left: none;
+  border-right: none;
+}
+
+#permission-request-buttons .btn {
+  margin-left: -.3rem;
+  margin-right: 1.5rem;
 }

--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -22,16 +22,12 @@ class PermissionRequestsController < ApplicationController
   # PATCH/PUT /permission_request/1
   # PATCH/PUT /permission_request/1.json
   def update
-    # byebug
+    send_mail if permission_request_params.key?('new_visibility')
     respond_to do |format|
-      if permission_request_params.key?('new_visibility')
-        send_mail
-        permission_request_params = clean_params
+      if permission_request_params.key?('new_visibility') && !permission_request_params.key?('request_status')
         format.html { redirect_to permission_request_path(@permission_request), notice: 'A request to change the access type of this object was sent successfully.' }
         format.json { render :show, status: :ok, location: @permission_request }
-        # byebug
-        break if permission_request_params.empty?
-      elsif @permission_request.update(permission_request_params)
+      elsif @permission_request.update(clean_params)
         format.html { redirect_to permission_request_path(@permission_request), notice: 'Changes saved successfully.' }
         format.json { render :show, status: :ok, location: @permission_request }
       else
@@ -58,7 +54,6 @@ class PermissionRequestsController < ApplicationController
   end
 
   def send_mail
-    # byebug
     access_change_request = {
       approver_name: current_user.first_name + ' ' + current_user.last_name,
       permission_set_label: @permission_request.permission_set.label,
@@ -70,8 +65,7 @@ class PermissionRequestsController < ApplicationController
   end
 
   def clean_params
-    # byebug
-    permission_request_params.delete('new_visibility')
+    permission_request_params.except('new_visibility').except('change_access_type')
   end
 
   private
@@ -83,6 +77,7 @@ class PermissionRequestsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def permission_request_params
-    params.require(:open_with_permission_permission_request).permit(:permission_set, :permission_request_user, :parent_object, :user, :request_status, :approver_note, :new_visibility)
+    params.require(:open_with_permission_permission_request).permit(:permission_set, :permission_request_user, :parent_object, :user,
+    :request_status, :approver_note, :new_visibility, :change_access_type)
   end
 end

--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -22,8 +22,16 @@ class PermissionRequestsController < ApplicationController
   # PATCH/PUT /permission_request/1
   # PATCH/PUT /permission_request/1.json
   def update
+    # byebug
     respond_to do |format|
-      if @permission_request.update(permission_request_params)
+      if permission_request_params.key?('new_visibility')
+        send_mail
+        permission_request_params = clean_params
+        format.html { redirect_to permission_request_path(@permission_request), notice: 'A request to change the access type of this object was sent successfully.' }
+        format.json { render :show, status: :ok, location: @permission_request }
+        # byebug
+        break if permission_request_params.empty?
+      elsif @permission_request.update(permission_request_params)
         format.html { redirect_to permission_request_path(@permission_request), notice: 'Changes saved successfully.' }
         format.json { render :show, status: :ok, location: @permission_request }
       else
@@ -49,6 +57,23 @@ class PermissionRequestsController < ApplicationController
     end
   end
 
+  def send_mail
+    # byebug
+    access_change_request = {
+      approver_name: current_user.first_name + ' ' + current_user.last_name,
+      permission_set_label: @permission_request.permission_set.label,
+      admin_set_label: @permission_request.parent_object.admin_set.label,
+      parent_object_oid: @permission_request.parent_object.oid,
+      new_visibility: permission_request_params[:new_visibility]
+    }
+    AccessChangeRequestMailer.with(access_change_request: access_change_request).access_change_request_email.deliver_now
+  end
+
+  def clean_params
+    # byebug
+    permission_request_params.delete('new_visibility')
+  end
+
   private
 
   # Use callbacks to share common setup or constraints between actions.
@@ -58,6 +83,6 @@ class PermissionRequestsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def permission_request_params
-    params.require(:open_with_permission_permission_request).permit(:permission_set, :permission_request_user, :parent_object, :user, :request_status, :approver_note)
+    params.require(:open_with_permission_permission_request).permit(:permission_set, :permission_request_user, :parent_object, :user, :request_status, :approver_note, :new_visibility)
   end
 end

--- a/app/mailers/access_change_request_mailer.rb
+++ b/app/mailers/access_change_request_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AccessChangeRequestMailer < ApplicationMailer
+  default from: "do_not_reply@library.yale.edu"
+
+  def access_change_request_email
+    @access_change_request = params[:access_change_request]
+    mail(to: 'digitalspecialcollections@yale.edu', subject: 'DCS Object Visibility Update Request')
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,7 +25,7 @@ class Ability
     can [:create_set, :crud, :owp_access], OpenWithPermission::PermissionSet if user.has_role?(:administrator, :any)
     can :read, OpenWithPermission::PermissionSet, roles: { name: approver_roles, users: { id: user.id } }
     can :crud, OpenWithPermission::PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
-    can [:read, :approve], OpenWithPermission::PermissionRequest, permission_set: { roles: { name: approver_roles, users: { id: user.id } } }
+    can [:read, :update, :approve], OpenWithPermission::PermissionRequest, permission_set: { roles: { name: approver_roles, users: { id: user.id } } }
     can [:crud, :approve], OpenWithPermission::PermissionRequest, permission_set: { roles: { name: administrator_roles, users: { id: user.id } } }
     can [:create, :read], ProblemReport if user.has_role?(:sysadmin)
   end

--- a/app/views/access_change_request_mailer/access_change_request_email.html.erb
+++ b/app/views/access_change_request_mailer/access_change_request_email.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <%= @access_change_request[:approver_name] %> has requested the following change in the Digital Collections System:</p>
+<p>
+  <strong>Permission Set:</strong> <%= @access_change_request[:permission_set_label] %><br />
+  <strong>Admin Set:</strong> <%= @access_change_request[:admin_set_label] %><br />
+  <strong>Parent OID:</strong> <%= @access_change_request[:parent_object_oid] %><br />
+  <strong>New Visibility:</strong> <%= @access_change_request[:new_visibility] %><br />
+</p>
+<p>Have a great day!</p>
+<small>
+  <pre>This is an automated message.  You are receiving this message because DSC is configured to use your email address.</pre>
+</small>

--- a/app/views/access_change_request_mailer/access_change_request_email.text.erb
+++ b/app/views/access_change_request_mailer/access_change_request_email.text.erb
@@ -1,0 +1,9 @@
+<%= @access_change_request[:approver_name] %> has requested the following change in the Digital Collections System:
+
+  Permission Set: <%= @access_change_request[:permission_set_label] %>
+  Admin Set: <%= @access_change_request[:admin_set_label] %>
+  Parent OID: <%= @access_change_request[:parent_object_oid] %>
+  New Visibility: <%= @access_change_request[:new_visibility] %>
+
+Have a great day!
+This is an automated message.

--- a/app/views/permission_requests/show.html.erb
+++ b/app/views/permission_requests/show.html.erb
@@ -1,61 +1,100 @@
-<%= render partial: "/management/flash_messages" %>
-<h1>Permission Request</h1>
+<%= render partial: '/management/flash_messages' %>
+<h1 id='permission-request-header'>Permission Request</h1>
 <%= form_with(model: [:open_with_permission, @permission_request], url: permission_request_path(@permission_request), local: true) do |form| %>
-  <div id='permission-requests-show'>
+  <div class='permission-requests-show'>
     <table class='metadata-block'>
       <tbody>
-        <tr class='requests-table-row'>
-          <td class="key">Request ID:</td>
+        <tr>
+          <td class='key'>Request ID:</td>
           <td><%= @permission_request.id %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">Permission Set Label:</td>
-          <td><%= @permission_request.permission_set.label %></td>
+        <tr>
+          <td class='key'>Permission Set Label:</td>
+          <td class='interior'><%= @permission_request.permission_set.label %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">Request Date:</td>
-          <td><%= @permission_request.created_at %></td>
+        <tr>
+          <td class='key'>Request Date:</td>
+          <td class='interior'><%= @permission_request.created_at %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">OID:</td>
-          <td><%= @permission_request.parent_object.oid %></td>
+        <tr>
+          <td class='key'>OID:</td>
+          <td class='interior'><%= @permission_request.parent_object.oid %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">User Name:</td>
-          <td><%= @permission_request.permission_request_user.name %></td>
+        <tr>
+          <td class='key'>User Name:</td>
+          <td class='interior'><%= @permission_request.permission_request_user.name %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">User ID:</td>
-          <td><%= @permission_request.permission_request_user.sub %></td>
+        <tr>
+          <td class='key'>User ID:</td>
+          <td class='interior'><%= @permission_request.permission_request_user.sub %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">User Note:</td>
-          <td><%= @permission_request.user_note %></td>
+        <tr>
+          <td class='key'>User Note:</td>
+          <td class='interior'><%= @permission_request.user_note %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">Request Status:</td>
-          <td><%= @permission_request.request_status %></td>
+        <tr>
+          <td class='key'>Request Status:</td>
+          <td class='interior'><%= @permission_request.request_status %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">Approver:</td>
-          <td><%= "#{@permission_request.user&.first_name} #{@permission_request.user&.last_name}" %></td>
+        <tr>
+          <td class='key'>Approver:</td>
+          <td class='interior'><%= "#{@permission_request.user&.first_name} #{@permission_request.user&.last_name}" %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">Approver Note:</td>
-          <td><%= form.text_area :approver_note %></td>
+        <tr>
+          <td class='key'>Approver Note:</td>
+          <td class='interior'><%= form.text_area :approver_note %></td>
         </tr>
-        <tr class='requests-table-row'>
-          <td class="key">Action:</td>
+        <tr>
+          <td class='key'>Action:</td>
           <td>
-            <%= form.radio_button :request_status, "true", class: 'request-true' %>Approve
-            <%= form.radio_button :request_status, "false", class: 'request-false' %>Deny
+            <%= form.radio_button :request_status, 'true' %> Approve
+            <%= form.radio_button :request_status, 'false', class: 'second-radio' %> Deny
           </td>     
         </tr>
       </tbody>
     </table>
   </div>
-  <div class='permission-request-buttons'>
-    <%= link_to 'Cancel', permission_requests_path, class: "btn button secondary-button" %>
-    <%= form.submit("Save", {class: "btn btn-primary"}) %>
+  <h2 id='access-type-header'>Object Access Type</h2>
+  <div class='permission-requests-show'>
+    <table class='metadata-block'>
+      <tbody>
+        <tr>
+          <td class='key'>Change Access Type?</td>
+          <td>
+            <%= form.radio_button :change_access_type, 'No', onchange: 'disableNewVisibility()' %> No
+            <%= form.radio_button :change_access_type, 'Yes', onchange: 'disableNewVisibility()', class: 'second-radio' %> Yes
+          </td>     
+        </tr>
+        <tr>
+          <td class='key'>New Access Type:</td>
+          <td id='new-type'>
+            <%= form.radio_button :new_visibility, 'Yale Community Only' %> Yale Community Only
+            <%= form.radio_button :new_visibility, 'Public', class: 'second-radio' %> Public
+          </td>     
+        </tr>
+        <tr>
+          <td class='key'></td>
+          <td id='permission-request-buttons'>
+            <div>
+              <%= link_to 'Cancel', permission_requests_path, class: 'btn button secondary-button' %>
+              <%= form.submit('Save', {class: 'btn button btn-primary'}) %>
+            </div>
+          </td>     
+        </tr>
+      </tbody>
+    </table>
   </div>
 <% end %>
+
+
+<script>
+  function disableNewVisibility() {
+    if(document.getElementById('open_with_permission_permission_request_change_access_type_no').checked) {
+      document.getElementById('open_with_permission_permission_request_new_visibility_yale_community_only').disabled = true;
+      document.getElementById('open_with_permission_permission_request_new_visibility_public').disabled = true;
+    } else if (document.getElementById('open_with_permission_permission_request_change_access_type_yes').checked) {
+      document.getElementById('open_with_permission_permission_request_new_visibility_yale_community_only').disabled = false;
+      document.getElementById('open_with_permission_permission_request_new_visibility_public').disabled = false;
+    }
+  };
+</script>

--- a/spec/mailers/access_change_request_mailer_spec.rb
+++ b/spec/mailers/access_change_request_mailer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AccessChangeRequestMailer, type: :mailer do
+  describe 'access_change_request_email' do
+    let(:admin_set) { FactoryBot.create(:admin_set) }
+    let(:metadata_source) { FactoryBot.create(:metadata_source) }
+    let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id) }
+    let(:permission_set) { FactoryBot.create(:permission_set) }
+    let(:user) { FactoryBot.create(:user) }
+    let(:approver_name) { user.first_name + ' ' + user.last_name }
+    let(:access_change_request) do
+      {
+        approver_name: approver_name,
+        permission_set_label: permission_set.label,
+        admin_set_label: admin_set.label,
+        parent_object_oid: parent_object.oid,
+        new_visibility: 'Public'
+      }
+    end
+    let(:mail) { described_class.with(access_change_request: access_change_request).access_change_request_email.deliver_now }
+
+    it 'renders the expected fields' do
+      expect(mail.subject).to eq 'DCS Object Visibility Update Request'
+      expect(mail.to).to eq ['digitalspecialcollections@yale.edu']
+      expect(mail.from).to eq ['do_not_reply@library.yale.edu']
+      expect(mail.body.encoded).to include(approver_name)
+      expect(mail.body.encoded).to include(permission_set.label)
+      expect(mail.body.encoded).to include(admin_set.label)
+      expect(mail.body.encoded).to include(parent_object.oid.to_s)
+      expect(mail.body.encoded).to include('Public')
+    end
+  end
+end

--- a/spec/mailers/access_change_request_mailer_spec.rb
+++ b/spec/mailers/access_change_request_mailer_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe AccessChangeRequestMailer, type: :mailer do
+RSpec.describe AccessChangeRequestMailer, type: :mailer, prep_admin_sets: true, prep_metadata_sources: true do
   describe 'access_change_request_email' do
-    let(:admin_set) { FactoryBot.create(:admin_set) }
-    let(:metadata_source) { FactoryBot.create(:metadata_source) }
+    let(:admin_set) { AdminSet.first }
+    let(:metadata_source) { MetadataSource.first }
     let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id) }
     let(:permission_set) { FactoryBot.create(:permission_set) }
     let(:user) { FactoryBot.create(:user) }

--- a/spec/system/permission_request_spec.rb
+++ b/spec/system/permission_request_spec.rb
@@ -7,13 +7,17 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
   let(:user) { FactoryBot.create(:user) }
   let(:admin_set) { FactoryBot.create(:admin_set) }
   let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "name 1", netid: "netid") }
-  let(:request_user_2) { FactoryBot.create(:permission_request_user, sub: "sub 2", name: "name 2", netid: "net id") }
+  let(:request_user_two) { FactoryBot.create(:permission_request_user, sub: "sub 2", name: "name 2", netid: "net id") }
   let(:permission_set) { FactoryBot.create(:permission_set, label: "set 1", key: 'key 1') }
-  let(:permission_set_2) { FactoryBot.create(:permission_set, label: "set 2", key: 'key 2') }
+  let(:permission_set_two) { FactoryBot.create(:permission_set, label: "set 2", key: 'key 2') }
   let(:parent_object) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
-  let(:parent_object_2) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
-  let(:permission_request) { FactoryBot.create(:permission_request, request_status: true, permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user) }
-  let(:permission_request_2) { FactoryBot.create(:permission_request, parent_object: parent_object_2, permission_set: permission_set_2, permission_request_user: request_user_2, request_status: true) }
+  let(:parent_object_two) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
+  let(:permission_request) do
+    FactoryBot.create(:permission_request, request_status: true, permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: 'something')
+  end
+  let(:permission_request_two) do
+    FactoryBot.create(:permission_request, parent_object: parent_object_two, permission_set: permission_set_two, permission_request_user: request_user_two, request_status: true)
+  end
   let(:administrator_user) { FactoryBot.create(:user, uid: 'admin') }
   let(:approver_user) { FactoryBot.create(:user, uid: 'approver') }
 
@@ -22,97 +26,243 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
     stub_metadata_cloud('2034600')
     stub_metadata_cloud('2005512')
     parent_object
-    parent_object_2
+    parent_object_two
     permission_request
-    permission_request_2
+    permission_request_two
   end
 
-  context 'as a sysadmin' do
-    before do
-      login_as sysadmin
+  describe 'index' do
+    context 'as a sysadmin' do
+      before do
+        login_as sysadmin
+      end
+
+      it 'can view all permission requests' do
+        visit '/'
+        expect(page).to have_content('PERMISSION REQUESTS')
+        visit '/permission_requests'
+        expect(page).to have_content('All Matching Entries')
+        expect(page).to have_content(permission_request.created_at.to_s)
+        expect(page).to have_content(permission_request.permission_set.label.to_s)
+        expect(page).to have_content(permission_request.parent_object.oid.to_s)
+        expect(page).to have_content(permission_request.permission_request_user.sub.to_s)
+        expect(page).to have_content(permission_request.permission_request_user.name.to_s)
+        expect(page).to have_content(permission_request.request_status.to_s)
+        expect(page).to have_content(permission_request_two.permission_set.label.to_s)
+        expect(page).to have_content(permission_request_two.created_at.to_s)
+        expect(page).to have_content(permission_request_two.parent_object.oid.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.sub.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.name.to_s)
+        expect(page).to have_content(permission_request_two.request_status.to_s)
+      end
     end
 
-    it 'can view all permission requests' do
-      visit '/'
-      expect(page).to have_content('PERMISSION REQUESTS')
-      visit '/permission_requests'
-      expect(page).to have_content('All Matching Entries')
-      expect(page).to have_content(permission_request.created_at.to_s)
-      expect(page).to have_content(permission_request.permission_set.label.to_s)
-      expect(page).to have_content(permission_request.parent_object.oid.to_s)
-      expect(page).to have_content(permission_request.permission_request_user.sub.to_s)
-      expect(page).to have_content(permission_request.permission_request_user.netid.to_s)
-      expect(page).to have_content(permission_request.permission_request_user.name.to_s)
-      expect(page).to have_content(permission_request.request_status.to_s)
-      expect(page).to have_content(permission_request_2.permission_set.label.to_s)
-      expect(page).to have_content(permission_request_2.created_at.to_s)
-      expect(page).to have_content(permission_request_2.parent_object.oid.to_s)
-      expect(page).to have_content(permission_request_2.permission_request_user.sub.to_s)
-      expect(page).to have_content(permission_request_2.permission_request_user.name.to_s)
-      expect(page).to have_content(permission_request_2.request_status.to_s)
+    context 'as a permission set admin' do
+      before do
+        permission_set_two.add_administrator(administrator_user)
+        login_as administrator_user
+      end
+
+      it 'can view a permission request from a set they are an admin for' do
+        visit '/'
+        expect(page).to have_content("PERMISSION REQUESTS")
+        visit '/permission_requests'
+        expect(page).to have_content('All Matching Entries')
+        expect(page).to have_content(permission_request_two.permission_set.label.to_s)
+        expect(page).to have_content(permission_request_two.created_at.to_s)
+        expect(page).to have_content(permission_request_two.parent_object.oid.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.sub.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.name.to_s)
+        expect(page).to have_content(permission_request_two.request_status.to_s)
+
+        expect(page).not_to have_content(permission_request.parent_object.oid.to_s)
+        expect(page).not_to have_content(permission_request.permission_request_user.sub.to_s)
+        expect(page).not_to have_content(permission_request.permission_request_user.name.to_s)
+      end
+    end
+
+    context 'as a permission set approver' do
+      before do
+        permission_set_two.add_approver(approver_user)
+        login_as approver_user
+      end
+
+      it 'can view a permission request from a set they are an approver for' do
+        visit '/'
+        expect(page).to have_content("PERMISSION REQUESTS")
+        visit '/permission_requests'
+        expect(page).to have_content('All Matching Entries')
+        expect(page).to have_content(permission_request_two.permission_set.label.to_s)
+        expect(page).to have_content(permission_request_two.created_at.to_s)
+        expect(page).to have_content(permission_request_two.parent_object.oid.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.sub.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.name.to_s)
+        expect(page).to have_content(permission_request_two.request_status.to_s)
+
+        expect(page).not_to have_content(permission_request.parent_object.oid.to_s)
+        expect(page).not_to have_content(permission_request.permission_request_user.sub.to_s)
+        expect(page).not_to have_content(permission_request.permission_request_user.name.to_s)
+      end
+    end
+
+    context 'as a regular user' do
+      before do
+        login_as user
+      end
+
+      it 'cannot view or access the Permission Requests page' do
+        visit '/'
+        expect(page).not_to have_content("PERMISSION REQUESTS")
+        visit '/permission_requests'
+        expect(page).to have_content("Access denied")
+      end
     end
   end
 
-  context 'as a permission set admin' do
-    before do
-      permission_set_2.add_administrator(administrator_user)
-      login_as administrator_user
+  describe 'show' do
+    context 'as a sysadmin' do
+      before do
+        login_as sysadmin
+      end
+
+      it 'can view a permission request' do
+        visit "/permission_requests/#{permission_request.id}"
+        expect(page).to have_content('Permission Request')
+        expect(page).to have_content(permission_request.id.to_s)
+        expect(page).to have_content(permission_request.permission_set.label.to_s)
+        expect(page).to have_content(permission_request.created_at.to_s)
+        expect(page).to have_content(permission_request.parent_object.oid.to_s)
+        expect(page).to have_content(permission_request.permission_request_user.sub.to_s)
+        expect(page).to have_content(permission_request.permission_request_user.name.to_s)
+        expect(page).to have_content(permission_request.user_note.to_s)
+      end
+
+      it 'can approve or deny a permission request' do
+        expect(permission_request.request_status).to eq true
+        visit "/permission_requests/#{permission_request.id}"
+        find('#open_with_permission_permission_request_request_status_false').click
+        click_on 'Save'
+        permission_request.reload
+        expect(permission_request.request_status).to eq false
+        visit "/permission_requests/#{permission_request.id}"
+        find('#open_with_permission_permission_request_request_status_true').click
+        click_on 'Save'
+        permission_request.reload
+        expect(permission_request.request_status).to eq true
+      end
+
+      it 'can request a change in access type' do
+        visit "/permission_requests/#{permission_request.id}"
+        find('#open_with_permission_permission_request_change_access_type_yes').click
+        find('#open_with_permission_permission_request_new_visibility_public').click
+        expect do
+          click_on 'Save'
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
     end
 
-    it 'can view a permission request from a set they are an admin for' do
-      visit '/'
-      expect(page).to have_content("PERMISSION REQUESTS")
-      visit '/permission_requests'
-      expect(page).to have_content('All Matching Entries')
-      expect(page).to have_content(permission_request_2.permission_set.label.to_s)
-      expect(page).to have_content(permission_request_2.created_at.to_s)
-      expect(page).to have_content(permission_request_2.parent_object.oid.to_s)
-      expect(page).to have_content(permission_request_2.permission_request_user.sub.to_s)
-      expect(page).to have_content(permission_request_2.permission_request_user.name.to_s)
-      expect(page).to have_content(permission_request_2.request_status.to_s)
+    context 'as a permission set admin' do
+      before do
+        permission_set.add_administrator(administrator_user)
+        login_as administrator_user
+      end
 
-      expect(page).not_to have_content(permission_request.parent_object.oid.to_s)
-      expect(page).not_to have_content(permission_request.permission_request_user.sub.to_s)
-      expect(page).not_to have_content(permission_request.permission_request_user.netid.to_s)
-      expect(page).not_to have_content(permission_request.permission_request_user.name.to_s)
+      it 'can view a permission request from a set they are an admin for' do
+        visit "/permission_requests/#{permission_request.id}"
+        expect(page).to have_content('Permission Request')
+        expect(page).to have_content(permission_request.id.to_s)
+        expect(page).to have_content(permission_request.permission_set.label.to_s)
+        expect(page).to have_content(permission_request.created_at.to_s)
+        expect(page).to have_content(permission_request.parent_object.oid.to_s)
+        expect(page).to have_content(permission_request.permission_request_user.sub.to_s)
+        expect(page).to have_content(permission_request.permission_request_user.name.to_s)
+        expect(page).to have_content(permission_request.user_note.to_s)
+      end
+
+      it 'can approve or deny a permission request' do
+        expect(permission_request.request_status).to eq true
+        visit "/permission_requests/#{permission_request.id}"
+        find('#open_with_permission_permission_request_request_status_false').click
+        click_on 'Save'
+        permission_request.reload
+        expect(permission_request.request_status).to eq false
+        visit "/permission_requests/#{permission_request.id}"
+        find('#open_with_permission_permission_request_request_status_true').click
+        click_on 'Save'
+        permission_request.reload
+        expect(permission_request.request_status).to eq true
+      end
+
+      it 'can request a change in access type' do
+        visit "/permission_requests/#{permission_request.id}"
+        find('#open_with_permission_permission_request_change_access_type_yes').click
+        find('#open_with_permission_permission_request_new_visibility_public').click
+        expect do
+          click_on 'Save'
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+
+      it 'cannot view, approve, or deny a permission request from a set they are not an admin or approver for' do
+        visit "/permission_requests/#{permission_request_two.id}"
+        expect(page).to have_content('Access denied')
+      end
     end
-  end
 
-  context 'as a permission set approver' do
-    before do
-      permission_set_2.add_approver(approver_user)
-      login_as approver_user
+    context 'as a permission set approver' do
+      before do
+        permission_set_two.add_approver(approver_user)
+        login_as approver_user
+      end
+
+      it 'can view a permission request from a set they are an approver for' do
+        visit "/permission_requests/#{permission_request_two.id}"
+        expect(page).to have_content('Permission Request')
+        expect(page).to have_content(permission_request_two.id.to_s)
+        expect(page).to have_content(permission_request_two.permission_set.label.to_s)
+        expect(page).to have_content(permission_request_two.created_at.to_s)
+        expect(page).to have_content(permission_request_two.parent_object.oid.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.sub.to_s)
+        expect(page).to have_content(permission_request_two.permission_request_user.name.to_s)
+        expect(page).to have_content(permission_request_two.user_note.to_s)
+      end
+
+      it 'can approve or deny a permission request from a set they are an approver for' do
+        expect(permission_request_two.request_status).to eq true
+        visit "/permission_requests/#{permission_request_two.id}"
+        find('#open_with_permission_permission_request_request_status_false').click
+        click_on 'Save'
+        permission_request_two.reload
+        expect(permission_request_two.request_status).to eq false
+        find('#open_with_permission_permission_request_request_status_true').click
+        click_on 'Save'
+        permission_request_two.reload
+        expect(permission_request_two.request_status).to eq true
+      end
+
+      it 'can request a change in access type' do
+        visit "/permission_requests/#{permission_request_two.id}"
+        find('#open_with_permission_permission_request_change_access_type_yes').click
+        find('#open_with_permission_permission_request_new_visibility_public').click
+        expect do
+          click_on 'Save'
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+
+      it 'cannot view, approve, or deny a permission request from a set they are not an admin or approver for' do
+        visit "/permission_requests/#{permission_request.id}"
+        expect(page).to have_content('Access denied')
+      end
     end
 
-    it 'can view a permission request from a set they are an admin for' do
-      visit '/'
-      expect(page).to have_content("PERMISSION REQUESTS")
-      visit '/permission_requests'
-      expect(page).to have_content('All Matching Entries')
-      expect(page).to have_content(permission_request_2.permission_set.label.to_s)
-      expect(page).to have_content(permission_request_2.created_at.to_s)
-      expect(page).to have_content(permission_request_2.parent_object.oid.to_s)
-      expect(page).to have_content(permission_request_2.permission_request_user.sub.to_s)
-      expect(page).to have_content(permission_request_2.permission_request_user.name.to_s)
-      expect(page).to have_content(permission_request_2.permission_request_user.netid.to_s)
-      expect(page).to have_content(permission_request_2.request_status.to_s)
+    context 'as a regular user' do
+      before do
+        login_as user
+      end
 
-      expect(page).not_to have_content(permission_request.parent_object.oid.to_s)
-      expect(page).not_to have_content(permission_request.permission_request_user.sub.to_s)
-      expect(page).not_to have_content(permission_request.permission_request_user.netid.to_s)
-      expect(page).not_to have_content(permission_request.permission_request_user.name.to_s)
-    end
-  end
-
-  context 'as a regular user' do
-    before do
-      login_as user
-    end
-    it 'cannot view or access the Permission Requests page' do
-      visit '/'
-      expect(page).not_to have_content("PERMISSION REQUESTS")
-      visit '/permission_requests'
-      expect(page).to have_content("Access denied")
+      it 'cannot view, approve, or deny a permission request from a set they are not an admin or approver for' do
+        visit "/permission_requests/#{permission_request.id}"
+        expect(page).to have_content('Access denied')
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary
Adds the ability to notify `digitalspecialcollections@yale.edu` when an approver requests a change in an object's visibility.

# Related Ticket
[#2749](https://github.com/yalelibrary/YUL-DC/issues/2749)

# Screenshot

![image](https://github.com/yalelibrary/yul-dc-management/assets/36549923/dfc3f8ef-6968-4b67-bee3-8ef3cdc0bb3e)
