### PR TITLE
'Synchronize Child Objects' button access to admin set editors

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,6 +21,7 @@ class Ability
     can :reindex_admin_set, AdminSet, roles: { name: editor_roles, users: { id: user.id } }
     can :crud, ChildObject, parent_object: { admin_set: { roles: { name: editor_roles, users: { id: user.id } } } }
     can :crud, ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
+    can :sync_from_preservica, ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
     can :view_list, [OpenWithPermission::PermissionSet, OpenWithPermission::PermissionRequest] if user.has_role?(:approver, :any) || user.has_role?(:administrator, :any)
     can [:read, :update, :owp_access], OpenWithPermission::PermissionSet if user.has_role?(:administrator, :any)
     can :read, OpenWithPermission::PermissionSet, roles: { name: approver_roles, users: { id: user.id } }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,8 +20,7 @@ class Ability
     can :add_member, AdminSet, roles: { name: editor_roles, users: { id: user.id } }
     can :reindex_admin_set, AdminSet, roles: { name: editor_roles, users: { id: user.id } }
     can :crud, ChildObject, parent_object: { admin_set: { roles: { name: editor_roles, users: { id: user.id } } } }
-    can :crud, ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
-    can :sync_from_preservica, ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
+    can [:crud, :sync_from_preservica], ParentObject, admin_set: { roles: { name: editor_roles, users: { id: user.id } } }
     can :view_list, [OpenWithPermission::PermissionSet, OpenWithPermission::PermissionRequest] if user.has_role?(:approver, :any) || user.has_role?(:administrator, :any)
     can [:read, :update, :owp_access], OpenWithPermission::PermissionSet if user.has_role?(:administrator, :any)
     can :read, OpenWithPermission::PermissionSet, roles: { name: approver_roles, users: { id: user.id } }


### PR DESCRIPTION
## Summary  
'Synchronize Child Objects' button on Parent Object showpage can now be accessed by admin set editors.  