### PR TITLE
Check json for OwP itemPermission

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -18,24 +18,23 @@ class SetupMetadataJob < ApplicationJob
       parent_object.processing_event("SetupMetadataJob failed to find all images.", "failed")
       return
     end
-    index_private(parent_object)
     unless parent_object.default_fetch(current_batch_process, current_batch_connection)
       # Don't retry in this case. default_fetch() will throw an exception if it's a network error and trigger retry
       parent_object.processing_event("SetupMetadataJob failed to retrieve authoritative metadata. [#{parent_object.metadata_cloud_url}]", "failed")
       return
     end
 
-    if parent_object.visibility == 'Open with Permission' || parent_object.authoritative_json&.[]('itemPermission') == 'Open with Permission'
+    # rubocop:disable Layout/LineLength
+    if (parent_object.visibility == 'Open with Permission' && parent_object.permission_set_id.nil?) || (parent_object.authoritative_json&.[]('itemPermission') == 'Open with Permission' && parent_object.permission_set_id.nil?) || (parent_object.authoritative_json&.[]('itemPermission') == 'Open With Permission' && parent_object.permission_set_id.nil?)
       permission_set = OpenWithPermission::PermissionSet.find_by(key: parent_object.permission_set&.key)
       if permission_set.nil?
-        parent_object.processing_event("SetupMetadataJob failed. Permission Set missing or nonexistent.", 'failed')
-        return
-      elsif !current_batch_process.user.has_role?(:administrator, permission_set) || !current_batch_process.user.has_role?(:sysadmin)
-        parent_object.processing_event("SetupMetadataJob failed because user does not have edit permissions for this Permission Set: #{permission_set.label}", 'failed')
+        parent_object.processing_event("SetupMetadataJob failed. Permission Set information missing or nonexistent from CSV.  To successfully ingest a Permission Set Key value must be present for any parent objects that have 'Open with Permission' visibility. Parent Object has defaulted to private and no child objects were created.  Please delete parent object and re-attempt ingest with Permission Set Key and Visibility values in CSV.", 'failed')
+        # rubocop:enable Layout/LineLength
         return
       end
     end
     setup_child_object_jobs(parent_object, current_batch_process)
+    index_private(parent_object)
   rescue => e
     parent_object.processing_event("Setup job failed to save: #{e.message}", "failed")
     raise # this reraises the error after we document it

--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -30,7 +30,7 @@ class SetupMetadataJob < ApplicationJob
       if permission_set.nil?
         parent_object.processing_event("SetupMetadataJob failed. Permission Set missing or nonexistent.", 'failed')
         return
-      elsif !user.has_role?(:administrator, permission_set) || !user.has_role?(:sysadmin)
+      elsif !current_batch_process.user.has_role?(:administrator, permission_set) || !current_batch_process.user.has_role?(:sysadmin)
         parent_object.processing_event("SetupMetadataJob failed because user does not have edit permissions for this Permission Set: #{permission_set.label}", 'failed')
         return
       end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -241,7 +241,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         parent_object.digitization_funding_source = row['digitization_funding_source']
         parent_object.rights_statement = row['rights_statement']
 
-        if row['visibility'] == 'Open with Permission' || parent_object&.authoritative_json&.[]('itemPermission') == 'Open with Permission'
+        if row['visibility'] == 'Open with Permission'
           permission_set = OpenWithPermission::PermissionSet.find_by(key: row['permission_set_key'])
           if permission_set.nil?
             batch_processing_event("Skipping row [#{index + 2}]. Process failed. Permission Set missing or nonexistent.", 'Skipped Row')

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -193,6 +193,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/BlockLength
+  # rubocop:disable Layout/LineLength
   def create_new_parent_csv
     self.admin_set = ''
     sets = admin_set
@@ -240,21 +241,6 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         parent_object.digitization_funding_source = row['digitization_funding_source']
         parent_object.rights_statement = row['rights_statement']
 
