### PR TITLE
Approved/Denied Email Language Update

### DIFF
--- a/app/views/user_notification_approved_mailer/user_notification_approved_email.html.erb
+++ b/app/views/user_notification_approved_mailer/user_notification_approved_email.html.erb
@@ -11,5 +11,5 @@
   <%= link_to("#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}", "#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}") %>
 </p>
 <small>
-  <pre>This is an automated message sent by Yale’s Digital Collections System.</pre>
+  <pre>This is an automated messagee.</pre>
 </small>

--- a/app/views/user_notification_approved_mailer/user_notification_approved_email.html.erb
+++ b/app/views/user_notification_approved_mailer/user_notification_approved_email.html.erb
@@ -11,5 +11,5 @@
   <%= link_to("#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}", "#{ENV['BLACKLIGHT_BASE_URL']}/catalog/#{@user_notification[:parent_object_oid]}") %>
 </p>
 <small>
-  <pre>This is an automated messagee.</pre>
+  <pre>This is an automated message.</pre>
 </small>

--- a/app/views/user_notification_denied_mailer/user_notification_denied_email.html.erb
+++ b/app/views/user_notification_denied_mailer/user_notification_denied_email.html.erb
@@ -5,5 +5,5 @@
   Your request to view the object <%= @user_notification[:parent_object_title] %> in Yale's Digital Collections System has been denied.
 </p>
 <small>
-  <pre>This is an automated message sent by Yale’s Digital Collections System.</pre>
+  <pre>This is an automated message.</pre>
 </small>


### PR DESCRIPTION
## Summary  
Removed the `sent by Yale’s Digital Collections System` language in approved/denied emails.