### PR TITLE
removes eye link

### DIFF
--- a/app/datatables/permission_request_datatable.rb
+++ b/app/datatables/permission_request_datatable.rb
@@ -52,10 +52,7 @@ class PermissionRequestDatatable < ApplicationDatatable
   # rubocop:enable Rails/OutputSafety
 
   def id_column(permission_request)
-    result = []
-    result << link_to(permission_request.id, permission_request_path(permission_request))
-    result << with_icon('fa fa-eye', permission_request_path(permission_request))
-    result.join(' ')
+    link_to(permission_request.id, permission_request_path(permission_request))
   end
 
   def with_icon(class_name, path, options = {})

--- a/spec/datatables/permission_request_datatable_spec.rb
+++ b/spec/datatables/permission_request_datatable_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
     expect(output.size).to eq(1)
     expect(output).to include(
       DT_RowId: pr.id,
-      id: "<a href='/permission_requests/#{pr.id}'>#{pr.id}</a> <a href='/permission_requests/#{pr.id}'>#{pr.id}</a>",
+      id: "<a href='/permission_requests/#{pr.id}'>#{pr.id}</a>",
       permission_set: "<a href='/permission_sets/#{pr.permission_set.id}'>#{pr.permission_set.label}</a>",
       request_date: pr.created_at,
       oid: pr.parent_object.oid,
@@ -50,7 +50,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
     expect(output).to include(
       DT_RowId: pr_one.id,
       approver: nil,
-      id: "<a href='/permission_requests/#{pr_one.id}'>#{pr_one.id}</a> <a href='/permission_requests/#{pr_one.id}'>#{pr_one.id}</a>",
+      id: "<a href='/permission_requests/#{pr_one.id}'>#{pr_one.id}</a>",
       net_id: pr_one.permission_request_user.netid,
       oid: pr_one.parent_object.oid,
       permission_set: "<a href='/permission_sets/#{pr_one.permission_set.id}'>#{pr_one.permission_set.label}</a>",


### PR DESCRIPTION
## Summary  
Removes eye link icon from permission request datatable.  
  
## Screenshot  
<img width="1432" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/523fcc72-e81a-4810-8840-09f1edcc9f3a">
