### PR TITLE
Add redo to write and remove other retries for preservica ingest

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -8,7 +8,6 @@
 # rubocop:disable ClassLength
 class ChildObject < ApplicationRecord
   # rubocop:enable ClassLength
-  MAX_ATTEMPTS = 3
   has_paper_trail
   include Statable
   include Delayable
@@ -163,7 +162,6 @@ class ChildObject < ApplicationRecord
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/PerceivedComplexity
   def convert_to_ptiff
-    attempt ||= 1
     Rails.logger.info "************ child_object.rb # convert_to_ptiff +++ is the ptiff valid? #{pyramidal_tiff.valid?} *************"
     if pyramidal_tiff.valid?
       if pyramidal_tiff.conversion_information&.[](:width)
@@ -172,16 +170,6 @@ class ChildObject < ApplicationRecord
         # Conversion info is true if the ptiff was skipped as already present
       end
       true
-    elsif !pyramidal_tiff.valid? && parent_object&.digital_object_source == 'Preservica'
-      if !access_master_exists? && (attempt += 1) <= MAX_ATTEMPTS
-        Rails.logger.info "************ child_object.rb # convert_to_ptiff +++ File not found at access path: #{access_master_path}.  Retrying copy to access (attempt #{attempt} of #{MAX_ATTEMPTS})"
-        PreservicaImageService.new(parent_object.preservica_uri, parent_object.admin_set.key).image_list(parent_object.preservica_representation_type).map do |child_hash|
-          parent_object.preservica_copy_to_access(child_hash, oid) unless access_master_exists?
-        end
-      else
-        Rails.logger.info "************ child_object.rb # convert_to_ptiff +++ File not downloaded after #{MAX_ATTEMPTS} attempts"
-        raise "Child Object #{oid} failed to convert PTIFF due to #{pyramidal_tiff.errors.full_messages.join('\n')}"
-      end
     else
       report_ptiff_generation_error
       raise "Child Object #{oid} failed to convert PTIFF due to #{pyramidal_tiff.errors.full_messages.join('\n')}"

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -5,7 +5,6 @@ require 'fileutils'
 
 class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   FIVE_HUNDRED_MB = 524_288_000
-  MAX_ATTEMPTS = 3
   has_paper_trail
   include JsonFile
   include SolrIndexable
@@ -218,22 +217,15 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:enable Metrics/MethodLength
 
   def preservica_copy_to_access(child_hash, co_oid)
-    attempt ||= 1
     pairtree_path = Partridge::Pairtree.oid_to_pairtree(co_oid)
     image_mount = ENV['ACCESS_MASTER_MOUNT'] || "data"
     directory = format("%02d", pairtree_path.first)
     FileUtils.mkdir_p(File.join(image_mount, directory, pairtree_path))
     access_master_path = File.join(image_mount, directory, pairtree_path, "#{co_oid}.tif")
     child_hash[:bitstream].download_to_file(access_master_path)
-  rescue => e
-    if (attempt += 1) <= MAX_ATTEMPTS && !File.exist?(access_master_path)
-      Rails.logger.info "********************* parent_object.rb # preservica_copy_to_access +++ File not downloaded.  Retrying (attempt #{attempt} of #{MAX_ATTEMPTS}) *************"
-      retry
-    else
-      Rails.logger.info "********************* parent_object.rb # preservica_copy_to_access +++ File not downloaded after #{MAX_ATTEMPTS} attempts *************"
-      processing_event(e.to_s, "failed")
-      raise e.to_s
-    end
+  rescue StandardError => e
+    processing_event(e.to_s, "failed")
+    raise e.to_s
   end
 
   # rubocop:disable Rails/SkipsModelValidations

--- a/app/models/preservica/bitstream.rb
+++ b/app/models/preservica/bitstream.rb
@@ -28,15 +28,19 @@ class Preservica::Bitstream
     preservica_client.get content_uri
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def download_to_file(file_name)
     Rails.logger.info "************ bitstream.rb # download_to_file +++ hits download to file method with file: #{file_name} *************"
     data_length = 0
     sha512 = Digest::SHA512. new
     File.open(file_name, 'wb') do |file|
-      Rails.logger.info "************ bitstream.rb # download_to_file +++ File.open works *************"
+      Rails.logger.info "************ bitstream.rb # download_to_file +++ File.open succeeds in opening file *************"
       preservica_client.get(content_uri) do |chunk|
         data_length += chunk.length
-        file.write(chunk)
+        no_of_bites = file.write(chunk)
+        redo if no_of_bites < 1
+        Rails.logger.info "************ bitstream.rb # download_to_file +++ File.write wrote #{no_of_bites} bites to file *************"
         sha512 << chunk
       end
     end
@@ -49,6 +53,8 @@ class Preservica::Bitstream
     raise StandardError, "File sizes do not match (#{file_size} != #{size})" unless file_size == size
     # could also check: Digest::SHA512.file(file_name).hexdigest == sha512_checksum, but probably not necessary
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   def xml
     @xml ||= Nokogiri::XML(preservica_client.content_object_generation_bitstream(@content_id, @generation_id, @id)).remove_namespaces!

--- a/spec/models/preservica/preservica_when_it_does_not_copy_sync_spec.rb
+++ b/spec/models/preservica/preservica_when_it_does_not_copy_sync_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
   let(:preservica_parent_with_children) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent_with_children.csv")) }
   let(:preservica_sync) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_sync.csv")) }
-  # let(:logger_mock) { instance_double('Rails.logger').as_null_object }
+  let(:logger_mock) { instance_double('Rails.logger').as_null_object }
 
   around do |example|
     preservica_host = ENV['PRESERVICA_HOST']
@@ -27,7 +27,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   end
 
   before do
-    # allow(Rails.logger).to receive(:info) { :logger_mock }
+    allow(Rails.logger).to receive(:info) { :logger_mock }
     login_as(:user)
     batch_process.user_id = user.id
     stub_pdfs
@@ -126,7 +126,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!
       end.to change { ChildObject.count }.from(3).to(4)
-      # expect(Rails.logger).to have_received(:info)
+      # expect(Rails.logger).to have_received(:info).with("************ bitstream.rb # download_to_file +++ File.write wrote 310202 bites to file *************")
 
       expect(File.exist?("spec/fixtures/images/access_masters/00/07/20/00/00/00/200000007.tif")).to eq true
       co_first = po_first.child_objects.first


### PR DESCRIPTION
# Summary
The prior PRs introduced an error where the resync job hangs as incomplete.  This PR removes the troublesome retry processes and adds a redo where the file is actually written.

# Related Ticket
[#2779](https://github.com/yalelibrary/YUL-DC/issues/2779)