-        # rubocop:disable Layout/LineLength
-        if row['visibility'] == 'Open with Permission'
-          permission_set = OpenWithPermission::PermissionSet.find_by(key: row['permission_set_key'])
-          if permission_set.nil?
-            batch_processing_event("Skipping row [#{index + 2}]. Process failed. Permission Set missing or nonexistent.", 'Skipped Row')
-            next
-          elsif user.has_role?(:administrator, permission_set) || user.has_role?(:sysadmin)
-            parent_object.visibility = row['visibility']
-            parent_object.permission_set_id = permission_set.id
-          else
-            batch_processing_event("Skipping row [#{index + 2}] because user does not have edit permissions for this Permission Set: #{permission_set.key}", 'Permission Denied')
-            next
-          end
-        end
-
         if ParentObject.viewing_directions.include?(row['viewing_direction'])
           parent_object.viewing_direction = row['viewing_direction']
         else
@@ -266,13 +252,12 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         else
           batch_processing_event("Parent #{oid} did not update value for Display Layout. Value: #{row['display_layout']} is invalid. For field Display Layout / Viewing Hint please use: individuals, paged, continuous, or leave column empty", 'Invalid Vocabulary')
         end
-        # rubocop:enable Layout/LineLength
 
         if metadata_source == 'aspace' && row['extent_of_digitization'].blank?
           batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}.  Parent objects with ASpace as a source must have an Extent of Digitization value.", 'Skipped Row')
           next
         elsif metadata_source == 'aspace' && row['extent_of_digitization'].present?
-          if row['extent_of_digitization'] == 'Completely digitized' || row['extent_of_digitization'] == 'Partially digitized'
+          if ParentObject.extent_of_digitizations.include?(row['extent_of_digitization'])
             parent_object.extent_of_digitization = row['extent_of_digitization']
           else
             batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid}.  Extent of Digitization value must be 'Completely digitized' or 'Partially digitized'.", 'Skipped Row')
@@ -287,8 +272,24 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         end
 
         parent_object.parent_model = model
-
         setup_for_background_jobs(parent_object, metadata_source)
+        parent_object.default_fetch
+        parent_object.metadata_update = true
+
+        if row['visibility'] == 'Open with Permission' || parent_object&.authoritative_json&.[]('itemPermission') == 'Open with Permission'
+          permission_set = OpenWithPermission::PermissionSet.find_by(key: row['permission_set_key'])
+          if permission_set.nil?
+            batch_processing_event("Skipping row [#{index + 2}]. Process failed. Permission Set missing or nonexistent.", 'Skipped Row')
+            next
+          elsif user.has_role?(:administrator, permission_set) || user.has_role?(:sysadmin)
+            parent_object.visibility = row['visibility']
+            parent_object.permission_set_id = permission_set.id
+          else
+            batch_processing_event("Skipping row [#{index + 2}] because user does not have edit permissions for this Permission Set: #{permission_set.key}", 'Permission Denied')
+            next
+          end
+        end
+
         parent_object.admin_set = admin_set
         # TODO: enable edit action when added to batch actions
       end
@@ -299,6 +300,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
       end
     end
   end
+  # rubocop:enable Layout/LineLength
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/PerceivedComplexity

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -241,6 +241,20 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         parent_object.digitization_funding_source = row['digitization_funding_source']
         parent_object.rights_statement = row['rights_statement']
 
+        if row['visibility'] == 'Open with Permission' || parent_object&.authoritative_json&.[]('itemPermission') == 'Open with Permission'
+          permission_set = OpenWithPermission::PermissionSet.find_by(key: row['permission_set_key'])
+          if permission_set.nil?
+            batch_processing_event("Skipping row [#{index + 2}]. Process failed. Permission Set missing or nonexistent.", 'Skipped Row')
+            next
+          elsif user.has_role?(:administrator, permission_set) || user.has_role?(:sysadmin)
+            parent_object.visibility = row['visibility']
+            parent_object.permission_set_id = permission_set.id
+          else
+            batch_processing_event("Skipping row [#{index + 2}] because user does not have edit permissions for this Permission Set: #{permission_set.key}", 'Permission Denied')
+            next
+          end
+        end
+
         if ParentObject.viewing_directions.include?(row['viewing_direction'])
           parent_object.viewing_direction = row['viewing_direction']
         else
