### PR TITLE
Adds mailer for new permission request

### DIFF
--- a/app/mailers/new_permission_request_mailer.rb
+++ b/app/mailers/new_permission_request_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class NewPermissionRequestMailer < ApplicationMailer
+  default from: "do_not_reply@library.yale.edu"
+
+  def new_permission_request_email
+    @new_permission_request = params[:new_permission_request]
+    permission_set = OpenWithPermission::PermissionSet.find_by(label: @new_permission_request[:permission_set_label])
+    admins_and_approvers = []
+    User.all.each do |user|
+      admins_and_approvers << user if user.has_role?(:administrator, permission_set) || user.has_role?(:approver, permission_set)
+    end
+    admins_and_approvers.each do |user|
+      @new_permission_request[:approver_name] = user.first_name + ' ' + user.last_name
+      mail(to: user.email, subject: "New Permission Request for #{@new_permission_request[:permission_set_label]}")
+    end
+  end
+end

--- a/app/views/new_permission_request_mailer/new_permission_request_email.html.erb
+++ b/app/views/new_permission_request_mailer/new_permission_request_email.html.erb
@@ -1,0 +1,16 @@
+<p>
+  Dear <%= @new_permission_request[:approver_name] %>,
+</p>
+<p>
+  A request for permission to view the object <%= link_to(@new_permission_request[:parent_object_title], "#{ENV['BLACKLIGHT_HOST']}/catalog/#{@new_permission_request[:parent_object_oid]}") %> from permission set <%= @new_permission_request[:permission_set_label] %> has been received. Details about the request are as follows:
+</p>
+<p>
+  <strong>Parent Object OID:</strong> <%= @new_permission_request[:parent_object_oid] %><br />
+  <strong>Requester Name:</strong> <%= @new_permission_request[:requester_name] %><br />
+  <strong>Requester Email Address:</strong> <%= @new_permission_request[:requester_email] %><br />
+  <strong>Reason for Request:</strong> <%= @new_permission_request[:requester_note] %><br />
+</p>
+<p>Please log into the Management App and review the request <%= link_to('here.', "#{ENV['MANAGEMENT_HOST']}/permission_requests/#{@new_permission_request[:permission_request_id]}") %></p>
+<small>
+  <pre>This is an automated message sent by Yale’s Digital Collections System.</pre>
+</small>

--- a/app/views/new_permission_request_mailer/new_permission_request_email.text.erb
+++ b/app/views/new_permission_request_mailer/new_permission_request_email.text.erb
@@ -1,0 +1,10 @@
+Dear <%= @new_permission_request[:approver_name] %>,
+
+A request for permission to view the object <%= link_to(@new_permission_request[:parent_object_title], "#{ENV['BLACKLIGHT_HOST']}/catalog/#{@new_permission_request[:parent_object_oid]}") %> from permission set <%= @new_permission_request[:permission_set_label] %> has been received. Details about the request are as follows:
+  Parent Object OID: <%= @new_permission_request[:parent_object_oid] %>
+  Requester Name: <%= @new_permission_request[:requester_name] %>
+  Requester Email Address: <%= @new_permission_request[:requester_email] %>
+  Reason for Request: <%= @new_permission_request[:requester_note] %>
+
+Please log into the Management App and review the request <%= link_to('here.', "#{ENV['MANAGEMENT_HOST']}/permission_requests/#{@new_permission_request[:permission_request_id]}") %>
+This is an automated message sent by Yale’s Digital Collections System.

