### PR TITLE
Send email to user on approved/denied requests

### DIFF
--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -30,6 +30,7 @@ class PermissionRequestsController < ApplicationController
         if @permission_request.request_status != old_request_status
           @permission_request.approver = current_user.uid
           @permission_request.save!
+          send_user_email(@permission_request)
         end
         format.html { redirect_to permission_request_path(@permission_request), notice: 'Changes saved successfully.' }
         format.json { render :show, status: :ok, location: @permission_request }
@@ -62,9 +63,29 @@ class PermissionRequestsController < ApplicationController
       permission_set_label: @permission_request.permission_set.label,
       admin_set_label: @permission_request.parent_object.admin_set.label,
       parent_object_oid: @permission_request.parent_object.oid,
-      new_visibility: permission_request_params[:new_visibility]
+      new_visibility: @permission_request.new_visibility
     }
     AccessChangeRequestMailer.with(access_change_request: access_change_request).access_change_request_email.deliver_now
+  end
+
+  def send_user_email(permission_request)
+    user_approved_notification = {
+      request_user_name: @permission_request.permission_request_user.name,
+      request_user_email: @permission_request.permission_request_user.email,
+      expiration_date: @permission_request.access_until,
+      parent_object_oid: @permission_request.parent_object.oid,
+      parent_object_title: @permission_request.parent_object&.authoritative_json&.[]('title')&.first
+    }
+    user_denied_notification = {
+      request_user_name: @permission_request.permission_request_user.name,
+      request_user_email: @permission_request.permission_request_user.email,
+      parent_object_title: @permission_request.parent_object&.authoritative_json&.[]('title')&.first,
+    }
+    if permission_request.request_status == "Approved"
+      UserNotificationApprovedMailer.with(user_notification: user_approved_notification).user_notification_approved_email.deliver_now
+    elsif permission_request.request_status == "Denied"
+      UserNotificationDeniedMailer.with(user_notification: user_denied_notification).user_notification_denied_email.deliver_now
+    end
   end
 
   private

--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -68,6 +68,10 @@ class PermissionRequestsController < ApplicationController
     AccessChangeRequestMailer.with(access_change_request: access_change_request).access_change_request_email.deliver_now
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
   def send_user_email(permission_request)
     user_approved_notification = {
       request_user_name: @permission_request.permission_request_user.name,
@@ -81,7 +85,7 @@ class PermissionRequestsController < ApplicationController
       request_user_name: @permission_request.permission_request_user.name,
       permission_set_label: @permission_request.permission_set.label,
       request_user_email: @permission_request.permission_request_user.email,
-      parent_object_title: @permission_request.parent_object&.authoritative_json&.[]('title')&.first,
+      parent_object_title: @permission_request.parent_object&.authoritative_json&.[]('title')&.first
     }
     if permission_request.request_status == "Approved"
       UserNotificationApprovedMailer.with(user_notification: user_approved_notification).user_notification_approved_email.deliver_now
@@ -89,6 +93,10 @@ class PermissionRequestsController < ApplicationController
       UserNotificationDeniedMailer.with(user_notification: user_denied_notification).user_notification_denied_email.deliver_now
     end
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 

--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -71,6 +71,7 @@ class PermissionRequestsController < ApplicationController
   def send_user_email(permission_request)
     user_approved_notification = {
       request_user_name: @permission_request.permission_request_user.name,
+      permission_set_label: @permission_request.permission_set.label,
       request_user_email: @permission_request.permission_request_user.email,
       expiration_date: @permission_request.access_until,
       parent_object_oid: @permission_request.parent_object.oid,
@@ -78,6 +79,7 @@ class PermissionRequestsController < ApplicationController
     }
     user_denied_notification = {
       request_user_name: @permission_request.permission_request_user.name,
+      permission_set_label: @permission_request.permission_set.label,
       request_user_email: @permission_request.permission_request_user.email,
       parent_object_title: @permission_request.parent_object&.authoritative_json&.[]('title')&.first,
     }

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: "do_not_reply@library.yale.edu"
   layout 'mailer'
 end

--- a/app/mailers/user_notification_approved_mailer.rb
+++ b/app/mailers/user_notification_approved_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UserNotificationApprovedMailer < ApplicationMailer
-
   def user_notification_approved_email
     @user_notification = params[:user_notification]
     if @user_notification[:permission_set_label] == "kiss"

