### PR TITLE
Sanitize user input

### DIFF
--- a/app/models/open_with_permission/permission_request.rb
+++ b/app/models/open_with_permission/permission_request.rb
@@ -5,8 +5,17 @@ class OpenWithPermission::PermissionRequest < ApplicationRecord
   belongs_to :permission_request_user, class_name: "OpenWithPermission::PermissionRequestUser"
   belongs_to :parent_object
   has_one :user
+  before_validation :sanitize_user_input, on: [:create]
 
   before_save do
     self.approved_or_denied_at = Time.zone.now if request_status_changed?
+  end
+
+  private
+
+  def sanitize_user_input
+    self.user_note = ActionView::Base.full_sanitizer.sanitize(self.user_note, tags: []).gsub('&amp;','&')
+    self.permission_request_user_name = ActionView::Base.full_sanitizer.sanitize(self.permission_request_user_name, tags: []).gsub('&amp;','&')
+    self.permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(self.permission_request_user.email, tags: []).gsub('&amp;','&')
   end
 end

--- a/app/models/open_with_permission/permission_request.rb
+++ b/app/models/open_with_permission/permission_request.rb
@@ -14,8 +14,8 @@ class OpenWithPermission::PermissionRequest < ApplicationRecord
   private
 
   def sanitize_user_input
-    self.user_note = ActionView::Base.full_sanitizer.sanitize(user_note, tags: []).gsub('&amp;', '&')
-    self.permission_request_user_name = ActionView::Base.full_sanitizer.sanitize(permission_request_user_name, tags: []).gsub('&amp;', '&')
-    permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(permission_request_user.email, tags: []).gsub('&amp;', '&')
+    self.user_note = ActionView::Base.full_sanitizer.sanitize(user_note, tags: [])
+    self.permission_request_user_name = ActionView::Base.full_sanitizer.sanitize(permission_request_user_name, tags: [])
+    self.permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(permission_request_user.email, tags: [])
   end
 end

--- a/app/models/open_with_permission/permission_request.rb
+++ b/app/models/open_with_permission/permission_request.rb
@@ -16,6 +16,6 @@ class OpenWithPermission::PermissionRequest < ApplicationRecord
   def sanitize_user_input
     self.user_note = ActionView::Base.full_sanitizer.sanitize(user_note, tags: [])
     self.permission_request_user_name = ActionView::Base.full_sanitizer.sanitize(permission_request_user_name, tags: [])
-    self.permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(permission_request_user.email, tags: [])
+    permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(permission_request_user.email, tags: [])
   end
 end

--- a/app/models/open_with_permission/permission_request.rb
+++ b/app/models/open_with_permission/permission_request.rb
@@ -14,8 +14,8 @@ class OpenWithPermission::PermissionRequest < ApplicationRecord
   private
 
   def sanitize_user_input
-    self.user_note = ActionView::Base.full_sanitizer.sanitize(self.user_note, tags: []).gsub('&amp;','&')
-    self.permission_request_user_name = ActionView::Base.full_sanitizer.sanitize(self.permission_request_user_name, tags: []).gsub('&amp;','&')
-    self.permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(self.permission_request_user.email, tags: []).gsub('&amp;','&')
+    self.user_note = ActionView::Base.full_sanitizer.sanitize(user_note, tags: []).gsub('&amp;', '&')
+    self.permission_request_user_name = ActionView::Base.full_sanitizer.sanitize(permission_request_user_name, tags: []).gsub('&amp;', '&')
+    permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(permission_request_user.email, tags: []).gsub('&amp;', '&')
   end
 end

--- a/app/models/open_with_permission/permission_request.rb
+++ b/app/models/open_with_permission/permission_request.rb
@@ -16,6 +16,5 @@ class OpenWithPermission::PermissionRequest < ApplicationRecord
   def sanitize_user_input
     self.user_note = ActionView::Base.full_sanitizer.sanitize(user_note, tags: [])
     self.permission_request_user_name = ActionView::Base.full_sanitizer.sanitize(permission_request_user_name, tags: [])
