### PR TITLE
Remove duplicate stylesheet link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
 
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 
   <%= render 'layouts/header' %>
 


### PR DESCRIPTION
# Summary
There was a webpacker error preventing the management site from loading properly.  This PR removes a duplicate stylesheet link that was causing the webpacker error and enables successful deploy of management app.

# Related Ticket
[#2764](https://github.com/yalelibrary/YUL-DC/issues/2764)