--- a/app/mailers/user_notification_approved_mailer.rb
+++ b/app/mailers/user_notification_approved_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UserNotificationApprovedMailer < ApplicationMailer
-  default from: "do_not_reply@library.yale.edu"
 
   def user_notification_approved_email
     @user_notification = params[:user_notification]

--- a/app/mailers/user_notification_approved_mailer.rb
+++ b/app/mailers/user_notification_approved_mailer.rb
@@ -5,10 +5,9 @@ class UserNotificationApprovedMailer < ApplicationMailer
     @user_notification = params[:user_notification]
     if @user_notification[:permission_set_label] == "kiss"
       mail(from: "kissingerpapers@gmail.com")
-      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been approved")
     else
       mail(from: "do_not_reply@library.yale.edu")
-      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been approved")
     end
+    mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been approved")
   end
 end

--- a/app/mailers/user_notification_approved_mailer.rb
+++ b/app/mailers/user_notification_approved_mailer.rb
@@ -5,6 +5,12 @@ class UserNotificationApprovedMailer < ApplicationMailer
 
   def user_notification_approved_email
     @user_notification = params[:user_notification]
-    mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been approved")
+    if @user_notification[:permission_set_label] == "kiss"
+      mail(from: "kissingerpapers@gmail.com")
+      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been approved")
+    else
+      mail(from: "do_not_reply@library.yale.edu")
+      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been approved")
+    end
   end
 end

--- a/app/mailers/user_notification_approved_mailer.rb
+++ b/app/mailers/user_notification_approved_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UserNotificationApprovedMailer < ApplicationMailer
+  default from: "do_not_reply@library.yale.edu"
+
+  def user_notification_approved_email
+    @user_notification = params[:user_notification]
+    mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been approved")
+  end
+end

--- a/app/mailers/user_notification_denied_mailer.rb
+++ b/app/mailers/user_notification_denied_mailer.rb
@@ -5,10 +5,9 @@ class UserNotificationDeniedMailer < ApplicationMailer
     @user_notification = params[:user_notification]
     if @user_notification[:permission_set_label] == "kiss"
       mail(from: "kissingerpapers@gmail.com")
-      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been denied")
     else
       mail(from: "do_not_reply@library.yale.edu")
-      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been denied")
     end
+    mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been denied")
   end
 end

--- a/app/mailers/user_notification_denied_mailer.rb
+++ b/app/mailers/user_notification_denied_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UserNotificationDeniedMailer < ApplicationMailer
+  default from: "do_not_reply@library.yale.edu"
+
+  def user_notification_denied_email
+    @user_notification = params[:user_notification]
+    mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been denied")
+  end
+end

--- a/app/mailers/user_notification_denied_mailer.rb
+++ b/app/mailers/user_notification_denied_mailer.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 class UserNotificationDeniedMailer < ApplicationMailer
-  default from: "do_not_reply@library.yale.edu"
+  # default from: "do_not_reply@library.yale.edu"
 
   def user_notification_denied_email
     @user_notification = params[:user_notification]
-    mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been denied")
+    if @user_notification[:permission_set_label] == "kiss"
+      mail(from: "kissingerpapers@gmail.com")
+      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been denied")
+    else
+      mail(from: "do_not_reply@library.yale.edu")
+      mail(to: @user_notification[:request_user_email], subject: "Your request to view #{@user_notification[:parent_object_title]} has been denied")
+    end
   end
 end

--- a/app/mailers/user_notification_denied_mailer.rb
+++ b/app/mailers/user_notification_denied_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UserNotificationDeniedMailer < ApplicationMailer
-  # default from: "do_not_reply@library.yale.edu"
 
   def user_notification_denied_email
     @user_notification = params[:user_notification]

--- a/app/mailers/user_notification_denied_mailer.rb
+++ b/app/mailers/user_notification_denied_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UserNotificationDeniedMailer < ApplicationMailer
-
   def user_notification_denied_email
     @user_notification = params[:user_notification]
     if @user_notification[:permission_set_label] == "kiss"