--- a/spec/mailers/new_permission_request_mailer_spec.rb
+++ b/spec/mailers/new_permission_request_mailer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NewPermissionRequestMailer, type: :mailer, prep_admin_sets: true, prep_metadata_sources: true do
+  describe 'new_permission_request_email' do
+    let(:admin_set) { AdminSet.first }
+    let(:metadata_source) { MetadataSource.first }
+    let(:parent_object) do
+      FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id, oid: '2005512',
+                                        ladybird_json: JSON.parse(File.read(File.join(fixture_path, "ladybird", "2005512.json"))))
+    end
+    let(:permission_set) { FactoryBot.create(:permission_set, key: 'xyz', label: 'Primary') }
+    let(:permission_request) { FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message') }
+    let(:user) { FactoryBot.create(:user, first_name: 'Paulo', last_name: 'Coelho') }
+    let(:approver_name) { user.first_name + ' ' + user.last_name }
+    let(:new_permission_request) do
+      {
+        permission_request_id: permission_request.id,
+        permission_set_label: permission_set.label,
+        parent_object_oid: parent_object.oid,
+        parent_object_title: parent_object&.authoritative_json&.[]('title')&.first,
+        requester_name: permission_request.permission_request_user.name,
+        requester_email: permission_request.permission_request_user.email,
+        requester_note: permission_request.user_note
+      }
+    end
+    let(:mail) { described_class.with(new_permission_request: new_permission_request).new_permission_request_email.deliver_now }
+
+    before do
+      user.add_role(:approver, permission_set)
+      stub_metadata_cloud('2005512')
+      parent_object
+    end
+
+    it 'renders the expected fields' do
+      expect(mail.subject).to eq "New Permission Request for #{permission_set.label}"
+      expect(mail.to).to eq [user.email]
+      expect(mail.from).to eq ['do_not_reply@library.yale.edu']
+      expect(mail.body.encoded).to include(permission_set.label)
+      expect(mail.body.encoded).to include(approver_name)
+      expect(mail.body.encoded).to include(parent_object.oid.to_s)
+      expect(mail.body.encoded).to include('The gold pen used by Lincoln to sign the Emancipation Proclamation')
+      expect(mail.body.encoded).to include("#{ENV['BLACKLIGHT_HOST']}/catalog/#{parent_object.oid}")
+      expect(mail.body.encoded).to include(permission_request.permission_request_user.name)
+      expect(mail.body.encoded).to include(permission_request.permission_request_user.email)
+      expect(mail.body.encoded).to include(permission_request.user_note)
+      expect(mail.body.encoded).to include("permission_requests/#{permission_request.id}")
+    end
+  end
+end

--- a/spec/requests/api/permission_requests_spec.rb
+++ b/spec/requests/api/permission_requests_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources: true, prep_admin_sets: true do
+  let(:user) { FactoryBot.create(:sysadmin_user) }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:permission_set) { FactoryBot.create(:permission_set, max_queue_length: 1) }
+  let(:permission_set_2) { FactoryBot.create(:permission_set, key: 'abc', label: 'Secondary') }
+  let(:oid) { 2_034_600 }
+  let(:oid_2) { "17105661" }
+  let(:oid_3) { "30000016189097" }
+  let(:parent) { FactoryBot.create(:parent_object, oid: oid, admin_set: admin_set, visibility: "Open with Permission", permission_set_id: permission_set.id) }
+  let(:parent_2) { FactoryBot.create(:parent_object, oid: oid_2, admin_set: admin_set, visibility: "Public", permission_set_id: permission_set.id) }
+  let(:parent_3) { FactoryBot.create(:parent_object, oid: oid_3, admin_set: admin_set, visibility: "Private", permission_set_id: permission_set.id) }
+  let(:json) { File.read(Rails.root.join(fixture_path, 'permission_request.json')) }
+  let(:invalid_oid_json) { File.read(Rails.root.join(fixture_path, 'invalid_oid_permission_request.json')) }
+  let(:public_visibility_json) { File.read(Rails.root.join(fixture_path, 'public_visibility_permission_request.json')) }
+  let(:private_visibility_json) { File.read(Rails.root.join(fixture_path, 'private_visibility_permission_request.json')) }
+  let(:invalid_sub_json) { File.read(Rails.root.join(fixture_path, 'invalid_sub_permission_request.json')) }
+  let(:invalid_name_json) { File.read(Rails.root.join(fixture_path, 'invalid_name_permission_request.json')) }
+  let(:invalid_email_json) { File.read(Rails.root.join(fixture_path, 'invalid_email_permission_request.json')) }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  before do
+    stub_metadata_cloud(oid)
+    stub_metadata_cloud(oid_2)
+    stub_metadata_cloud(oid_3)
+    parent
+    parent_2
+    parent_3
+    parent
+    login_as user
+    user.add_role(:editor, admin_set)
+    user.add_role(:approver, permission_set)
+  end
+
+  describe '/api/permission_requests' do
+    it 'creates a new permission request' do
+      request = JSON.parse(json)
+      expect do
+        post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(response).to have_http_status(:created)
+      expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
+      pr = OpenWithPermission::PermissionRequest.first
+      expect(pr.user_note).not_to be nil
+    end
+
+    it 'errors if requests go over max' do
+      request = JSON.parse(json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(:created)
+      expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(403)
+      expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
+    end
+
+    it 'errors if a parent OID is invalid' do
+      request = JSON.parse(invalid_oid_json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(400)
+      expect(response.body).to match("{\"title\":\"Invalid Parent OID\"}")
+    end
+
+    it 'errors if a users subject is missing' do
+      request = JSON.parse(invalid_sub_json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(400)
+      expect(response.body).to match("{\"title\":\"User subject is missing\"}")
+    end
+
+    it 'errors if a users name is missing' do
+      request = JSON.parse(invalid_name_json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(400)
+      expect(response.body).to match("{\"title\":\"User name is missing\"}")
+    end
+
+    it 'errors if a users email is missing' do
+      request = JSON.parse(invalid_email_json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(400)
+      expect(response.body).to match("{\"title\":\"User email is missing\"}")
+    end
+
+    it 'errors if a parent object visibility is public' do
+      request = JSON.parse(public_visibility_json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(400)
+      expect(response.body).to match("{\"title\":\"Parent Object is public, permission not required\"}")
+    end
+
+    it 'errors if a parent object visibility is private' do
+      request = JSON.parse(private_visibility_json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
+      expect(response).to have_http_status(400)
+      expect(response.body).to match("{\"title\":\"Parent Object is private\"}")
+    end
+  end
+end

--- a/spec/requests/permission_requests_spec.rb
+++ b/spec/requests/permission_requests_spec.rb
@@ -4,102 +4,21 @@ require 'rails_helper'
 
 RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: true, prep_admin_sets: true do
   let(:user) { FactoryBot.create(:sysadmin_user) }
-  let(:admin_set) { FactoryBot.create(:admin_set) }
-  let(:permission_set) { FactoryBot.create(:permission_set, max_queue_length: 1) }
-  let(:permission_set_2) { FactoryBot.create(:permission_set, key: 'abc', label: 'Secondary') }
-  let(:oid) { 2_034_600 }
-  let(:oid_2) { "17105661" }
-  let(:oid_3) { "30000016189097" }
-  let(:parent) { FactoryBot.create(:parent_object, oid: oid, admin_set: admin_set, visibility: "Open with Permission", permission_set_id: permission_set.id) }
-  let(:parent_2) { FactoryBot.create(:parent_object, oid: oid_2, admin_set: admin_set, visibility: "Public", permission_set_id: permission_set.id) }
-  let(:parent_3) { FactoryBot.create(:parent_object, oid: oid_3, admin_set: admin_set, visibility: "Private", permission_set_id: permission_set.id) }
   let(:json) { File.read(Rails.root.join(fixture_path, 'permission_request.json')) }
-  let(:invalid_oid_json) { File.read(Rails.root.join(fixture_path, 'invalid_oid_permission_request.json')) }
-  let(:public_visibility_json) { File.read(Rails.root.join(fixture_path, 'public_visibility_permission_request.json')) }
-  let(:private_visibility_json) { File.read(Rails.root.join(fixture_path, 'private_visibility_permission_request.json')) }
-  let(:invalid_sub_json) { File.read(Rails.root.join(fixture_path, 'invalid_sub_permission_request.json')) }
-  let(:invalid_name_json) { File.read(Rails.root.join(fixture_path, 'invalid_name_permission_request.json')) }
-  let(:invalid_email_json) { File.read(Rails.root.join(fixture_path, 'invalid_email_permission_request.json')) }
+  let(:admin_set) { AdminSet.first }
+  let(:oid) { '2034600' }
+  let(:parent_object) { FactoryBot.create(:parent_object, admin_set_id: admin_set.id, oid: oid) }
+  let(:permission_set) { FactoryBot.create(:permission_set, key: 'abc', label: 'Secondary') }
+  let(:permission_request_user) { FactoryBot.create(:permission_request_user) }
   let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
 
   before do
     stub_metadata_cloud(oid)
-    stub_metadata_cloud(oid_2)
-    stub_metadata_cloud(oid_3)
-    parent
-    parent_2
-    parent_3
-    parent
     login_as user
-    user.add_role(:editor, admin_set)
-    user.add_role(:approver, permission_set)
-  end
-
-  describe 'index /api/permission_requests' do
-    it 'creates a new permission request' do
-      request = JSON.parse(json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(:created)
-      expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
-      pr = OpenWithPermission::PermissionRequest.first
-      expect(pr.user_note).not_to be nil
-    end
-
-    it 'errors if requests go over max' do
-      request = JSON.parse(json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(:created)
-      expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(403)
-      expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
-    end
-
-    it 'errors if a parent OID is invalid' do
-      request = JSON.parse(invalid_oid_json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(400)
-      expect(response.body).to match("{\"title\":\"Invalid Parent OID\"}")
-    end
-
-    it 'errors if a users subject is missing' do
-      request = JSON.parse(invalid_sub_json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(400)
-      expect(response.body).to match("{\"title\":\"User subject is missing\"}")
-    end
-
-    it 'errors if a users name is missing' do
-      request = JSON.parse(invalid_name_json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(400)
-      expect(response.body).to match("{\"title\":\"User name is missing\"}")
-    end
-
-    it 'errors if a users email is missing' do
-      request = JSON.parse(invalid_email_json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(400)
-      expect(response.body).to match("{\"title\":\"User email is missing\"}")
-    end
-
-    it 'errors if a parent object visibility is public' do
-      request = JSON.parse(public_visibility_json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(400)
-      expect(response.body).to match("{\"title\":\"Parent Object is public, permission not required\"}")
-    end
-
-    it 'errors if a parent object visibility is private' do
-      request = JSON.parse(private_visibility_json)
-      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      expect(response).to have_http_status(400)
-      expect(response.body).to match("{\"title\":\"Parent Object is private\"}")
-    end
   end
 
   describe 'update' do
-    let(:updatable_permission_request) { FactoryBot.create(:permission_request, permission_set: permission_set_2) }
+    let(:updatable_permission_request) { FactoryBot.create(:permission_request, permission_set: permission_set) }
 
     context 'with an authenticated approver' do
       it 'will change request status' do


### PR DESCRIPTION
# Summary
Upon creation of a new permission request all approvers and administrators will be emailed information about and a link to that permission request.

# Related Ticket
[#2763](https://github.com/yalelibrary/YUL-DC/issues/2763)