### PR TITLE
adds guard for checking request_status

### DIFF
--- a/app/jobs/update_permission_requests_job.rb
+++ b/app/jobs/update_permission_requests_job.rb
@@ -6,6 +6,7 @@ class UpdatePermissionRequestsJob < ApplicationJob
   def perform
     permission_requests = OpenWithPermission::PermissionRequest.all
     permission_requests.each do |pr|
+      return if pr.access_until.nil? || pr.request_status != "Approved"
       if pr.access_until < Time.zone.now
         pr.request_status = "Expired"
         pr.save!

--- a/app/jobs/update_permission_requests_job.rb
+++ b/app/jobs/update_permission_requests_job.rb
@@ -6,7 +6,7 @@ class UpdatePermissionRequestsJob < ApplicationJob
   def perform
     permission_requests = OpenWithPermission::PermissionRequest.all
     permission_requests.each do |pr|
-      return if pr.access_until.nil? || pr.request_status != "Approved"
+      next if pr.access_until.nil? || pr.request_status != "Approved"
       if pr.access_until < Time.zone.now
         pr.request_status = "Expired"
         pr.save!


### PR DESCRIPTION
## Summary  
Previous update jobs were failing for objects that did not have a request_status. This PR fix will only compare access time if the access_until time is present and the object is is an "approved" state. 