### PR TITLE
Changes abilities for sysadmin with permission sets

### DIFF
--- a/app/controllers/permission_sets_controller.rb
+++ b/app/controllers/permission_sets_controller.rb
@@ -42,6 +42,7 @@ class PermissionSetsController < ApplicationController
   def create
     authorize!(:create, OpenWithPermission::PermissionSet)
     @permission_set = OpenWithPermission::PermissionSet.new(permission_set_params)
+    current_user&.add_role(:administrator, @permission_set)
 
     respond_to do |format|
       if @permission_set.save

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,7 +12,7 @@ class Ability
     return unless user
     can :create_new, ParentObject if user.roles.find_by(name: :editor)
     if user.has_role? :sysadmin
-      apply_sysadmin_abilities
+      apply_sysadmin_abilities(user)
     else
       can :read, ParentObject, admin_set: { roles: { name: viewer_roles, users: { id: user.id } } }
       can :read, ChildObject, parent_object: { admin_set: { roles: { name: viewer_roles, users: { id: user.id } } } }
@@ -34,10 +34,11 @@ class Ability
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
 
-  def apply_sysadmin_abilities
+  def apply_sysadmin_abilities(user)
     can :manage, User
     can :crud, AdminSet
-    can [:crud, :view_list, :owp_access, :create_set], OpenWithPermission::PermissionSet
+    can [:view_list, :owp_access, :create_set], OpenWithPermission::PermissionSet
+    can [:crud], OpenWithPermission::PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
     can [:crud, :view_list], OpenWithPermission::PermissionRequest
     can :read, ParentObject
     can :read, ChildObject

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,7 +37,7 @@ class Ability
   def apply_sysadmin_abilities(user)
     can :manage, User
     can :crud, AdminSet
-    can [:view_list, :owp_access, :create_set], OpenWithPermission::PermissionSet
+    can [:view_list, :owp_access, :create], OpenWithPermission::PermissionSet
     can [:crud], OpenWithPermission::PermissionSet, roles: { name: administrator_roles, users: { id: user.id } }
     can [:crud, :view_list], OpenWithPermission::PermissionRequest
     can :read, ParentObject

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   subject(:batch_process) { BatchProcess.new }
   let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl') }
   let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:sysadmin_user) { FactoryBot.create(:sysadmin_user) }
   let(:permission_set) { FactoryBot.create(:permission_set, key: 'psKey') }
   let(:preservica_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent.csv")) }
   let(:preservica_parent_no_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "csv", "preservica", "preservica_parent_no_source.csv")) }
@@ -31,8 +32,8 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   before do
     permission_set
     user.add_role(:editor, admin_set)
-    login_as(:user)
-    batch_process.user_id = user.id
+    # login_as(:user)
+    # batch_process.user_id = user.id
     stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
@@ -62,57 +63,98 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       )
     end
     stub_preservica_tifs_set_of_three
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
+    # rubocop:enable RSpec/AnyInstance
   end
 
-  # rubocop:disable RSpec/AnyInstance
-  it 'can send an error when Preservica credentials are not set' do
-    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    expect do
-      batch_process.file = preservica_parent
-      batch_process.save
-      expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with admin set [brbl] for parent: 200000000. Preservica credentials not set for brbl.")
-    end.not_to change { ParentObject.count }
+  context 'with regular user' do
+    before do
+      batch_process.user_id = user.id
+      login_as(:user)
+    end
+
+    it 'can send an error when Preservica credentials are not set' do
+      expect do
+        batch_process.file = preservica_parent
+        batch_process.save
+        expect(batch_process.batch_ingest_events.count).to eq(1)
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with admin set [brbl] for parent: 200000000. Preservica credentials not set for brbl.")
+      end.not_to change { ParentObject.count }
+    end
+
+    it 'can send an error when no metadata source is set' do
+      expect do
+        batch_process.file = preservica_parent_no_source
+        batch_process.save
+        expect(batch_process.batch_ingest_events.count).to eq(1)
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown source []. Source must be 'ils' or 'aspace'")
+      end.not_to change { ParentObject.count }
+    end
+
+    it 'can send an error when no admin set is set' do
+      expect do
+        batch_process.file = preservica_parent_no_admin_set
+        batch_process.save
+        expect(batch_process.batch_ingest_events.count).to eq(1)
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown admin set [] for parent: 200000000")
+      end.not_to change { ParentObject.count }
+    end
+
+    it 'can send an error when no permission set is set' do
+      expect do
+        batch_process.file = preservica_parent_no_permission_set
+        batch_process.save
+        expect(batch_process.batch_ingest_events.count).to eq(1)
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown Permission Set with Key: [] for parent: 200000000")
+      end.not_to change { ParentObject.count }
+    end
+
+    it 'can send an error when user does not have admin role on permission set' do
+      expect do
+        batch_process.file = preservica_parent_with_permission_set
+        batch_process.save
+        expect(batch_process.batch_ingest_events.count).to eq(1)
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] because mk2525 does not have permission to update objects in Permission Set: Permission Label")
+      end.not_to change { ParentObject.count }
+    end
   end
 
