### PR TITLE
Enables Owp objects to be ingested with Preservica

### DIFF
--- a/app/services/csv_row_parent_service.rb
+++ b/app/services/csv_row_parent_service.rb
@@ -33,7 +33,7 @@ class CsvRowParentService
   end
 
   row_accessor :aspace_uri, :bib, :holding, :item, :barcode, :oid, :admin_set,
-               :preservica_uri, :visibility, :digital_object_source,
+               :preservica_uri, :visibility, :digital_object_source, :permission_set,
                :authoritative_metadata_source_id, :preservica_representation_type, :extent_of_digitization
 
   def parent_object
@@ -74,9 +74,7 @@ class CsvRowParentService
   end
 
   def visibility
-    visibilities = ['Private', 'Public', 'Redirect', 'Yale Community Only']
-
-    return row['visibility'] if visibilities.include?(row['visibility'])
+    return row['visibility'] if ParentObject.visibilities.include?(row['visibility'])
 
     raise BatchProcessingError.new("Skipping row [#{index + 2}] with unknown visibility: #{row['visibility']}", 'Skipped Row')
   end
@@ -88,9 +86,7 @@ class CsvRowParentService
 
   # rubocop:disable Layout/LineLength
   def extent_of_digitization
-    valid_extents = [nil, "Completely digitized", "Partially digitized"]
-
-    return row['extent_of_digitization'] if valid_extents.include?(row['extent_of_digitization'])
+    return row['extent_of_digitization'] if ParentObject.extent_of_digitizations.include?(row['extent_of_digitization'])
 
     raise BatchProcessingError.new("Skipping row [#{index + 2}] with unknown extent of digitization: #{row['extent_of_digitization']}. For field Extent of Digitization please use: Completely digitizied, Partially digitizied, or leave column empty", 'Skipped Row')
   end
@@ -111,6 +107,22 @@ class CsvRowParentService
     end
 
     admin_set
+  end
+
+  def permission_set
+    permission_sets_hash = {}
+    permission_set_key = row['permission_set_key']
+    permission_sets_hash[permission_set_key] ||= OpenWithPermission::PermissionSet.find_by(key: permission_set_key)
+    permission_set = permission_sets_hash[permission_set_key]
+
+    if row['visibility'] == 'Open with Permission'
+      raise BatchProcessingError.new("Skipping row [#{index + 2}] with unknown Permission Set with Key: [#{permission_set_key}] for parent: #{oid}", 'Skipped Row') if permission_set.nil?
+      raise BatchProcessingError.new("Skipping row [#{index + 2}] because #{user.uid} does not have permission to update objects in Permission Set: #{permission_set&.label}", 'Permission Denied') unless current_ability.can?(:update, permission_set) && permission_set.present?
+    else
+      permission_set = nil
+    end
+
+    permission_set
   end
   # rubocop:enable Layout/LineLength
 

--- a/spec/fixtures/csv/preservica/preservica_owp_parent_no_permission_set.csv
+++ b/spec/fixtures/csv/preservica/preservica_owp_parent_no_permission_set.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,permission_set_key,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization
+,sml,aspace,/repositories/11/archival_objects/200000000,36,holding,item,barcode,Open with Permission,,Preservica,/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5,Preservation,Partially digitized

--- a/spec/fixtures/csv/preservica/preservica_owp_parent_with_permission_set.csv
+++ b/spec/fixtures/csv/preservica/preservica_owp_parent_with_permission_set.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,permission_set_key,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization
+,sml,aspace,/repositories/11/archival_objects/200000000,36,holding,item,barcode,Open with Permission,psKey,Preservica,/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5,Preservation,Partially digitized

