### PR TITLE
SPIKE: Changes how image mount is built for child objects

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -56,7 +56,7 @@ class ChildObject < ApplicationRecord
 
   def access_master_path
     return @access_master_path if @access_master_path
-    image_mount = ENV['ACCESS_MASTER_MOUNT'] || "data"
+    image_mount = Rails.env.test? ? ENV['ACCESS_MASTER_MOUNT'] : "data"
     pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
     directory = format("%02d", pairtree_path.first)
     @access_master_path = File.join(image_mount, directory, pairtree_path, "#{oid}.tif")
@@ -79,7 +79,7 @@ class ChildObject < ApplicationRecord
       processing_event("Original Copy of checksum does not match", 'failed')
       false
     end
-    image_mount = ENV['ACCESS_MASTER_MOUNT'] || "data"
+    image_mount = Rails.env.test? ? ENV['ACCESS_MASTER_MOUNT'] : "data"
     pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
     directory = format("%02d", pairtree_path.first)
     # Create path to access master if it doesn't exist

--- a/app/models/pyramidal_tiff.rb
+++ b/app/models/pyramidal_tiff.rb
@@ -46,12 +46,13 @@ class PyramidalTiff
     end
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def original_file_exists?
     if child_object.parent_object&.from_mets == true
       image_exists = File.exist?(mets_access_master_path) || File.exist?(mets_access_master_path.gsub('.tif', '.TIF').gsub('.jpg', '.JPG'))
       errors.add(:base, "Expected file #{mets_access_master_path} on mets not found.") unless image_exists
-    elsif ENV['ACCESS_MASTER_MOUNT'] == "s3"
+    elsif ENV['ACCESS_MASTER_MOUNT'] == "s3" && (Rails.env.test? || Rails.env.dev?)
       image_exists = S3Service.s3_exists?(remote_access_master_path)
       errors.add(:base, "Expected file #{remote_access_master_path} on S3 not found.") unless image_exists
     else
@@ -60,6 +61,7 @@ class PyramidalTiff
     end
     image_exists
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
 
   ##

--- a/app/models/pyramidal_tiff.rb
+++ b/app/models/pyramidal_tiff.rb
@@ -52,7 +52,7 @@ class PyramidalTiff
     if child_object.parent_object&.from_mets == true
       image_exists = File.exist?(mets_access_master_path) || File.exist?(mets_access_master_path.gsub('.tif', '.TIF').gsub('.jpg', '.JPG'))
       errors.add(:base, "Expected file #{mets_access_master_path} on mets not found.") unless image_exists
-    elsif ENV['ACCESS_MASTER_MOUNT'] == "s3" && (Rails.env.test? || Rails.env.dev?)
+    elsif ENV['ACCESS_MASTER_MOUNT'] == "s3" && Rails.env.test?
       image_exists = S3Service.s3_exists?(remote_access_master_path)
       errors.add(:base, "Expected file #{remote_access_master_path} on S3 not found.") unless image_exists
     else


### PR DESCRIPTION
# Summary
Spike PR to debug 'original file missing' issue.

# Related Ticket
[#2824](https://github.com/yalelibrary/YUL-DC/issues/2824)