--- a/app/views/access_change_request_mailer/access_change_request_email.html.erb
+++ b/app/views/access_change_request_mailer/access_change_request_email.html.erb
@@ -8,5 +8,5 @@
 </p>
 <p>Have a great day!</p>
 <small>
-  <pre>This is an automated message.  You are receiving this message because DSC is configured to use your email address.</pre>
+  <pre>This is an automated message.  You are receiving this message because DCS is configured to use your email address.</pre>
 </small>

--- a/app/views/problem_report_mailer/problem_report_email.html.erb
+++ b/app/views/problem_report_mailer/problem_report_email.html.erb
@@ -12,5 +12,5 @@
 </p>
 <p>Have a great day!</p>
 <small>
-  <pre>This is an automated message.  You are receiving this message because DSC is configured to use your email address.</pre>
+  <pre>This is an automated message.  You are receiving this message because DCS is configured to use your email address.</pre>
 </small>

--- a/app/views/user_notification_approved_mailer/user_notification_approved_email.html.erb
+++ b/app/views/user_notification_approved_mailer/user_notification_approved_email.html.erb
@@ -1,0 +1,15 @@
+<p>
+  Dear <%= @user_notification[:request_user_name] %>,
+</p>
+<p>
+  Your request to view the object <%= @user_notification[:parent_object_title] %> in Yale's Digital Collections System has been approved. Your access will expire on <%= @user_notification[:expiration_date] %>.
+</p>
+<p>
+  You can access the object directly at the following link:
+</p>
+<p>
+  <%= link_to("#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}", "#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}") %>
+</p>
+<small>
+  <pre>This is an automated message sent by Yale’s Digital Collections System.</pre>
+</small>

--- a/app/views/user_notification_approved_mailer/user_notification_approved_email.text.erb
+++ b/app/views/user_notification_approved_mailer/user_notification_approved_email.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @user_notification[:request_user_name] %>,
+
+Your request to view the object <%= @user_notification[:parent_object_title] %> in Yale's Digital Collections System has been approved. Your access will expire on <%= @user_notification[:expiration_date] %>.
+
+You can access the object directly at the following link:
+
+<%= link_to("#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}", "#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}") %>
+
+This is an automated message from an address that is unable to receive incoming messages. Please do not reply to this email.

--- a/app/views/user_notification_denied_mailer/user_notification_denied_email.html.erb
+++ b/app/views/user_notification_denied_mailer/user_notification_denied_email.html.erb
@@ -1,0 +1,9 @@
+<p>
+  Dear <%= @user_notification[:request_user_name] %>,
+</p>
+<p>
+  Your request to view the object <%= @user_notification[:parent_object_title] %> in Yale's Digital Collections System has been denied.
+</p>
+<small>
+  <pre>This is an automated message sent by Yale’s Digital Collections System.</pre>
+</small>

--- a/app/views/user_notification_denied_mailer/user_notification_denied_email.text.erb
+++ b/app/views/user_notification_denied_mailer/user_notification_denied_email.text.erb
@@ -1,0 +1,5 @@
+Dear <%= @user_notification[:request_user_name] %>,
+
+Your request to view the object <%= @user_notification[:parent_object_oid] %> in Yale's Digital Collections System has been denied.
+
+This is an automated message from an address that is unable to receive incoming messages. Please do not reply to this email.

--- a/spec/mailers/user_notification_approved_mailer_spec.rb
+++ b/spec/mailers/user_notification_approved_mailer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserNotificationApprovedMailer, type: :mailer, prep_admin_sets: true, prep_metadata_sources: true do
+  describe 'user_notification_approved_email' do
+    let(:admin_set) { AdminSet.first }
+    let(:metadata_source) { MetadataSource.first }
+    let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id) }
+    let(:permission_set) { FactoryBot.create(:permission_set) }
+    let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "name 1", netid: "netid", email: "email@example.com") }
+    let(:permission_request) { FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message', permission_request_user: request_user, access_until: "2030-06-10 00:00:00") }
+    let(:user_approved_notification) do
+      {
+        request_user_name: permission_request.permission_request_user.name,
+        permission_set_label: permission_set.label,
+        request_user_email: permission_request.permission_request_user.email,
+        expiration_date: permission_request.access_until,
+        parent_object_title: "Title",
+        parent_object_oid: parent_object.oid
+      }
+    end
+    let(:mail) { described_class.with(user_notification: user_approved_notification).user_notification_approved_email.deliver_now }
+
+    it 'renders the expected fields' do
+      expect(mail.subject).to eq 'Your request to view Title has been approved'
+      expect(mail.to).to eq ["email@example.com"]
+      expect(mail.from).to eq ['do_not_reply@library.yale.edu']
+      expect(mail.body.encoded).to include(permission_request.permission_request_user.name)
+      expect(mail.body.encoded).to include("2030-06-10 00:00:00")
+    end
+  end
+end

--- a/spec/mailers/user_notification_approved_mailer_spec.rb
+++ b/spec/mailers/user_notification_approved_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UserNotificationApprovedMailer, type: :mailer, prep_admin_sets: t
     let(:admin_set) { AdminSet.first }
     let(:metadata_source) { MetadataSource.first }
     let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id) }