-    permission_request_user.email = ActionView::Base.full_sanitizer.sanitize(permission_request_user.email, tags: [])
   end
 end

--- a/app/models/open_with_permission/permission_request_user.rb
+++ b/app/models/open_with_permission/permission_request_user.rb
@@ -7,4 +7,11 @@ class OpenWithPermission::PermissionRequestUser < ApplicationRecord
   validates :email, presence: true
   validates :email_verified, inclusion: { in: [true, false] }
   validates :oidc_updated_at, presence: true
+  before_validation :sanitize_user_input, on: [:create]
+
+  private
+
+  def sanitize_user_input
+    self.email = ActionView::Base.full_sanitizer.sanitize(email, tags: [])
+  end
 end

--- a/app/models/open_with_permission/permission_request_user.rb
+++ b/app/models/open_with_permission/permission_request_user.rb
@@ -13,5 +13,6 @@ class OpenWithPermission::PermissionRequestUser < ApplicationRecord
 
   def sanitize_user_input
     self.email = ActionView::Base.full_sanitizer.sanitize(email, tags: [])
+    self.name = ActionView::Base.full_sanitizer.sanitize(name, tags: [])
   end
 end

--- a/spec/system/permission_request_spec.rb
+++ b/spec/system/permission_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
   let(:sysadmin) { FactoryBot.create(:sysadmin_user) }
   let(:user) { FactoryBot.create(:user) }
   let(:admin_set) { FactoryBot.create(:admin_set) }
-  let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "name 1", netid: "netid") }
+  let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "<p>name 1</p>", netid: "netid", email: "<h2>email@example.com</h2>") }
   let(:request_user_two) { FactoryBot.create(:permission_request_user, sub: "sub 2", name: "name 2", netid: "net id") }
   let(:permission_set) { FactoryBot.create(:permission_set, label: "set 1", key: 'key 1') }
   let(:permission_set_two) { FactoryBot.create(:permission_set, label: "set 2", key: 'key 2') }
@@ -14,7 +14,7 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
   let(:parent_object_two) { FactoryBot.create(:parent_object, oid: "2005512", admin_set_id: admin_set.id) }
   # rubocop:disable Layout/LineLength
   let(:permission_request) do
-    FactoryBot.create(:permission_request, request_status: "Approved", permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: 'something', permission_request_user_name: 'name 2')
+    FactoryBot.create(:permission_request, request_status: "Approved", permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: '<p>something</p>', permission_request_user_name: '<h1>name 2</h1>')
   end
   let(:permission_request_two) do
     FactoryBot.create(:permission_request, parent_object: parent_object_two, permission_set: permission_set_two, permission_request_user: request_user_two, request_status: "Approved", permission_request_user_name: 'name 3')
@@ -137,6 +137,14 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
         expect(page).to have_content(permission_request.permission_request_user.sub.to_s)
         expect(page).to have_content(permission_request.permission_request_user.name.to_s)
         expect(page).to have_content(permission_request.user_note.to_s)
+        expect(permission_request.user_note).to eq "something"
+      end
+
+      it 'has sanitized values for user_note, name, and email' do
+        expect(permission_request.user_note).to eq "something"
+        expect(permission_request.permission_request_user_name).to eq "name 2"
+        expect(permission_request.permission_request_user.name).to eq "name 1"
+        expect(permission_request.permission_request_user.email).to eq "email@example.com"
       end
 
       it 'can approve or deny a permission request' do


### PR DESCRIPTION
## Summary  
Request form fields from Blacklight users will now be sanitized prior to saving to database.  
  
## Screenshots:  
What is entered in the request form:  
<img width="623" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/037fdf88-a3c5-4f3d-b064-79187e13ab21">
  
  
What is saved to db:  
<img width="815" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/068f2089-55ee-4877-aea7-3f0dd3503fe9">
