### PR TITLE
Add migrations and update schema for goodjob

### DIFF
--- a/db/migrate/20240508022331_create_good_job_settings.rb
+++ b/db/migrate/20240508022331_create_good_job_settings.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateGoodJobSettings < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_settings)
+      end
+    end
+
+    create_table :good_job_settings, id: :uuid do |t|
+      t.timestamps
+      t.text :key
+      t.jsonb :value
+      t.index :key, unique: true
+    end
+  end
+end

--- a/db/migrate/20240508022332_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
+++ b/db/migrate/20240508022332_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_jobs_on_priority_created_at_when_unfinished)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240508022333_create_good_job_batches.rb
+++ b/db/migrate/20240508022333_create_good_job_batches.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateGoodJobBatches < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_batches)
+      end
+    end
+
+    create_table :good_job_batches, id: :uuid do |t|
+      t.timestamps
+      t.text :description
+      t.jsonb :serialized_properties
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_discard
+      t.text :callback_queue_name
+      t.integer :callback_priority
+      t.datetime :enqueued_at
+      t.datetime :discarded_at
+      t.datetime :finished_at
+    end
+
+    change_table :good_jobs do |t|
+      t.uuid :batch_id
+      t.uuid :batch_callback_id
+
+      t.index :batch_id, where: "batch_id IS NOT NULL"
+      t.index :batch_callback_id, where: "batch_callback_id IS NOT NULL"
+    end
+  end
+end

--- a/db/migrate/20240508022334_create_good_job_executions.rb
+++ b/db/migrate/20240508022334_create_good_job_executions.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutions < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_executions)
+      end
+    end
+
+    create_table :good_job_executions, id: :uuid do |t|
+      t.timestamps
+
+      t.uuid :active_job_id, null: false
+      t.text :job_class
+      t.text :queue_name
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.text :error
+
+      t.index [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+    end
+
+    change_table :good_jobs do |t|
+      t.boolean :is_discrete
+      t.integer :executions_count
+      t.text :job_class
+    end
+  end
+end

--- a/db/migrate/20240508022335_create_good_jobs_error_event.rb
+++ b/db/migrate/20240508022335_create_good_jobs_error_event.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateGoodJobsErrorEvent < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :error_event)
+      end
+    end
+
+    add_column :good_jobs, :error_event, :integer, limit: 2
+    add_column :good_job_executions, :error_event, :integer, limit: 2
+  end
+end

--- a/db/migrate/20240508022336_recreate_good_job_cron_indexes_with_conditional.rb
+++ b/db/migrate/20240508022336_recreate_good_job_cron_indexes_with_conditional.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)",
+                    name: :index_good_jobs_on_cron_key_and_created_at_cond, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at_cond, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          add_index :good_jobs, [:cron_key, :created_at],
+                    name: :index_good_jobs_on_cron_key_and_created_at, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          add_index :good_jobs, [:cron_key, :cron_at], unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at_cond
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240508022337_create_good_job_labels.rb
+++ b/db/migrate/20240508022337_create_good_job_labels.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabels < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :labels)
+      end
+    end
+
+    add_column :good_jobs, :labels, :text, array: true
+  end
+end

--- a/db/migrate/20240508022338_create_good_job_labels_index.rb
+++ b/db/migrate/20240508022338_create_good_job_labels_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)",
+            name: :index_good_jobs_on_labels, algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          remove_index :good_jobs, name: :index_good_jobs_on_labels
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240508022339_remove_good_job_active_id_index.rb
+++ b/db/migrate/20240508022339_remove_good_job_active_id_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RemoveGoodJobActiveIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          remove_index :good_jobs, name: :index_good_jobs_on_active_job_id
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          add_index :good_jobs, :active_job_id, name: :index_good_jobs_on_active_job_id
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_02_202722) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_08_022339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -202,14 +202,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_02_202722) do
     t.integer "executions_count"
     t.text "job_class"
     t.integer "error_event", limit: 2
+    t.text "labels", array: true
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
-    t.index ["active_job_id"], name: "index_good_jobs_on_active_job_id"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
     t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
-    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at"
-    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at", unique: true
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
+    t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"


### PR DESCRIPTION
# Summary
In both the test and uat environments GoodJob was not starting successfully because it had pending migrations.  This PR adds those migrations and updates the schema.

# Related Ticket
[#2779](https://github.com/yalelibrary/YUL-DC/issues/2779)

# Screenshot
![image](https://github.com/yalelibrary/yul-dc-management/assets/36549923/9894841a-8997-4584-bf26-a20492b07774)