--- a/spec/models/preservica/preservica_owp_import_spec.rb
+++ b/spec/models/preservica/preservica_owp_import_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  subject(:batch_process) { BatchProcess.new }
+  let(:admin_set) { AdminSet.find_by(key: 'sml') }
+  let(:user) { FactoryBot.create(:user, uid: "mk2529") }
+  let(:permission_set) { FactoryBot.create(:permission_set, key: 'psKey') }
+  let(:preservica_owp_parent_with_children) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_owp_parent_with_permission_set.csv")) }
+
+  around do |example|
+    preservica_host = ENV['PRESERVICA_HOST']
+    preservica_creds = ENV['PRESERVICA_CREDENTIALS']
+    ENV['PRESERVICA_HOST'] = "testpreservica"
+    ENV['PRESERVICA_CREDENTIALS'] = '{"sml": {"username":"xxxxx", "password":"xxxxx"}}'
+    access_host = ENV['ACCESS_MASTER_MOUNT']
+    ENV['ACCESS_MASTER_MOUNT'] = File.join("spec", "fixtures", "images", "access_masters")
+    perform_enqueued_jobs do
+      example.run
+    end
+    ENV['PRESERVICA_HOST'] = preservica_host
+    ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
+    ENV['ACCESS_MASTER_MOUNT'] = access_host
+  end
+
+  before do
+    user.add_role(:editor, admin_set)
+    user.add_role(:administrator, permission_set)
+    login_as(:user)
+    batch_process.user_id = user.id
+    stub_pdfs
+    stub_preservica_aspace_single
+    stub_preservica_login
+    fixtures = %w[preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5/children
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Access
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3r/representations/Preservation
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Access
+                  preservica/api/entity/information-objects/1e42a2bb-8953-41b6-bcc3-1a19c86a5e3d/representations/Preservation
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Access
+                  preservica/api/entity/information-objects/f44ba97e-af2b-498e-b118-ed1247822f44/representations/Preservation
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1
+                  preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1]
+
+    fixtures.each do |fixture|
+      stub_request(:get, "https://test#{fixture}").to_return(
+        status: 200, body: File.open(File.join(fixture_path, "#{fixture}.xml"))
+      )
+    end
+    stub_preservica_tifs_set_of_three
+  end
+
+  it 'can create child objects' do
+    File.delete("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif") if File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")
+    File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
+    File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
+
+    allow(S3Service).to receive(:s3_exists?).and_return(false)
+    expect(File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")).to eq false
+    expect(File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")).to eq false
+    expect(File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")).to eq false
+    expect do
+      batch_process.file = preservica_owp_parent_with_children
+      batch_process.save
+    end.to change { ChildObject.count }.from(0).to(3)
+    po_first = ParentObject.first
+    co_first = ChildObject.first
+    expect(co_first.oid).to eq 200_000_001
+    expect(co_first.parent_object_oid).to eq 200_000_000
+    expect(co_first.order).to eq 1
+    co_last = ChildObject.last
+    expect(co_last.order).to eq 3
+    expect(po_first.last_preservica_update).not_to eq nil
+    expect(po_first.visibility).to eq "Open with Permission"
+    expect(co_first.preservica_content_object_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486"
+    expect(co_first.preservica_generation_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1"
+    expect(co_first.preservica_bitstream_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1"
+    expect(co_first.sha512_checksum).to eq "1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7"
+    expect(co_first.caption).to eq "mss_29_s03_b092_f0019.TIF"
+    expect(File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")).to eq true
+    expect(File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")).to eq true
+    expect(File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")).to eq true
+    expect(co_first.ptiff_conversion_at.present?).to be_truthy
+    File.delete("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif") if File.exist?("spec/fixtures/images/access_masters/00/01/20/00/00/00/200000001.tif")
+    File.delete("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif") if File.exist?("spec/fixtures/images/access_masters/00/02/20/00/00/00/200000002.tif")
+    File.delete("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif") if File.exist?("spec/fixtures/images/access_masters/00/03/20/00/00/00/200000003.tif")
+  end
+end

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   subject(:batch_process) { BatchProcess.new }
   let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl') }
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:permission_set) { FactoryBot.create(:permission_set, key: 'psKey') }
   let(:preservica_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent.csv")) }
   let(:preservica_parent_no_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent_no_source.csv")) }
   let(:preservica_parent_no_admin_set) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent_no_admin_set.csv")) }
+  let(:preservica_parent_no_permission_set) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_owp_parent_no_permission_set.csv")) }
+  let(:preservica_parent_with_permission_set) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_owp_parent_with_permission_set.csv")) }
 
   around do |example|
     preservica_host = ENV['PRESERVICA_HOST']
@@ -26,6 +29,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   end
 
   before do
+    permission_set
     user.add_role(:editor, admin_set)
     login_as(:user)
     batch_process.user_id = user.id
@@ -60,10 +64,9 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     stub_preservica_tifs_set_of_three
   end
 
+  # rubocop:disable RSpec/AnyInstance
   it 'can send an error when Preservica credentials are not set' do
-    # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    # rubocop:enable RSpec/AnyInstance
     expect do
       batch_process.file = preservica_parent
       batch_process.save
@@ -73,9 +76,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   end
 
   it 'can send an error when no metadata source is set' do
-    # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    # rubocop:enable RSpec/AnyInstance
     expect do
       batch_process.file = preservica_parent_no_source
       batch_process.save
@@ -85,9 +86,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   end
 
   it 'can send an error when no admin set is set' do
-    # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    # rubocop:enable RSpec/AnyInstance
     expect do
       batch_process.file = preservica_parent_no_admin_set
       batch_process.save
@@ -95,4 +94,25 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown admin set [] for parent: 200000000")
     end.not_to change { ParentObject.count }
   end
+
+  it 'can send an error when no permission set is set' do
+    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
+    expect do
+      batch_process.file = preservica_parent_no_permission_set
+      batch_process.save
+      expect(batch_process.batch_ingest_events.count).to eq(1)
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown Permission Set with Key: [] for parent: 200000000")
+    end.not_to change { ParentObject.count }
+  end
+
+  it 'can send an error when user does not have admin role on permission set' do
+    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
+    expect do
+      batch_process.file = preservica_parent_with_permission_set
+      batch_process.save
+      expect(batch_process.batch_ingest_events.count).to eq(1)
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] because mk2525 does not have permission to update objects in Permission Set: Permission Label")
+    end.not_to change { ParentObject.count }
+  end
+  # rubocop:enable RSpec/AnyInstance
 end


### PR DESCRIPTION
# Summary
No permission set information was being saved to objects with Open with Permission visibility.  This PR enables parent objects to be created when ingesting with Preservica.

# Related Ticket
[#2827](https://github.com/yalelibrary/YUL-DC/issues/2827)