-    let(:permission_set) { FactoryBot.create(:permission_set) }
+    let(:permission_set) { FactoryBot.create(:permission_set, label: "PS1") }
     let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "name 1", netid: "netid", email: "email@example.com") }
     let(:permission_request) { FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message', permission_request_user: request_user, access_until: "2030-06-10 00:00:00") }
     let(:user_approved_notification) do
@@ -20,7 +20,18 @@ RSpec.describe UserNotificationApprovedMailer, type: :mailer, prep_admin_sets: t
         parent_object_oid: parent_object.oid
       }
     end
+    let(:user_approved_notification_kissinger) do
+      {
+        request_user_name: permission_request.permission_request_user.name,
+        permission_set_label: "kiss",
+        request_user_email: permission_request.permission_request_user.email,
+        expiration_date: permission_request.access_until,
+        parent_object_title: "Title",
+        parent_object_oid: parent_object.oid
+      }
+    end
     let(:mail) { described_class.with(user_notification: user_approved_notification).user_notification_approved_email.deliver_now }
+    let(:kissinger_mail) { described_class.with(user_notification: user_approved_notification_kissinger).user_notification_approved_email.deliver_now }
 
     it 'renders the expected fields' do
       expect(mail.subject).to eq 'Your request to view Title has been approved'
@@ -28,6 +39,14 @@ RSpec.describe UserNotificationApprovedMailer, type: :mailer, prep_admin_sets: t
       expect(mail.from).to eq ['do_not_reply@library.yale.edu']
       expect(mail.body.encoded).to include(permission_request.permission_request_user.name)
       expect(mail.body.encoded).to include("2030-06-10 00:00:00")
+    end
+
+    it 'sends email from correct address for a kissinger permission set' do
+      expect(kissinger_mail.subject).to eq 'Your request to view Title has been approved'
+      expect(kissinger_mail.to).to eq ["email@example.com"]
+      expect(kissinger_mail.from).to eq ['kissingerpapers@gmail.com']
+      expect(kissinger_mail.body.encoded).to include(permission_request.permission_request_user.name)
+      expect(kissinger_mail.body.encoded).to include("2030-06-10 00:00:00")
     end
   end
 end

--- a/spec/mailers/user_notification_approved_mailer_spec.rb
+++ b/spec/mailers/user_notification_approved_mailer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe UserNotificationApprovedMailer, type: :mailer, prep_admin_sets: t
     let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id) }
     let(:permission_set) { FactoryBot.create(:permission_set, label: "PS1") }
     let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "name 1", netid: "netid", email: "email@example.com") }
-    let(:permission_request) { FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message', permission_request_user: request_user, access_until: "2030-06-10 00:00:00") }
+    let(:permission_request) do
+      FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message', permission_request_user: request_user,
+                                             access_until: "2030-06-10 00:00:00")
+    end
     let(:user_approved_notification) do
       {
         request_user_name: permission_request.permission_request_user.name,

--- a/spec/mailers/user_notification_denied_mailer_spec.rb
+++ b/spec/mailers/user_notification_denied_mailer_spec.rb
@@ -19,13 +19,30 @@ RSpec.describe UserNotificationDeniedMailer, type: :mailer, prep_admin_sets: tru
         parent_object_oid: parent_object.oid
       }
     end
