### PR TITLE
Display Admin Set Keys in BP

### DIFF
--- a/app/models/concerns/csv_exportable.rb
+++ b/app/models/concerns/csv_exportable.rb
@@ -21,17 +21,11 @@ module CsvExportable
   # rubocop:disable Metrics/PerceivedComplexity
   def parent_output_csv(*admin_set_id)
     return nil unless batch_action == 'export all parent objects by admin set'
-    self.admin_set = ''
-    sets = admin_set
     output_csv = CSV.generate do |csv|
       csv << parent_headers
       with_each_parent_object(*admin_set_id) do |po|
         case po
         when ParentObject
-          sets << ', ' + po.admin_set.key
-          split_sets = sets.split(',').uniq.reject(&:blank?)
-          self.admin_set = split_sets.join(', ')
-          save!
           csv << [po.oid, po.admin_set.key, po.source_name,
                   po.child_object_count, po.authoritative_json&.[]('title')&.first, po.call_number, po.container_grouping, po.bib, po.holding, po.item,
                   po.barcode, po.aspace_uri, po.digital_object_source, po.preservica_uri, po.preservica_representation_type,
@@ -77,11 +71,15 @@ module CsvExportable
   # rubocop:disable Lint/UselessAssignment
   def with_each_parent_object(*admin_set_id)
     arr = []
+    self.admin_set = ''
+    sets = admin_set
     if csv.present?
       imported_csv = CSV.parse(csv, headers: true).presence
       imported_csv.each_with_index do |row, index|
         admin_set = AdminSet.find_by!(key: row[0])
-        self.admin_set = admin_set.key
+        sets << ', ' + admin_set.key
+        split_sets = sets.split(',').uniq.reject(&:blank?)
+        self.admin_set = split_sets.join(', ')
         save!
         if user.viewer(admin_set) || user.editor(admin_set)
           ParentObject.where(admin_set_id: admin_set.id).order(:oid).find_each do |parent|


### PR DESCRIPTION
## Summary  
This allows the BP table to display admin sets that are present in the CSV, even if the Admin Set doe snot have any Parent Objects.  
  
## Screenshot:  
This CSV only had parent objects for brbl:  
<img width="1398" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/f95b531a-73a0-4795-9851-0bc0acf9af0e">
