### PR TITLE
Set worker queues

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   config.good_job.retry_on_unhandled_error = false
   config.good_job.on_thread_error = ->(exception) { Raven.capture_exception(exception) }
   config.good_job.execution_mode = :external
-  config.good_job.queues = ENV['WORKER QUEUES']
+  config.good_job.queues = ENV['WORKER_QUEUES']
   config.good_job.shutdown_timeout = 60 # seconds
   config.good_job.poll_interval = 5
   config.good_job.enable_cron = true

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   config.good_job.retry_on_unhandled_error = false
   config.good_job.on_thread_error = ->(exception) { Raven.capture_exception(exception) }
   config.good_job.execution_mode = :external
-  # config.good_job.queues = '*'
+  config.good_job.queues = ENV['WORKER QUEUES']
   config.good_job.shutdown_timeout = 60 # seconds
   config.good_job.poll_interval = 5
   config.good_job.enable_cron = true


### PR DESCRIPTION
# Summary
Changes good job configuration. Sets the worker queues via env vars from camerata - see deploy scripts for worker and intensive worker. 

# Related Ticket
[#2824](https://github.com/yalelibrary/YUL-DC/issues/2824)