@@ -273,23 +287,6 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
         parent_object.parent_model = model
         setup_for_background_jobs(parent_object, metadata_source)
-        parent_object.default_fetch
-        parent_object.metadata_update = true
-
-        if row['visibility'] == 'Open with Permission' || parent_object&.authoritative_json&.[]('itemPermission') == 'Open with Permission'
-          permission_set = OpenWithPermission::PermissionSet.find_by(key: row['permission_set_key'])
-          if permission_set.nil?
-            batch_processing_event("Skipping row [#{index + 2}]. Process failed. Permission Set missing or nonexistent.", 'Skipped Row')
-            next
-          elsif user.has_role?(:administrator, permission_set) || user.has_role?(:sysadmin)
-            parent_object.visibility = row['visibility']
-            parent_object.permission_set_id = permission_set.id
-          else
-            batch_processing_event("Skipping row [#{index + 2}] because user does not have edit permissions for this Permission Set: #{permission_set.key}", 'Permission Denied')
-            next
-          end
-        end
-
         parent_object.admin_set = admin_set
         # TODO: enable edit action when added to batch actions
       end

--- a/spec/fixtures/csv/mini_owp_parent.csv
+++ b/spec/fixtures/csv/mini_owp_parent.csv
@@ -1,0 +1,2 @@
+oid,admin_set
+200000045,brbl

--- a/spec/fixtures/ladybird/200000045.json
+++ b/spec/fixtures/ladybird/200000045.json
@@ -1,0 +1,82 @@
+{
+  "jsonModelType": "ArchiveSpaceSolrRecord",
+  "source": "aspace",
+  "recordType": "archival_object",
+  "uri": "/aspace/repositories/11/archival_objects/200000045",
+  "identifier": "/aspace/repositories/11/archival_objects/200000045",
+  "localRecordNumber": "GEN MSS 257",
+  "callNumber": "GEN MSS 257",
+  "containerGrouping": "Box 3, folder 24",
+  "creator": [
+    "Lincoln, Abraham, 1809-1865"
+  ],
+  "title": [
+    "The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1"
+  ],
+  "date": [
+    "n.d."
+  ],
+  "language": [
+    "English"
+  ],
+  "languageCode": [
+    "eng"
+  ],
+  "description": [
+    "Gift, 1965"
+  ],
+  "rights": [
+    "The Abraham Lincoln Collection is the physical property of the Beinecke Rare Book and Manuscript Library, Yale University. Literary rights, including copyright, belong to the authors or their legal heirs and assigns. For further information, consult the appropriate curator.",
+    "The materials are open for research. \n\nBox 4 and broadside folder 28: Restricted fragile material.  Reference surrogates have been substituted in the main files.  For further information consult the appropriate curator."
+  ],
+  "orbisBibId": "4113177",
+  "orbisBarcode": "39002093768050",
+  "findingAid": [
+    "http://hdl.handle.net/10079/fa/beinecke.lincoln"
+  ],
+  "dateStructured": [
+
+  ],
+  "resourceType": "mixed materials digital object",
+  "provenanceUncontrolled": "Ongoing collection of documents acquired by gift and purchase from various sources. Type of accession (gift or purchase) and date of acquisition is noted in the box-and-folder list. For further information, consult the appropriate curator.",
+  "ancestorTitles": [
+    "Oversize",
+    "Abraham Lincoln collection (GEN MSS 257)",
+    "Beinecke Rare Book and Manuscript Library"
+  ],
+  "ancestorDisplayStrings": [
+    "Oversize, n.d.",
+    "Abraham Lincoln collection",
+    "Beinecke Rare Book and Manuscript Library"
+  ],
+  "ancestorIdentifiers": [
+    "/aspace/repositories/11/archival_objects/214637",
+    "/aspace/repositories/11/resources/640",
+    "/aspace/repositories/11"
+  ],
+  "repository": "Beinecke Rare Book and Manuscript Library",
+  "createdBeginDate": [
+
+  ],
+  "createdEndDate": [
+
+  ],
+  "archiveSpaceUri": "/repositories/11/archival_objects/214638",
+  "archivalSort": "00002.00000",
+  "dependentUris": [
+    "/aspace/repositories/11/top_containers/19359",
+    "/aspace/repositories/11/archival_objects/214638",
+    "/aspace/agents/people/87197",
+    "/aspace/repositories/11/archival_objects/214637",
+    "/aspace/repositories/11/resources/640",
+    "/aspace/repositories/11"
+  ],
+  "itemPermission": "Open with Permission",
+  "children": [
+
+  ],
+  "abstract": [
+    "Correspondence and writings by and about Abraham Lincoln, and a gold pen used by Lincoln. 4 ALS from Lincoln to Benjamin F. James, William M. Dickson, and to an unidentified recipient. Writings by Lincoln include an autograph praecipe issued by Lincoln for writ in his first law case, \"David Woolridge vs. Hawthorne\", and a fragment of a speech on slavery. Also present is a letter by Edwin Booth to Colonel A. Badeau concerning Lincoln's assassination by his brother, John Wilkes Booth, two days earlier; two volumes containing letters and writings by and about members of Lincoln's cabinet, including Andrew Johnson, Edwin M. Stanton, a letter to W. P. Fessenden regarding the attack on Petersburg, and Gideon Welles' autographed manuscript recollections on the formation of Lincoln's cabinet. Accompanied by the gold pen used by Lincoln to sign the Emancipation Proclamation, with accompanying documentation."
+  ],
+  "series": "Oversize"
+}

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SetupMetadataJob, type: :job, prep_admin_sets: true, prep_metadat
   context 'job fails' do
     it 'notifies on save failure' do
       allow(parent_object).to receive(:default_fetch).and_raise('boom!')
