### PR TITLE
request_status refactor

### DIFF
--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -16,7 +16,7 @@ class Api::PermissionRequestsController < ApplicationController
     return unless valid_json_request(request)
     pr_user = find_or_create_user(request)
     permission_set = OpenWithPermission::PermissionSet.find(parent_object.permission_set_id)
-    current_requests_count = OpenWithPermission::PermissionRequest.where(permission_request_user: pr_user, request_status: nil, permission_set: permission_set).count
+    current_requests_count = OpenWithPermission::PermissionRequest.where(permission_request_user: pr_user, request_status: "Pending", permission_set: permission_set).count
     if current_requests_count >= permission_set.max_queue_length
       render json: { "title": "Too many pending requests" }, status: 403
     else

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -422,16 +422,18 @@ $( document ).on('turbolinks:load', function() {
 
 // Enables/disabled permission request datepicker based on selected request_status
 $( document ).on('turbolinks:load', function() {
-  if($('#open_with_permission_permission_request_request_status_false').val() == 'false' || $('#open_with_permission_permission_request_request_status_false').val() == nil) {
+  if($('#open_with_permission_permission_request_request_status_denied').val() == 'Denied' || $('#open_with_permission_permission_request_request_status_denied').val() == nil) {
     $('#open_with_permission_permission_request_access_until').prop('disabled', true);
   }
-  $('#open_with_permission_permission_request_request_status_true').on('input change', function() {
-    if($(this).val() == 'true') {
+  console.log($('#open_with_permission_permission_request_request_status_denied').val())
+  console.log($('#open_with_permission_permission_request_request_status_approved').val())
+  $('#open_with_permission_permission_request_request_status_approved').on('input change', function() {
+    if($(this).val() == 'Approved') {
       $('#open_with_permission_permission_request_access_until').prop('disabled', false);
     }
   });
-  $('#open_with_permission_permission_request_request_status_false').on('input change', function() {
-    if($(this).val() == 'false') {
+  $('#open_with_permission_permission_request_request_status_denied').on('input change', function() {
+    if($(this).val() == 'Denied') {
       $('#open_with_permission_permission_request_access_until').prop('disabled', true);
     }
   });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -425,8 +425,6 @@ $( document ).on('turbolinks:load', function() {
   if($('#open_with_permission_permission_request_request_status_denied').val() == 'Denied' || $('#open_with_permission_permission_request_request_status_denied').val() == nil) {
     $('#open_with_permission_permission_request_access_until').prop('disabled', true);
   }
-  console.log($('#open_with_permission_permission_request_request_status_denied').val())
-  console.log($('#open_with_permission_permission_request_request_status_approved').val())
   $('#open_with_permission_permission_request_request_status_approved').on('input change', function() {
     if($(this).val() == 'Approved') {
       $('#open_with_permission_permission_request_access_until').prop('disabled', false);

--- a/app/views/permission_requests/show.html.erb
+++ b/app/views/permission_requests/show.html.erb
@@ -47,8 +47,8 @@
         <tr>
           <td class='key'>Action:</td>
           <td>
-            <%= form.radio_button :request_status, 'true' %> Approve
-            <%= form.radio_button :request_status, 'false', class: 'second-radio' %> Deny
+            <%= form.radio_button :request_status, 'Approved' %> Approve
+            <%= form.radio_button :request_status, 'Denied', class: 'second-radio' %> Deny
           </td>     
         </tr>
         <tr class='requests-table-row'>

--- a/db/migrate/20240502202722_change_request_status.rb
+++ b/db/migrate/20240502202722_change_request_status.rb
@@ -1,0 +1,11 @@
+class ChangeRequestStatus < ActiveRecord::Migration[7.0]
+  def change
+    add_column :permission_requests, :request_status_new, :string, default: "Pending"
+
+    OpenWithPermission::PermissionRequest.where(request_status: true).update_all request_status_new: "Approved"
+    OpenWithPermission::PermissionRequest.where(request_status: false).update_all request_status_new: "Denied"
+
+    remove_column :permission_requests, :request_status
+    rename_column :permission_requests, :request_status_new, :request_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -317,7 +317,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_02_202722) do
     t.string "permission_request_user_name"
     t.string "change_access_type"
     t.string "new_visibility"
-    t.string "approver"
     t.string "request_status", default: "Pending"
     t.index ["parent_object_id"], name: "index_permission_requests_on_parent_object_id"
     t.index ["permission_request_user_id"], name: "index_permission_requests_on_permission_request_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_30_174608) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_02_202722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -303,7 +303,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_174608) do
   end
 
   create_table "permission_requests", force: :cascade do |t|
-    t.boolean "request_status"
     t.text "approver_note"
     t.boolean "terms_approved"
     t.datetime "access_until", precision: nil
@@ -318,6 +317,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_174608) do
     t.string "permission_request_user_name"
     t.string "change_access_type"
     t.string "new_visibility"
+    t.string "approver"
+    t.string "request_status", default: "Pending"
     t.index ["parent_object_id"], name: "index_permission_requests_on_parent_object_id"
     t.index ["permission_request_user_id"], name: "index_permission_requests_on_permission_request_user_id"
     t.index ["permission_set_id"], name: "index_permission_requests_on_permission_set_id"

--- a/spec/models/api/permission_request_spec.rb
+++ b/spec/models/api/permission_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::PermissionRequest, type: :model, prep_metadata_sources: true
       expect(u.permission_request_user_id).to eq request_user.id
       expect(u.user_id).to eq user.id
       expect(u.user_note).to eq "Note"
-      expect(u.request_status).to eq nil
+      expect(u.request_status).to eq "Pending"
     end
   end
 end

--- a/spec/requests/permission_requests_spec.rb
+++ b/spec/requests/permission_requests_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: tru
 
     context 'with an authenticated approver' do
       it 'will change request status' do
-        expect(updatable_permission_request.request_status).to be_nil
+        expect(updatable_permission_request.request_status).to eq "Pending"
         valid_status_update_params = { open_with_permission_permission_request:
           {
-            request_status: true,
+            request_status: "Approved",
             change_access_type: 'No'
           } }
         patch "/permission_requests/#{updatable_permission_request.id}", params: JSON.pretty_generate(valid_status_update_params), headers: headers
         expect(response).to have_http_status(302)
         updatable_permission_request.reload
-        expect(updatable_permission_request.request_status).to eq true
+        expect(updatable_permission_request.request_status).to eq "Approved"
       end
 
       it 'will send an email when access type change is requested but does not change visibility of parent object' do
@@ -49,11 +49,11 @@ RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: tru
       end
 
       it 'will change request status (but not the visibility of the parent) and send email' do
-        expect(updatable_permission_request.request_status).to be_nil
+        expect(updatable_permission_request.request_status).to eq "Pending"
         expect(updatable_permission_request.parent_object.visibility).to eq 'Private'
         valid_status_and_access_update_params = { open_with_permission_permission_request:
           {
-            request_status: true,
+            request_status: "Approved",
             new_visibility: 'Public',
             change_access_type: 'Yes'
           } }
@@ -62,7 +62,7 @@ RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: tru
         end.to change { ActionMailer::Base.deliveries.count }.by(1)
         expect(response).to have_http_status(302)
         updatable_permission_request.reload
-        expect(updatable_permission_request.request_status).to eq true
+        expect(updatable_permission_request.request_status).to eq "Approved"
         expect(updatable_permission_request.parent_object.visibility).to eq 'Private'
       end
     end

--- a/spec/system/permission_request_spec.rb
+++ b/spec/system/permission_request_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
   let(:parent_object_two) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
   # rubocop:disable Layout/LineLength
   let(:permission_request) do
-    FactoryBot.create(:permission_request, request_status: true, permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: 'something', permission_request_user_name: 'name 2')
+    FactoryBot.create(:permission_request, request_status: "Approved", permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: 'something', permission_request_user_name: 'name 2')
   end
   let(:permission_request_two) do
-    FactoryBot.create(:permission_request, parent_object: parent_object_two, permission_set: permission_set_two, permission_request_user: request_user_two, request_status: true, permission_request_user_name: 'name 3')
+    FactoryBot.create(:permission_request, parent_object: parent_object_two, permission_set: permission_set_two, permission_request_user: request_user_two, request_status: "Approved", permission_request_user_name: 'name 3')
   end
   # rubocop:enable Layout/LineLength
   let(:administrator_user) { FactoryBot.create(:user, uid: 'admin') }
@@ -140,17 +140,17 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
       end
 
       it 'can approve or deny a permission request' do
-        expect(permission_request.request_status).to eq true
+        expect(permission_request.request_status).to eq "Approved"
         visit "/permission_requests/#{permission_request.id}"
-        find('#open_with_permission_permission_request_request_status_false').click
+        find('#open_with_permission_permission_request_request_status_denied').click
         click_on 'Save'
         permission_request.reload
-        expect(permission_request.request_status).to eq false
+        expect(permission_request.request_status).to eq "Denied"
         visit "/permission_requests/#{permission_request.id}"
-        find('#open_with_permission_permission_request_request_status_true').click
+        find('#open_with_permission_permission_request_request_status_approved').click
         click_on 'Save'
         permission_request.reload
-        expect(permission_request.request_status).to eq true
+        expect(permission_request.request_status).to eq "Approved"
       end
 
       it 'can request a change in access type' do
@@ -182,17 +182,17 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
       end
 
       it 'can approve or deny a permission request' do
-        expect(permission_request.request_status).to eq true
+        expect(permission_request.request_status).to eq "Approved"
         visit "/permission_requests/#{permission_request.id}"
-        find('#open_with_permission_permission_request_request_status_false').click
+        find('#open_with_permission_permission_request_request_status_denied').click
         click_on 'Save'
         permission_request.reload
-        expect(permission_request.request_status).to eq false
+        expect(permission_request.request_status).to eq "Denied"
         visit "/permission_requests/#{permission_request.id}"
-        find('#open_with_permission_permission_request_request_status_true').click
+        find('#open_with_permission_permission_request_request_status_approved').click
         click_on 'Save'
         permission_request.reload
-        expect(permission_request.request_status).to eq true
+        expect(permission_request.request_status).to eq "Approved"
       end
 
       it 'can request a change in access type' do
@@ -229,16 +229,16 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
       end
 
       it 'can approve or deny a permission request from a set they are an approver for' do
-        expect(permission_request_two.request_status).to eq true
+        expect(permission_request_two.request_status).to eq "Approved"
         visit "/permission_requests/#{permission_request_two.id}"
-        find('#open_with_permission_permission_request_request_status_false').click
+        find('#open_with_permission_permission_request_request_status_denied').click
         click_on 'Save'
         permission_request_two.reload
-        expect(permission_request_two.request_status).to eq false
-        find('#open_with_permission_permission_request_request_status_true').click
+        expect(permission_request_two.request_status).to eq "Denied"
+        find('#open_with_permission_permission_request_request_status_approved').click
         click_on 'Save'
         permission_request_two.reload
-        expect(permission_request_two.request_status).to eq true
+        expect(permission_request_two.request_status).to eq "Approved"
       end
 
       it 'can request a change in access type' do


### PR DESCRIPTION
## Summary  
request_status has been refactored to be a string. "Approved", "Denied", and a default value of "Pending"