### PR TITLE
2758 request access until

### DIFF
--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -58,6 +58,6 @@ class PermissionRequestsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def permission_request_params
-    params.require(:open_with_permission_permission_request).permit(:permission_set, :permission_request_user, :parent_object, :user, :request_status, :approver_note)
+    params.require(:open_with_permission_permission_request).permit(:permission_set, :permission_request_user, :parent_object, :user, :request_status, :approver_note, :access_until)
   end
 end

--- a/app/datatables/permission_request_datatable.rb
+++ b/app/datatables/permission_request_datatable.rb
@@ -24,6 +24,7 @@ class PermissionRequestDatatable < ApplicationDatatable
       sub: { source: "OpenWithPermission::PermissionRequestUser.sub", cond: :start_with, searchable: true, orderable: true },
       net_id: { source: "OpenWithPermission::PermissionRequestUser.netid", cond: :start_with, searchable: true, orderable: true },
       request_status: { source: "OpenWithPermission::PermissionRequest.request_status", cond: :start_with, searchable: true, orderable: true },
+      access_until: { source: "OpenWithPermission::PermissionRequest.access_until", cond: :start_with, searchable: true, orderable: true },
       approver: { source: "User.id", cond: :start_with, searchable: true, orderable: true }
     }
   end
@@ -41,6 +42,7 @@ class PermissionRequestDatatable < ApplicationDatatable
         sub: permission_request.permission_request_user.sub,
         net_id: permission_request.permission_request_user.netid,
         request_status: permission_request.request_status,
+        access_until: permission_request.access_until,
         approver: permission_request.user&.uid.presence || 'TODO'
       }
     end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -244,8 +244,6 @@ $( document ).on('turbolinks:load', function() {
   )
 });
 
-
-
 //  Delay the redraw so that if more changes trigger a redraw
 //  it will wait and make one request to the server.
 let drawTimer = 0;
@@ -420,3 +418,20 @@ $( document ).on('turbolinks:load', function() {
     }
   });
 });
+
+$( document ).on('turbolinks:load', function() {
+  if($('#open_with_permission_permission_request_request_status_false').val() == 'false' || $('#open_with_permission_permission_request_request_status_false').val() == nil) {
+    $('#open_with_permission_permission_request_access_until').prop('disabled', true);
+  }
+  $('#open_with_permission_permission_request_request_status_true').on('input change', function() {
+    if($(this).val() == 'true') {
+      $('#open_with_permission_permission_request_access_until').prop('disabled', false);
+    }
+  });
+  $('#open_with_permission_permission_request_request_status_false').on('input change', function() {
+    if($(this).val() == 'false') {
+      $('#open_with_permission_permission_request_access_until').prop('disabled', true);
+    }
+  });
+});
+

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -406,6 +406,7 @@ $( document ).on('turbolinks:load', function() {
   })
 })
 
+// Enables/Disabled permission set dropdown based on visibility
 $( document ).on('turbolinks:load', function() {
   if($('#parent_object_visibility').val() != 'Open with Permission') {
     $('#parent_object_permission_set_id').prop('disabled', true);
@@ -419,6 +420,7 @@ $( document ).on('turbolinks:load', function() {
   });
 });
 
+// Enables/disabled permission request datepicker based on selected request_status
 $( document ).on('turbolinks:load', function() {
   if($('#open_with_permission_permission_request_request_status_false').val() == 'false' || $('#open_with_permission_permission_request_request_status_false').val() == nil) {
     $('#open_with_permission_permission_request_access_until').prop('disabled', true);

--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -19,6 +19,7 @@
           <th scope='col'> User ID </th>
           <th scope='col'> Net ID </th>
           <th scope='col'> Request Status </th>
+          <th scope='col'> Access Expired </th>
           <th scope='col'> Approver </th>
         </tr>
       </thead>

--- a/app/views/permission_requests/show.html.erb
+++ b/app/views/permission_requests/show.html.erb
@@ -51,6 +51,10 @@
             <%= form.radio_button :request_status, "false", class: 'request-false' %>Deny
           </td>     
         </tr>
+        <tr class='requests-table-row'>
+          <td class="key">Allow Access Until:</td>
+          <td><%= form.date_field :access_until, min: 0.days.ago %></td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/spec/datatables/permission_request_datatable_spec.rb
+++ b/spec/datatables/permission_request_datatable_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
       sub: pr.permission_request_user.sub,
       net_id: pr.permission_request_user.netid,
       request_status: pr.request_status,
+      access_until: pr.access_until,
       approver: 'TODO'
     )
   end
@@ -54,6 +55,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
       permission_set: "<a href='/permission_sets/#{pr_one.permission_set.id}'>#{pr_one.permission_set.label}</a>",
       request_date: pr_one.created_at,
       request_status: pr_one.request_status,
+      access_until: pr_one.access_until,
       sub: pr_one.permission_request_user.sub,
       user_name: pr_one.permission_request_user.name
     )


### PR DESCRIPTION
## Summary  
Adds the ability to set a requests access_until date. Datepicker is disabled on page load and is enabled once the user clicks "Approve".   
  
## Screenshots:  
<img width="1401" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/05d60922-04ce-4e25-a2c6-8bd4eb2a7f23">
  
<img width="1388" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/c06dc3c1-f429-4425-a27f-0b5c56af0870">
