### PR TITLE
Email to Permission Request Showpage

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -34,6 +34,7 @@ import "@fortawesome/fontawesome-free/js/all.js";
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 window.JSZip = JSZip;
+global.$ = jQuery;
 
 let dataTable;
 $( document ).on('turbolinks:load', function() {

--- a/app/views/permission_requests/show.html.erb
+++ b/app/views/permission_requests/show.html.erb
@@ -29,6 +29,10 @@
           <td class='interior'><%= @permission_request.permission_request_user.sub %></td>
         </tr>
         <tr>
+          <td class='key'>User Email:</td>
+          <td class="copy-email"><%= @permission_request.permission_request_user.email %> <em id="copy-icon" class='fa-regular fa-copy' data-toggle="popover" data-placement="right" data-original-title="" data-content="Copied" aria-describedby="tooltip" onclick="copyToClipboard()"></em></td>
+        </tr>
+        <tr>
           <td class='key'>User Note:</td>
           <td class='interior'><%= @permission_request.user_note %></td>
         </tr>
@@ -91,7 +95,6 @@
   <%= link_to 'Back', permission_requests_path %>
 <% end %>
 
-
 <script>
   function disableNewVisibility() {
     if(document.getElementById('open_with_permission_permission_request_change_access_type_no').checked) {
@@ -100,6 +103,16 @@
     } else if (document.getElementById('open_with_permission_permission_request_change_access_type_yes').checked) {
       document.getElementById('open_with_permission_permission_request_new_visibility_yale_community_only').disabled = false;
       document.getElementById('open_with_permission_permission_request_new_visibility_public').disabled = false;
+    }
+  };
+
+  const copyToClipboard = async () => {
+    try {
+      const element = document.querySelector(".copy-email");
+      await navigator.clipboard.writeText(element.textContent);
+      $('#copy-icon').addClass('fa-check');
+    } catch (error) {
+      console.error("Failed to copy to clipboard:", error);
     }
   };
 </script>

--- a/app/views/permission_requests/show.html.erb
+++ b/app/views/permission_requests/show.html.erb
@@ -30,7 +30,7 @@
         </tr>
         <tr>
           <td class='key'>User Email:</td>
-          <td class="copy-email"><%= @permission_request.permission_request_user.email %> <em id="copy-icon" class='fa-regular fa-copy' data-toggle="popover" data-placement="right" data-original-title="" data-content="Copied" aria-describedby="tooltip" onclick="copyToClipboard()"></em></td>
+          <td class="copy-email"><%= @permission_request.permission_request_user.email %> <em id="copy-icon" class='fa-regular fa-copy' onclick="copyToClipboard()"></em></td>
         </tr>
         <tr>
           <td class='key'>User Note:</td>


### PR DESCRIPTION
## Summary  
Adds 'Email' to Permission Request showpage. Also adds a "Copy" icon that will copy the email address to the clipboard.  
  
## Screenshot:  
<img width="1775" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/ee64aedf-3699-4dbc-8d2f-582956cad736">
