### PR TITLE
Add OwP visibility to Preservica ingest service

### DIFF
--- a/app/services/csv_row_parent_service.rb
+++ b/app/services/csv_row_parent_service.rb
@@ -74,7 +74,7 @@ class CsvRowParentService
   end
 
   def visibility
-    visibilities = ['Private', 'Public', 'Redirect', 'Yale Community Only']
+    visibilities = ['Private', 'Public', 'Redirect', 'Yale Community Only', 'Open with Permission']
 
     return row['visibility'] if visibilities.include?(row['visibility'])
 


### PR DESCRIPTION
# Summary
The `Open with Permission` visibility option was not included in the list of visibility options in the preservica ingest service.  This PR remedies that and eliminates the chance for the visibility or the extent of digitization from not matching the parent object model.

# Related Ticket
[#2824](https://github.com/yalelibrary/YUL-DC/issues/2824)