### PR TITLE
Prevent admins from removing selves from PS

### DIFF
--- a/app/views/permission_sets/show.html.erb
+++ b/app/views/permission_sets/show.html.erb
@@ -62,7 +62,7 @@
   <tbody>
     <% User.with_role(:administrator, @permission_set).order('last_name ASC').each do |user| %>
         <tr>
-          <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %><%= link_to 'X', remove_roles_path(uid: user.uid, item_class: 'PermissionSet', item_id: @permission_set.id, role: :administrator), method: :delete unless current_user.has_role?(:approver, @permission_set)%></td>
+          <td class='user-role'><%= "#{user.last_name}, #{user.first_name} (#{user.uid})" %><%= link_to 'X', remove_roles_path(uid: user.uid, item_class: 'PermissionSet', item_id: @permission_set.id, role: :administrator), method: :delete unless current_user.has_role?(:approver, @permission_set) || user == current_user %></td>
         </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
## Summary  
Admins of permission sets can no longer remove themselves from the permission set roles.  
  
## Screenshot:  
<img width="1779" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/cb449e0d-952c-49d5-86dc-327825dadf98">
