### PR TITLE
Adds gsub to sanitize for manifests

### DIFF
--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -144,7 +144,6 @@ class IiifPresentationV3
   # rubocop:enable Metrics/PerceivedComplexity
 
   def sanitize_and_wrap(value)
-    # byebug
     if value.is_a?(Array)
       value&.map { |v| wrap_if_html(ActionController::Base.helpers.sanitize(v, tags: ["a", "i", "b"], attributes: %w[href])).gsub('&amp;', '&') }
     elsif value.is_a?(String)

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -144,10 +144,11 @@ class IiifPresentationV3
   # rubocop:enable Metrics/PerceivedComplexity
 
   def sanitize_and_wrap(value)
+    # byebug
     if value.is_a?(Array)
-      value&.map { |v| wrap_if_html(ActionController::Base.helpers.sanitize(v, tags: ["a", "i", "b"], attributes: %w[href])) }
+      value&.map { |v| wrap_if_html(ActionController::Base.helpers.sanitize(v, tags: ["a", "i", "b"], attributes: %w[href])).gsub('&amp;', '&') }
     elsif value.is_a?(String)
-      wrap_if_html(ActionController::Base.helpers.sanitize(value, tags: ["a", "i", "b"], attributes: %w[href]))
+      wrap_if_html(ActionController::Base.helpers.sanitize(value, tags: ["a", "i", "b"], attributes: %w[href])).gsub('&amp;', '&')
     else
       value
     end

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -170,7 +170,7 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["metadata"].class).to eq Array
       expect(iiif_presentation.manifest["metadata"].first.class).to eq Hash
       expect(iiif_presentation.manifest["metadata"].first["label"]["en"].first).to eq "Creator"
-      expect(iiif_presentation.manifest["metadata"].first["value"]['none'].first).to include "Morris &amp; Co. (London, England)"
+      expect(iiif_presentation.manifest["metadata"].first["value"]['none'].first).to include "Morris & Co. (London, England)"
       expect(iiif_presentation.manifest["metadata"].last.class).to eq Hash
       expect(iiif_presentation.manifest["metadata"].last["label"]['en'].first).to eq "Object ID (OID)"
       expect(iiif_presentation.manifest["metadata"].select { |k| true if k["label"]["en"].first == "Orbis ID" }).not_to be_empty


### PR DESCRIPTION
# Summary
During the review for [this PR](https://github.com/yalelibrary/yul-dc-management/pull/1348/files#diff-487c6db6ac726f34f1a91ffbae954366637de8a97d2668cd14420b27256c4569) a change in the behavior of the sanitize method was noticed.  This PR will return the sanitize method to it's desired behavior.

# Related Ticket
[#2818](https://github.com/yalelibrary/YUL-DC/issues/2818)