-  it 'can send an error when no metadata source is set' do
-    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    expect do
-      batch_process.file = preservica_parent_no_source
-      batch_process.save
-      expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown source []. Source must be 'ils' or 'aspace'")
-    end.not_to change { ParentObject.count }
-  end
+  context 'with sysadmin user' do
+    before do
+      batch_process.user_id = sysadmin_user.id
+      login_as(:sysadmin_user)
+    end
 
-  it 'can send an error when no admin set is set' do
-    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    expect do
-      batch_process.file = preservica_parent_no_admin_set
-      batch_process.save
-      expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown admin set [] for parent: 200000000")
-    end.not_to change { ParentObject.count }
-  end
+    it 'can send an error when user does not have admin role on permission set' do
+      expect do
+        batch_process.file = preservica_parent_with_permission_set
+        batch_process.save
+        expect(batch_process.batch_ingest_events.count).to eq(1)
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] because #{sysadmin_user.uid} does not have permission to update objects in Permission Set: Permission Label")
+      end.not_to change { ParentObject.count }
+    end
 
-  it 'can send an error when no permission set is set' do
-    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    expect do
-      batch_process.file = preservica_parent_no_permission_set
-      batch_process.save
-      expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] with unknown Permission Set with Key: [] for parent: 200000000")
-    end.not_to change { ParentObject.count }
+    it 'can send an error when user WAS an admin for permission set' do
+      expect(sysadmin_user.has_role?(:administrator, permission_set)).to eq false
+      sysadmin_user.add_role(:administrator, permission_set)
+      expect(sysadmin_user.has_role?(:administrator, permission_set)).to eq true
+      expect do
+        batch_process.file = preservica_parent_with_permission_set
+        batch_process.save
+      end.to change { ParentObject.count }
+      ParentObject.all.each(&:destroy)
+      expect(ParentObject.count).to eq 0
+      sysadmin_user.remove_role(:administrator, permission_set)
+      expect(sysadmin_user.has_role?(:administrator, permission_set)).to eq false
+      new_batch_process = BatchProcess.new
+      new_batch_process.user_id = sysadmin_user.id
+      expect do
+        new_batch_process.file = preservica_parent_with_permission_set
+        new_batch_process.save
+        expect(new_batch_process.batch_ingest_events.count).to eq(1)
+        expect(new_batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] because #{sysadmin_user.uid} does not have permission to update objects in Permission Set: Permission Label")
+      end.not_to change { ParentObject.count }
+    end
   end
-
-  it 'can send an error when user does not have admin role on permission set' do
-    allow_any_instance_of(SetupMetadataJob).to receive(:perform).and_return(true)
-    expect do
-      batch_process.file = preservica_parent_with_permission_set
-      batch_process.save
-      expect(batch_process.batch_ingest_events.count).to eq(1)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] because mk2525 does not have permission to update objects in Permission Set: Permission Label")
-    end.not_to change { ParentObject.count }
-  end
-  # rubocop:enable RSpec/AnyInstance
 end

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   before do
     permission_set
     user.add_role(:editor, admin_set)
-    # login_as(:user)
-    # batch_process.user_id = user.id
     stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login

--- a/spec/requests/permission_set_spec.rb
+++ b/spec/requests/permission_set_spec.rb
@@ -23,14 +23,15 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
       label: "Newer Label"
     }
   end
-  let(:user) { FactoryBot.create(:sysadmin_user) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:permission_set) { OpenWithPermission::PermissionSet.create! valid_attributes }
 
   describe 'update /permission_sets' do
     before do
+      user.add_role(:administrator, permission_set)
       login_as user
     end
     it 'updates permission set with valid attributes' do
-      permission_set = OpenWithPermission::PermissionSet.create! valid_attributes
       patch permission_set_url(permission_set), params: { open_with_permission_permission_set: updated_attributes }
       permission_set.reload
       expect(permission_set.key).to eq "Newer Key"
@@ -38,7 +39,6 @@ RSpec.describe 'Permission Sets', type: :request, prep_metadata_sources: true, p
     end
 
     it 'does not update permission set with invalid attributes' do
-      permission_set = OpenWithPermission::PermissionSet.create(valid_attributes)
       patch permission_set_url(permission_set), params: { open_with_permission_permission_set: invalid_attributes }
       permission_set.reload
       expect(permission_set.key).to eq "New Key"


### PR DESCRIPTION
# Summary
Modifies sysadmin abilities so they cannot crud Permission Sets they are no longer an administrator for.

# Related Ticket
[#2836](https://github.com/yalelibrary/YUL-DC/issues/2836)