### PR TITLE
Integrity Check job rework

### DIFF
--- a/app/models/concerns/integrity_checkable.rb
+++ b/app/models/concerns/integrity_checkable.rb
@@ -27,16 +27,9 @@ module IntegrityCheckable
         split_sets = sets.split(',').uniq.reject(&:blank?)
 
         if co.access_master_exists?
-          if co.access_master_checksum_matches?
-            co.processing_event("Child Object: #{co.oid} - checksum matches and file exists.", 'review-complete')
-          else
-            co.processing_event(
-              "Child Object: #{co.oid} - file exists but the file's checksum [#{Digest::SHA1.file(co.access_master_path)}] does not match what is saved on the child object [#{co.checksum}].", 'failed'
-            )
-          end
+          co.processing_event("Child Object: #{co.oid} - file exists.", 'review-complete')
         else
-          co.processing_event("Child Object: #{co.oid} - file not found at #{co.access_master_path} on #{ENV['ACCESS_MASTER_MOUNT']}.  Checksum could not be compared for the child object.",
-  'failed')
+          co.processing_event("Child Object: #{co.oid} - file not found at #{co.access_master_path} on #{ENV['ACCESS_MASTER_MOUNT']}.", 'failed')
         end
         self.admin_set = split_sets.join(', ')
         save!

--- a/spec/models/concerns/integrity_checkable_spec.rb
+++ b/spec/models/concerns/integrity_checkable_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe IntegrityCheckable, type: :model, prep_metadata_sources: true, pr
     it 'reflects messages as expected' do
       expect { ChildObjectIntegrityCheckJob.new.perform }.to change { IngestEvent.count }.by(7)
       # rubocop:disable Layout/LineLength
-      expect(child_object_one.events_for_batch_process(BatchProcess.first)[0].reason).to eq "Child Object: #{child_object_one.oid} - file not found at #{child_object_one.access_master_path} on #{ENV['ACCESS_MASTER_MOUNT']}.  Checksum could not be compared for the child object."
-      expect(child_object_two.events_for_batch_process(BatchProcess.first)[0].reason).to eq "Child Object: #{child_object_two.oid} - file exists but the file's checksum [#{Digest::SHA1.file(child_object_two.access_master_path)}] does not match what is saved on the child object [#{child_object_two.checksum}]."
-      expect(child_object_three.events_for_batch_process(BatchProcess.first)[0].reason).to eq "Child Object: #{child_object_three.oid} - checksum matches and file exists."
+      expect(child_object_one.events_for_batch_process(BatchProcess.first)[0].reason).to eq "Child Object: #{child_object_one.oid} - file not found at #{child_object_one.access_master_path} on #{ENV['ACCESS_MASTER_MOUNT']}."
+      expect(child_object_two.events_for_batch_process(BatchProcess.first)[0].reason).to eq "Child Object: #{child_object_two.oid} - file exists."
+      expect(child_object_three.events_for_batch_process(BatchProcess.first)[0].reason).to eq "Child Object: #{child_object_three.oid} - file exists."
       # rubocop:enable Layout/LineLength
     end
   end


### PR DESCRIPTION
## Summary  
Integrity Check job now only validates presence of access_master_path file instead of also checking checksum.