+    let(:user_denied_notification_kissinger) do
+      {
+        request_user_name: permission_request.permission_request_user.name,
+        permission_set_label: "kiss",
+        request_user_email: permission_request.permission_request_user.email,
+        parent_object_title: "Title",
+        parent_object_oid: parent_object.oid
+      }
+    end
     let(:mail) { described_class.with(user_notification: user_denied_notification).user_notification_denied_email.deliver_now }
+    let(:kissinger_mail) { described_class.with(user_notification: user_denied_notification_kissinger).user_notification_denied_email.deliver_now }
 
     it 'renders the expected fields' do
       expect(mail.subject).to eq 'Your request to view Title has been denied'
       expect(mail.to).to eq ["email@example.com"]
       expect(mail.from).to eq ['do_not_reply@library.yale.edu']
       expect(mail.body.encoded).to include(permission_request.permission_request_user.name)
+    end
+
+    it 'sends email from correct address for a kissinger permission set' do
+      expect(kissinger_mail.subject).to eq 'Your request to view Title has been denied'
+      expect(kissinger_mail.to).to eq ["email@example.com"]
+      expect(kissinger_mail.from).to eq ['kissingerpapers@gmail.com']
+      expect(kissinger_mail.body.encoded).to include(permission_request.permission_request_user.name)
     end
   end
 end

--- a/spec/mailers/user_notification_denied_mailer_spec.rb
+++ b/spec/mailers/user_notification_denied_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserNotificationDeniedMailer, type: :mailer, prep_admin_sets: true, prep_metadata_sources: true do
+  describe 'user_notification_denied_email' do
+    let(:admin_set) { AdminSet.first }
+    let(:metadata_source) { MetadataSource.first }
+    let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id) }
+    let(:permission_set) { FactoryBot.create(:permission_set) }
+    let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "name 1", netid: "netid", email: "email@example.com") }
+    let(:permission_request) { FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message', permission_request_user: request_user) }
+    let(:user_denied_notification) do
+      {
+        request_user_name: permission_request.permission_request_user.name,
+        permission_set_label: permission_set.label,
+        request_user_email: permission_request.permission_request_user.email,
+        parent_object_title: "Title",
+        parent_object_oid: parent_object.oid
+      }
+    end
+    let(:mail) { described_class.with(user_notification: user_denied_notification).user_notification_denied_email.deliver_now }
+
+    it 'renders the expected fields' do
+      expect(mail.subject).to eq 'Your request to view Title has been denied'
+      expect(mail.to).to eq ["email@example.com"]
+      expect(mail.from).to eq ['do_not_reply@library.yale.edu']
+      expect(mail.body.encoded).to include(permission_request.permission_request_user.name)
+    end
+  end
+end

--- a/spec/mailers/user_notification_denied_mailer_spec.rb
+++ b/spec/mailers/user_notification_denied_mailer_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe UserNotificationDeniedMailer, type: :mailer, prep_admin_sets: tru
     let(:parent_object) { FactoryBot.create(:parent_object, authoritative_metadata_source_id: metadata_source.id, admin_set_id: admin_set.id) }
     let(:permission_set) { FactoryBot.create(:permission_set) }
     let(:request_user) { FactoryBot.create(:permission_request_user, sub: "sub 1", name: "name 1", netid: "netid", email: "email@example.com") }
-    let(:permission_request) { FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message', permission_request_user: request_user) }
+    let(:permission_request) do
+      FactoryBot.create(:permission_request, permission_set_id: permission_set.id, parent_object_id: parent_object.oid, user_note: 'message', permission_request_user: request_user)
+    end
     let(:user_denied_notification) do
       {
         request_user_name: permission_request.permission_request_user.name,

--- a/spec/requests/permission_requests_spec.rb
+++ b/spec/requests/permission_requests_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: tru
           } }
         expect do
           patch "/permission_requests/#{updatable_permission_request.id}", params: JSON.pretty_generate(valid_status_and_access_update_params), headers: headers
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end.to change { ActionMailer::Base.deliveries.count }.by(2)
         expect(response).to have_http_status(302)
         updatable_permission_request.reload
         expect(updatable_permission_request.request_status).to eq "Approved"


### PR DESCRIPTION
## Summary  
User will receive an email based on approved/denied requests. Requests for kissinger sets will send from 'kissingerpapers@gmail.com' and all other sets will send from 'do_not_reply@library.yale.edu'.