### PR TITLE
Updates sha512 symbol

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -257,7 +257,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       co.preservica_content_object_uri = value[:content_uri]
       co.preservica_generation_uri = value[:generation_uri]
       co.preservica_bitstream_uri = value[:bitstream_uri]
-      co.sha512_checksum = value[:sha512_checksum]
+      co.sha512_checksum = value[:checksum]
       co.last_preservica_update = Time.current
       replace_preservica_tif(co)
       co.save!


### PR DESCRIPTION
# Summary
During testing of the resync process we discovered that the sha checksum was not being saved properly.  This change should remedy this issue.

[#2779](https://github.com/yalelibrary/YUL-DC/issues/2779)