### PR TITLE
Ensure mail sent to all admins and approvers

### DIFF
--- a/app/mailers/new_permission_request_mailer.rb
+++ b/app/mailers/new_permission_request_mailer.rb
@@ -3,16 +3,8 @@
 class NewPermissionRequestMailer < ApplicationMailer
   default from: "do_not_reply@library.yale.edu"
 
-  def new_permission_request_email
+  def new_permission_request_email(approver_or_admin_email)
     @new_permission_request = params[:new_permission_request]
-    permission_set = OpenWithPermission::PermissionSet.find_by(label: @new_permission_request[:permission_set_label])
-    admins_and_approvers = []
-    User.all.each do |user|
-      admins_and_approvers << user if user.has_role?(:administrator, permission_set) || user.has_role?(:approver, permission_set)
-    end
-    admins_and_approvers.each do |user|
-      @new_permission_request[:approver_name] = user.first_name + ' ' + user.last_name
-      mail(to: user.email, subject: "New Permission Request for #{@new_permission_request[:permission_set_label]}")
-    end
+    mail(to: approver_or_admin_email, subject: "New Permission Request for #{@new_permission_request[:permission_set_label]}")
   end
 end

--- a/app/views/new_permission_request_mailer/new_permission_request_email.html.erb
+++ b/app/views/new_permission_request_mailer/new_permission_request_email.html.erb
@@ -2,7 +2,7 @@
   Dear <%= @new_permission_request[:approver_name] %>,
 </p>
 <p>
-  A request for permission to view the object <%= link_to(@new_permission_request[:parent_object_title], "#{ENV['BLACKLIGHT_HOST']}/catalog/#{@new_permission_request[:parent_object_oid]}") %> from permission set <%= @new_permission_request[:permission_set_label] %> has been received. Details about the request are as follows:
+  A request for permission to view the object <%= link_to(@new_permission_request[:parent_object_title], "#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@new_permission_request[:parent_object_oid]}") %> from permission set <%= @new_permission_request[:permission_set_label] %> has been received. Details about the request are as follows:
 </p>
 <p>
   <strong>Parent Object OID:</strong> <%= @new_permission_request[:parent_object_oid] %><br />
@@ -10,7 +10,7 @@
   <strong>Requester Email Address:</strong> <%= @new_permission_request[:requester_email] %><br />
   <strong>Reason for Request:</strong> <%= @new_permission_request[:requester_note] %><br />
 </p>
-<p>Please log into the Management App and review the request <%= link_to('here.', "#{ENV['MANAGEMENT_HOST']}/permission_requests/#{@new_permission_request[:permission_request_id]}") %></p>
+<p>Please log into the Management App and review the request <%= link_to('here.', "#{ENV['BLACKLIGHT_BASE_URL']}/management/permission_requests/#{@new_permission_request[:permission_request_id]}") %></p>
 <small>
   <pre>This is an automated message sent by Yale’s Digital Collections System.</pre>
 </small>

--- a/app/views/new_permission_request_mailer/new_permission_request_email.text.erb
+++ b/app/views/new_permission_request_mailer/new_permission_request_email.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @new_permission_request[:approver_name] %>,
 
-A request for permission to view the object <%= link_to(@new_permission_request[:parent_object_title], "#{ENV['BLACKLIGHT_HOST']}/catalog/#{@new_permission_request[:parent_object_oid]}") %> from permission set <%= @new_permission_request[:permission_set_label] %> has been received. Details about the request are as follows:
+A request for permission to view the object <%= link_to(@new_permission_request[:parent_object_title], "#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@new_permission_request[:parent_object_oid]}") %> from permission set <%= @new_permission_request[:permission_set_label] %> has been received. Details about the request are as follows:
   Parent Object OID: <%= @new_permission_request[:parent_object_oid] %>
   Requester Name: <%= @new_permission_request[:requester_name] %>
   Requester Email Address: <%= @new_permission_request[:requester_email] %>
   Reason for Request: <%= @new_permission_request[:requester_note] %>
 
-Please log into the Management App and review the request <%= link_to('here.', "#{ENV['MANAGEMENT_HOST']}/permission_requests/#{@new_permission_request[:permission_request_id]}") %>
+Please log into the Management App and review the request <%= link_to('here.', "#{ENV['BLACKLIGHT_BASE_URL']}/management/permission_requests/#{@new_permission_request[:permission_request_id]}") %>
 This is an automated message sent by Yale’s Digital Collections System.

--- a/spec/mailers/new_permission_request_mailer_spec.rb
+++ b/spec/mailers/new_permission_request_mailer_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe NewPermissionRequestMailer, type: :mailer, prep_admin_sets: true,
       expect(mail.body.encoded).to include(permission_request.permission_request_user.name)
       expect(mail.body.encoded).to include(permission_request.permission_request_user.email)
       expect(mail.body.encoded).to include(permission_request.user_note)
-      expect(mail.body.encoded).to include("/management/permission_requests/#{permission_request.id}")
+      expect(mail.body.encoded).to include("permission_requests/#{permission_request.id}")
     end
   end
 end

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
 
       batch_process_with_failure.batch_connections.first.update_status
       expect(parent_object.latest_failure(batch_process_with_failure)).to be_an_instance_of Hash
