### PR TITLE
Approver note to datatable

### DIFF
--- a/app/datatables/permission_request_datatable.rb
+++ b/app/datatables/permission_request_datatable.rb
@@ -24,6 +24,7 @@ class PermissionRequestDatatable < ApplicationDatatable
       sub: { source: "OpenWithPermission::PermissionRequestUser.sub", cond: :start_with, searchable: true, orderable: true },
       net_id: { source: "OpenWithPermission::PermissionRequestUser.netid", cond: :start_with, searchable: true, orderable: true },
       request_status: { source: "OpenWithPermission::PermissionRequest.request_status", cond: :start_with, searchable: true, orderable: true },
+      approver_note: { source: "OpenWithPermission::PermissionRequest.approver_note", cond: :start_with, searchable: true, orderable: true },
       approved_or_denied_at: { source: "OpenWithPermission::PermissionRequest.approved_or_denied_at", cond: :start_with, searchable: true, orderable: true },
       access_until: { source: "OpenWithPermission::PermissionRequest.access_until", cond: :start_with, searchable: true, orderable: true },
       approver: { source: "OpenWithPermission::PermissionRequest.approver", cond: :start_with, searchable: true, orderable: true }
@@ -43,6 +44,7 @@ class PermissionRequestDatatable < ApplicationDatatable
         sub: permission_request.permission_request_user.sub,
         net_id: permission_request.permission_request_user.netid,
         request_status: permission_request.request_status,
+        approver_note: permission_request.approver_note,
         approved_or_denied_at: permission_request.approved_or_denied_at,
         access_until: permission_request.access_until,
         approver: permission_request.approver

--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -19,6 +19,7 @@
           <th scope='col'> User ID </th>
           <th scope='col'> Net ID </th>
           <th scope='col'> Request Status </th>
+          <th scope='col'> Approver Note </th>
           <th scope='col'> Date Approved/Denied </th>
           <th scope='col'> Access Expired </th>
           <th scope='col'> Approver </th>

--- a/spec/datatables/permission_request_datatable_spec.rb
+++ b/spec/datatables/permission_request_datatable_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
   end
 
   it 'can handle a permission request' do
-    pr = FactoryBot.create(:permission_request, approver_note: "approver note example",)
+    pr = FactoryBot.create(:permission_request, approver_note: "approver note example")
     output = PermissionRequestDatatable.new(datatable_sample_params(columns), view_context: pr_datatable_view_mock(pr.id, pr.permission_set.id), current_ability: Ability.new(user)).data
 
     expect(output.size).to eq(1)

--- a/spec/datatables/permission_request_datatable_spec.rb
+++ b/spec/datatables/permission_request_datatable_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
   end
 
   it 'can handle a permission request' do
-    pr = FactoryBot.create(:permission_request)
+    pr = FactoryBot.create(:permission_request, approver_note: "approver note example",)
     output = PermissionRequestDatatable.new(datatable_sample_params(columns), view_context: pr_datatable_view_mock(pr.id, pr.permission_set.id), current_ability: Ability.new(user)).data
 
     expect(output.size).to eq(1)
@@ -25,6 +25,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
       sub: pr.permission_request_user.sub,
       net_id: pr.permission_request_user.netid,
       request_status: pr.request_status,
+      approver_note: pr.approver_note,
       approved_or_denied_at: pr.approved_or_denied_at,
       access_until: pr.access_until,
       approver: nil
@@ -38,8 +39,8 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
     ps_two = FactoryBot.create(:permission_set, key: 'def', label: 'dan')
     po_one = FactoryBot.create(:parent_object, permission_set: ps_one, oid: '3456789')
     po_two = FactoryBot.create(:parent_object, permission_set: ps_two, oid: '1234567')
-    pr_one = FactoryBot.create(:permission_request, permission_set: ps_one, parent_object: po_one)
-    pr_two = FactoryBot.create(:permission_request, permission_set: ps_two, parent_object: po_two)
+    pr_one = FactoryBot.create(:permission_request, permission_set: ps_one, parent_object: po_one, approver_note: "approver note example")
+    pr_two = FactoryBot.create(:permission_request, permission_set: ps_two, parent_object: po_two, approver_note: "approver note example")
 
     as.add_editor(reg_user)
     ps_one.add_administrator(reg_user)
@@ -56,6 +57,7 @@ RSpec.describe PermissionRequestDatatable, type: :datatable, prep_metadata_sourc
       permission_set: "<a href='/permission_sets/#{pr_one.permission_set.id}'>#{pr_one.permission_set.label}</a>",
       request_date: pr_one.created_at,
       request_status: pr_one.request_status,
+      approver_note: pr_one.approver_note,
       access_until: pr_one.access_until,
       approved_or_denied_at: pr_one.approved_or_denied_at,
       sub: pr_one.permission_request_user.sub,


### PR DESCRIPTION
## Summary  
"Approver Note" is now displayed on the permission request datatable.  
  
## Screenshot  
<img width="1765" alt="image" src="https://github.com/yalelibrary/yul-dc-management/assets/24666568/3b0b2026-8031-4b13-bf79-c90a20daef6e">
