### PR TITLE
adds validation on access_until

### DIFF
--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -35,7 +35,7 @@ class PermissionRequestsController < ApplicationController
         format.html { redirect_to permission_request_path(@permission_request), notice: 'Changes saved successfully.' }
         format.json { render :show, status: :ok, location: @permission_request }
       else
-        format.html { render :edit }
+        format.html { render :show }
         format.json { render json: @permission_request.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/open_with_permission/permission_request.rb
+++ b/app/models/open_with_permission/permission_request.rb
@@ -6,7 +6,7 @@ class OpenWithPermission::PermissionRequest < ApplicationRecord
   belongs_to :parent_object
   has_one :user
   before_validation :sanitize_user_input, on: [:create]
-  validates_presence_of :access_until, if: lambda { request_status == "Approved" }
+  validates :access_until, presence: { if: -> { request_status == "Approved" } }
 
   before_save do
     self.approved_or_denied_at = Time.zone.now if request_status_changed?

--- a/app/models/open_with_permission/permission_request.rb
+++ b/app/models/open_with_permission/permission_request.rb
@@ -6,6 +6,7 @@ class OpenWithPermission::PermissionRequest < ApplicationRecord
   belongs_to :parent_object
   has_one :user
   before_validation :sanitize_user_input, on: [:create]
+  validates_presence_of :access_until, if: lambda { request_status == "Approved" }
 
   before_save do
     self.approved_or_denied_at = Time.zone.now if request_status_changed?

--- a/spec/requests/permission_requests_spec.rb
+++ b/spec/requests/permission_requests_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: tru
         valid_status_update_params = { open_with_permission_permission_request:
           {
             request_status: "Approved",
+            access_until: "2080-06-10 00:00:00",
             change_access_type: 'No'
           } }
         patch "/permission_requests/#{updatable_permission_request.id}", params: JSON.pretty_generate(valid_status_update_params), headers: headers
@@ -54,6 +55,7 @@ RSpec.describe 'Permission Requests', type: :request, prep_metadata_sources: tru
         valid_status_and_access_update_params = { open_with_permission_permission_request:
           {
             request_status: "Approved",
+            access_until: "2080-06-10 00:00:00",
             new_visibility: 'Public',
             change_access_type: 'Yes'
           } }

--- a/spec/system/permission_request_spec.rb
+++ b/spec/system/permission_request_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe "PermissionRequests", type: :system, prep_metadata_sources: true,
     FactoryBot.create(:permission_request, request_status: "Approved", permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: '<p>something</p>', permission_request_user_name: '<h1>name 2</h1>', access_until: "2030-06-10 00:00:00")
   end
   let(:permission_request_two) do
-    FactoryBot.create(:permission_request, parent_object: parent_object_two, permission_set: permission_set_two, permission_request_user: request_user_two, request_status: "Approved", permission_request_user_name: 'name 3')
+    FactoryBot.create(:permission_request, parent_object: parent_object_two, permission_set: permission_set_two, permission_request_user: request_user_two, request_status: "Approved", access_until: "2080-06-10 00:00:00", permission_request_user_name: 'name 3')
   end
   let(:permission_request_three) do
-    FactoryBot.create(:permission_request, permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: '<p>something</p>', permission_request_user_name: '<h1>name 2</h1>')
+    FactoryBot.create(:permission_request, permission_set: permission_set, parent_object: parent_object, permission_request_user: request_user, user_note: '<p>something</p>', access_until: "2080-06-10 00:00:00", permission_request_user_name: '<h1>name 2</h1>')
   end
   # rubocop:enable Layout/LineLength
   let(:administrator_user) { FactoryBot.create(:user, uid: 'admin') }


### PR DESCRIPTION
## Summary  
Blacklight Permission Requests page was broken whenever a request had an "Approved" request status and no access_until date. This PR prevents requests from getting an "Approved" status without an access date selected. 