### PR TITLE
strips whitespace from terms

### DIFF
--- a/app/models/open_with_permission/permission_set_term.rb
+++ b/app/models/open_with_permission/permission_set_term.rb
@@ -8,6 +8,13 @@ class OpenWithPermission::PermissionSetTerm < ApplicationRecord
 
   attr_readonly :title, :body
 
+  before_validation :strip_whitespace
+
+  def strip_whitespace
+    self.title = self.title.strip unless self.title.nil?
+    self.body = self.body.strip unless self.body.nil?
+  end
+
   def activate_by!(user)
     raise "Unable to activate previously activated permission set" unless activated_at.nil?
     raise "User cannot be nil" unless user

--- a/app/models/open_with_permission/permission_set_term.rb
+++ b/app/models/open_with_permission/permission_set_term.rb
@@ -11,8 +11,8 @@ class OpenWithPermission::PermissionSetTerm < ApplicationRecord
   before_validation :strip_whitespace
 
   def strip_whitespace
-    self.title = self.title.strip unless self.title.nil?
-    self.body = self.body.strip unless self.body.nil?
+    self.title = title.strip unless title.nil?
+    self.body = body.strip unless body.nil?
   end
 
   def activate_by!(user)


### PR DESCRIPTION
## Summary  
Empty whitespaces in terms body and title will now be stripped prior to saving.