-      expect(parent_object).to receive(:processing_event).twice
+      expect(parent_object).to receive(:processing_event)
       expect { metadata_job.perform(parent_object, batch_process) }.to raise_error('boom!')
     end
 

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -593,7 +593,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.file = csv_upload
           batch_process.save
           expect(ParentObject.count).to eq(1)
-          expect(IngestEvent.count).to eq(11)
+          expect(IngestEvent.count).to eq(10)
         end
 
         it "creates a Parent Object with added fields digitization_note, digitization_funding_source, rights_statement, viewing_direction, and display_layout" do

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         batch_process.save
         batch_process.run_callbacks :create
       end.to change { batch_process.batch_connections.where(connectable_type: "ParentObject").count }.from(0).to(1)
-        .and change { IngestEvent.count }.from(0).to(11)
+        .and change { IngestEvent.count }.from(0).to(10)
       statuses = IngestEvent.all.map(&:status)
       expect(statuses).to include "processing-queued"
       expect(statuses).to include "metadata-fetched"
@@ -764,7 +764,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         parent_object.authoritative_metadata_source_id = aspace
         parent_object.child_object_count = 1
         parent_object.visibility = "Public"
-        expect(parent_object).to receive(:mc_post).exactly(2).time.and_return(OpenStruct.new(status: 200))
+        expect(parent_object).to receive(:mc_post).and_return(OpenStruct.new(status: 200))
         parent_object.aspace_json = { "title": ["test title"] }
         parent_object.save!
         parent_object.solr_index


### PR DESCRIPTION
# Summary
Parent objects intended to have a OwP visibility were defaulting to private because during the create process the logic only evaluated the CSV.  This PR changes the behavior so if a user submits a create/update parent job for an OwP object and doesn't have the Permission Set Key in the CSV or the user doesn't have an adequate (admin or sysadmin) role the parent object will still default private and child objects won't be created but the user will get a descriptive error in the batch process parent detail page explaining the failure of successful ingest.

# Related Ticket
[#2827](https://github.com/yalelibrary/YUL-DC/issues/2827)

# Screenshots

<details>

### Not in CSV Error
![image](https://github.com/yalelibrary/yul-dc-management/assets/36549923/6f64d4af-1f1f-487d-a985-a2e5d9366f44)

### Permission Error

![image](https://github.com/yalelibrary/yul-dc-management/assets/36549923/e042ecad-5019-441a-ba56-28214b11e953)

</details>