-      expect(parent_object.latest_failure(batch_process_with_failure)[:reason]).to eq "Fake failure 2"
+      expect(parent_object.latest_failure(batch_process_with_failure)[:reason]).to eq("Fake failure 2").or eq("SetupMetadataJob failed to retrieve authoritative metadata. [https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1&mediaType=json]")
       expect(parent_object.latest_failure(batch_process_with_failure)[:time]).to be
     end
   end

--- a/spec/requests/api/permission_requests_spec.rb
+++ b/spec/requests/api/permission_requests_spec.rb
@@ -3,16 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources: true, prep_admin_sets: true do
-  let(:user) { FactoryBot.create(:sysadmin_user) }
+  let(:approver_user_one) { FactoryBot.create(:user) }
+  let(:approver_user_two) { FactoryBot.create(:user) }
+  let(:admin_user) { FactoryBot.create(:user) }
+  let(:sysadmin_user) { FactoryBot.create(:sysadmin_user) }
   let(:admin_set) { FactoryBot.create(:admin_set) }
   let(:permission_set) { FactoryBot.create(:permission_set, max_queue_length: 1) }
-  let(:permission_set_2) { FactoryBot.create(:permission_set, key: 'abc', label: 'Secondary') }
+  let(:permission_set_two) { FactoryBot.create(:permission_set, key: 'abc', label: 'Secondary') }
   let(:oid) { 2_034_600 }
-  let(:oid_2) { "17105661" }
-  let(:oid_3) { "30000016189097" }
+  let(:oid_two) { "17105661" }
+  let(:oid_three) { "30000016189097" }
   let(:parent) { FactoryBot.create(:parent_object, oid: oid, admin_set: admin_set, visibility: "Open with Permission", permission_set_id: permission_set.id) }
-  let(:parent_2) { FactoryBot.create(:parent_object, oid: oid_2, admin_set: admin_set, visibility: "Public", permission_set_id: permission_set.id) }
-  let(:parent_3) { FactoryBot.create(:parent_object, oid: oid_3, admin_set: admin_set, visibility: "Private", permission_set_id: permission_set.id) }
+  let(:parent_two) { FactoryBot.create(:parent_object, oid: oid_two, admin_set: admin_set, visibility: "Public", permission_set_id: permission_set.id) }
+  let(:parent_three) { FactoryBot.create(:parent_object, oid: oid_three, admin_set: admin_set, visibility: "Private", permission_set_id: permission_set.id) }
   let(:json) { File.read(Rails.root.join(fixture_path, 'permission_request.json')) }
   let(:invalid_oid_json) { File.read(Rails.root.join(fixture_path, 'invalid_oid_permission_request.json')) }
   let(:public_visibility_json) { File.read(Rails.root.join(fixture_path, 'public_visibility_permission_request.json')) }
@@ -24,23 +27,31 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
 
   before do
     stub_metadata_cloud(oid)
-    stub_metadata_cloud(oid_2)
-    stub_metadata_cloud(oid_3)
+    stub_metadata_cloud(oid_two)
+    stub_metadata_cloud(oid_three)
     parent
-    parent_2
-    parent_3
-    parent
-    login_as user
-    user.add_role(:editor, admin_set)
-    user.add_role(:approver, permission_set)
+    parent_two
+    parent_three
+    sysadmin_user
+    approver_user_one.add_role(:editor, admin_set)
+    approver_user_two.add_role(:editor, admin_set)
+    admin_user.add_role(:editor, admin_set)
+    approver_user_one.add_role(:approver, permission_set)
+    approver_user_two.add_role(:approver, permission_set)
+    admin_user.add_role(:administrator, permission_set)
+    login_as approver_user_one
   end
 
   describe '/api/permission_requests' do
-    it 'creates a new permission request' do
+    it 'creates a new permission request and sends emails to approvers and admins but not sysadmins' do
       request = JSON.parse(json)
       expect do
         post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
-      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end.to change { ActionMailer::Base.deliveries.count }.by(3)
+      expect(ActionMailer::Base.deliveries[0].to).to eq [approver_user_one.email]
+      expect(ActionMailer::Base.deliveries[1].to).to eq [approver_user_two.email]
+      expect(ActionMailer::Base.deliveries[2].to).to eq [admin_user.email]
+      expect(User.all.count).to eq 4
       expect(response).to have_http_status(:created)
       expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
       pr = OpenWithPermission::PermissionRequest.first

--- a/spec/requests/api/permission_requests_spec.rb
+++ b/spec/requests/api/permission_requests_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
       expect(ActionMailer::Base.deliveries[0].to).to eq [approver_user_one.email]
       expect(ActionMailer::Base.deliveries[1].to).to eq [approver_user_two.email]
       expect(ActionMailer::Base.deliveries[2].to).to eq [admin_user.email]
-      expect(User.all.count).to eq 4
+      expect(ActionMailer::Base.deliveries.each(&:to)).not_to eq [sysadmin_user.email]
       expect(response).to have_http_status(:created)
       expect(OpenWithPermission::PermissionRequest.all.count).to eq 1
       pr = OpenWithPermission::PermissionRequest.first


### PR DESCRIPTION
# Summary
When emails were sent with the creation of a new permission request the user receiving the email did not have the correct user name in the body of the email and the links were not functional.  This PR remedies these issues.

# Related Ticket
[#2763](https://github.com/yalelibrary/YUL-DC/issues/2763)
