### PR TITLE
Add retry of copy to access during generate ptiff process

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -172,7 +172,7 @@ class ChildObject < ApplicationRecord
         # Conversion info is true if the ptiff was skipped as already present
       end
       true
-    elsif !pyramidal_tiff.valid? && parent_object.digital_object_source == 'Preservica'
+    elsif !pyramidal_tiff.valid? && parent_object&.digital_object_source == 'Preservica'
       if !access_master_exists && (attempt += 1) <= MAX_ATTEMPTS
         Rails.logger.info "************ child_object.rb # convert_to_ptiff +++ File not found at access path: #{access_master_path}.  Retrying copy to access (attempt #{attempt} of #{MAX_ATTEMPTS})"
         PreservicaImageService.new(parent_object.preservica_uri, parent_object.admin_set.key).image_list(parent_object.preservica_representation_type).map do |child_hash|

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -227,10 +227,10 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     child_hash[:bitstream].download_to_file(access_master_path)
   rescue => e
     if (attempt += 1) <= MAX_ATTEMPTS && !File.exist?(access_master_path)
-      Rails.logger.info "File not downloaded.  Retrying (attempt #{attempt} of #{MAX_ATTEMPTS})"
+      Rails.logger.info "********************* parent_object.rb # preservica_copy_to_access +++ File not downloaded.  Retrying (attempt #{attempt} of #{MAX_ATTEMPTS}) *************"
       retry
     else
-      Rails.logger.info "File not downloaded after #{MAX_ATTEMPTS} attempts"
+      Rails.logger.info "********************* parent_object.rb # preservica_copy_to_access +++ File not downloaded after #{MAX_ATTEMPTS} attempts *************"
       processing_event(e.to_s, "failed")
       raise e.to_s
     end


### PR DESCRIPTION
# Summary
Adds a retry of the preservica specific copy to access process during the GeneratePtiffJob.  Also adds more specific logging messaging.

# Related Ticket
[#2779](https://github.com/yalelibraryit/YUL-DC/issues/2779)
