### PR TITLE
Save Access Type Info

### DIFF
--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -22,7 +22,6 @@ class PermissionRequestsController < ApplicationController
   # PATCH/PUT /permission_request/1
   # PATCH/PUT /permission_request/1.json
   def update
-    @permission_request = OpenWithPermission::PermissionRequest.find(params[:id])
     old_visibility = @permission_request.new_visibility
     respond_to do |format|
       if @permission_request.update(permission_request_params)

--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -22,12 +22,11 @@ class PermissionRequestsController < ApplicationController
   # PATCH/PUT /permission_request/1
   # PATCH/PUT /permission_request/1.json
   def update
-    send_mail if permission_request_params.key?('new_visibility')
+    @permission_request = OpenWithPermission::PermissionRequest.find(params[:id])
+    old_visibility = @permission_request.new_visibility
     respond_to do |format|
-      if permission_request_params.key?('new_visibility') && !permission_request_params.key?('request_status')
-        format.html { redirect_to permission_request_path(@permission_request), notice: 'A request to change the access type of this object was sent successfully.' }
-        format.json { render :show, status: :ok, location: @permission_request }
-      elsif @permission_request.update(clean_params)
+      if @permission_request.update(permission_request_params)
+        send_mail if @permission_request.new_visibility != old_visibility
         format.html { redirect_to permission_request_path(@permission_request), notice: 'Changes saved successfully.' }
         format.json { render :show, status: :ok, location: @permission_request }
       else
@@ -62,10 +61,6 @@ class PermissionRequestsController < ApplicationController
       new_visibility: permission_request_params[:new_visibility]
     }
     AccessChangeRequestMailer.with(access_change_request: access_change_request).access_change_request_email.deliver_now
-  end
-
-  def clean_params
-    permission_request_params.except('new_visibility').except('change_access_type')
   end
 
   private

--- a/db/migrate/20240430174608_add_access_type_to_permission_requests.rb
+++ b/db/migrate/20240430174608_add_access_type_to_permission_requests.rb
@@ -1,0 +1,6 @@
+class AddAccessTypeToPermissionRequests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :permission_requests, :change_access_type, :string
+    add_column :permission_requests, :new_visibility, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_17_200952) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_30_174608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -316,6 +316,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_17_200952) do
     t.text "user_note"
     t.datetime "approved_or_denied_at"
     t.string "permission_request_user_name"
+    t.string "change_access_type"
+    t.string "new_visibility"
     t.index ["parent_object_id"], name: "index_permission_requests_on_parent_object_id"
     t.index ["permission_request_user_id"], name: "index_permission_requests_on_permission_request_user_id"
     t.index ["permission_set_id"], name: "index_permission_requests_on_permission_set_id"


### PR DESCRIPTION
## Summary  
Added `change_access_type` and `new_visibility` columns in order to save selected information to the request.  
`send_email` will only send when a new visibility is submitted. 