### PR TITLE
adds strong params to save date

### DIFF
--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -78,6 +78,6 @@ class PermissionRequestsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def permission_request_params
     params.require(:open_with_permission_permission_request).permit(:permission_set, :permission_request_user, :parent_object, :user,
-    :request_status, :approver_note, :new_visibility, :change_access_type)
+    :request_status, :approver_note, :new_visibility, :change_access_type, :access_until)
   end
 end


### PR DESCRIPTION
## Summary  
access_until was accidentally removed from strong params in a merge or merge conflict. This re-adds the params and the date now saves and displays accordingly:  
<img width="1414" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/3615b0c9-6d81-45d4-9c36-99ae3951d3f1">
