### PR TITLE
Adds auth token to OwP post requests

### DIFF
--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -6,6 +6,7 @@ class Api::PermissionRequestsController < ApplicationController
 
   # rubocop:disable Metrics/MethodLength
   def create
+    return unless request.headers['OWP_AUTH_TOKEN'] == ENV['OWP_AUTH_TOKEN']
     request = params
     begin
       parent_object = ParentObject.find(request['oid'].to_i)

--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -6,7 +6,7 @@ class Api::PermissionRequestsController < ApplicationController
 
   # rubocop:disable Metrics/MethodLength
   def create
-    return unless request.headers['OWP_AUTH_TOKEN'] == ENV['OWP_AUTH_TOKEN']
+    return unless request.headers['Authorization'] == "Bearer #{ENV['OWP_AUTH_TOKEN']}"
     request = params
     begin
       parent_object = ParentObject.find(request['oid'].to_i)

--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -4,9 +4,14 @@ class Api::PermissionRequestsController < ApplicationController
   skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
 
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def create
-    return unless request.headers['Authorization'] == "Bearer #{ENV['OWP_AUTH_TOKEN']}"
+    if request.headers['Authorization'] != "Bearer #{ENV['OWP_AUTH_TOKEN']}" || ENV['OWP_AUTH_TOKEN'].blank? || ENV['OWP_AUTH_TOKEN'].nil?
+      render json: { error: 'unauthorized' }.to_json, status: :unauthorized and return
+    end
     request = params
     begin
       parent_object = ParentObject.find(request['oid'].to_i)
@@ -33,8 +38,10 @@ class Api::PermissionRequestsController < ApplicationController
       render json: { "title": "New request created" }, status: 201
     end
   end
-
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def check_parent_visibility(parent_object)
     if parent_object.visibility == "Private"

--- a/app/controllers/api/permission_sets_controller.rb
+++ b/app/controllers/api/permission_sets_controller.rb
@@ -52,7 +52,7 @@ class Api::PermissionSetsController < ApplicationController
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def agreement_term
-    return unless request.headers['OWP_AUTH_TOKEN'] == ENV['OWP_AUTH_TOKEN']
+    return unless request.headers['Authorization'] == "Bearer #{ENV['OWP_AUTH_TOKEN']}"
     begin
       term = OpenWithPermission::PermissionSetTerm.find(params[:permission_set_terms_id])
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/permission_sets_controller.rb
+++ b/app/controllers/api/permission_sets_controller.rb
@@ -52,6 +52,7 @@ class Api::PermissionSetsController < ApplicationController
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def agreement_term
+    return unless request.headers['OWP_AUTH_TOKEN'] == ENV['OWP_AUTH_TOKEN']
     begin
       term = OpenWithPermission::PermissionSetTerm.find(params[:permission_set_terms_id])
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/permission_sets_controller.rb
+++ b/app/controllers/api/permission_sets_controller.rb
@@ -52,7 +52,7 @@ class Api::PermissionSetsController < ApplicationController
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def agreement_term
-    return unless request.headers['Authorization'] == "Bearer #{ENV['OWP_AUTH_TOKEN']}"
+    render json: { error: 'unauthorized' }.to_json, status: :unauthorized and return if request.headers['Authorization'] != "Bearer #{ENV['OWP_AUTH_TOKEN']}"
     begin
       term = OpenWithPermission::PermissionSetTerm.find(params[:permission_set_terms_id])
     rescue ActiveRecord::RecordNotFound

--- a/spec/requests/api/permission_requests_spec.rb
+++ b/spec/requests/api/permission_requests_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
   let(:invalid_sub_json) { File.read(Rails.root.join(fixture_path, 'invalid_sub_permission_request.json')) }
   let(:invalid_name_json) { File.read(Rails.root.join(fixture_path, 'invalid_name_permission_request.json')) }
   let(:invalid_email_json) { File.read(Rails.root.join(fixture_path, 'invalid_email_permission_request.json')) }
-  let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'OWP_AUTH_TOKEN' => 'valid' } }
-  let(:invalid_headers) { { 'CONTENT_TYPE' => 'application/json', 'OWP_AUTH_TOKEN' => 'invalid' } }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer valid" } }
+  let(:invalid_headers) { { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer invalid" } }
 
   before do
     stub_metadata_cloud(oid)

--- a/spec/requests/api/permission_requests_spec.rb
+++ b/spec/requests/api/permission_requests_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
   let(:invalid_sub_json) { File.read(Rails.root.join(fixture_path, 'invalid_sub_permission_request.json')) }
   let(:invalid_name_json) { File.read(Rails.root.join(fixture_path, 'invalid_name_permission_request.json')) }
   let(:invalid_email_json) { File.read(Rails.root.join(fixture_path, 'invalid_email_permission_request.json')) }
-  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'OWP_AUTH_TOKEN' => 'valid' } }
+  let(:invalid_headers) { { 'CONTENT_TYPE' => 'application/json', 'OWP_AUTH_TOKEN' => 'invalid' } }
 
   before do
     stub_metadata_cloud(oid)
@@ -40,6 +41,13 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
     approver_user_two.add_role(:approver, permission_set)
     admin_user.add_role(:administrator, permission_set)
     login_as approver_user_one
+  end
+
+  around do |example|
+    original_token = ENV['OWP_AUTH_TOKEN']
+    ENV['OWP_AUTH_TOKEN'] = 'valid'
+    example.run
+    ENV['OWP_AUTH_TOKEN'] = original_token
   end
 
   describe '/api/permission_requests' do
@@ -108,6 +116,12 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
       post "/api/permission_requests", params: JSON.pretty_generate(request), headers: headers
       expect(response).to have_http_status(400)
       expect(response.body).to match("{\"title\":\"Parent Object is private\"}")
+    end
+
+    it 'errors if a valid auth token is not present' do
+      request = JSON.parse(json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: invalid_headers
+      expect(response).to have_http_status(:no_content)
     end
   end
 end

--- a/spec/requests/api/permission_requests_spec.rb
+++ b/spec/requests/api/permission_requests_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
   let(:invalid_email_json) { File.read(Rails.root.join(fixture_path, 'invalid_email_permission_request.json')) }
   let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer valid" } }
   let(:invalid_headers) { { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer invalid" } }
+  let(:empty_headers) { {} }
 
   before do
     stub_metadata_cloud(oid)
@@ -118,10 +119,16 @@ RSpec.describe 'Permission Requests API', type: :request, prep_metadata_sources:
       expect(response.body).to match("{\"title\":\"Parent Object is private\"}")
     end
 
-    it 'errors if a valid auth token is not present' do
+    it 'errors if a valid auth token does not match' do
       request = JSON.parse(json)
       post "/api/permission_requests", params: JSON.pretty_generate(request), headers: invalid_headers
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'errors if a valid auth token is not present' do
+      request = JSON.parse(json)
+      post "/api/permission_requests", params: JSON.pretty_generate(request), headers: empty_headers
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/requests/api/permission_sets_spec.rb
+++ b/spec/requests/api/permission_sets_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
   let(:term_agreement) { FactoryBot.create(:term_agreement, permission_request_user: request_user, permission_set_term: terms) }
   let(:terms) { FactoryBot.create(:permission_set_term, activated_by: user, activated_at: Time.zone.now, permission_set: permission_set) }
   let(:request_user) { FactoryBot.create(:permission_request_user, sub: '1234') }
-  let(:headers) { { 'CONTENT_TYPE' => 'text/html', 'OWP_AUTH_TOKEN' => 'valid' } }
-  let(:invalid_headers) { { 'CONTENT_TYPE' => 'text/html', 'OWP_AUTH_TOKEN' => 'invalid' } }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer valid" } }
+  let(:invalid_headers) { { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer invalid" } }
   let(:params) do
     {
       'oid': '123',

--- a/spec/requests/api/permission_sets_spec.rb
+++ b/spec/requests/api/permission_sets_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
     end
     it 'throws error if auth token is invalid' do
       post agreement_term_url(invalid_term_params), headers: invalid_headers
-      expect(response).to have_http_status(204)
+      expect(response).to have_http_status(401)
     end
   end
 

--- a/spec/requests/api/permission_sets_spec.rb
+++ b/spec/requests/api/permission_sets_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
   let(:term_agreement) { FactoryBot.create(:term_agreement, permission_request_user: request_user, permission_set_term: terms) }
   let(:terms) { FactoryBot.create(:permission_set_term, activated_by: user, activated_at: Time.zone.now, permission_set: permission_set) }
   let(:request_user) { FactoryBot.create(:permission_request_user, sub: '1234') }
+  let(:headers) { { 'CONTENT_TYPE' => 'text/html', 'OWP_AUTH_TOKEN' => 'valid' } }
+  let(:invalid_headers) { { 'CONTENT_TYPE' => 'text/html', 'OWP_AUTH_TOKEN' => 'invalid' } }
   let(:params) do
     {
       'oid': '123',
@@ -55,6 +57,13 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
     term_agreement
   end
 
+  around do |example|
+    original_token = ENV['OWP_AUTH_TOKEN']
+    ENV['OWP_AUTH_TOKEN'] = 'valid'
+    example.run
+    ENV['OWP_AUTH_TOKEN'] = original_token
+  end
+
   describe 'get /api/permission_sets/id/terms' do
     it 'can display the active permission set term' do
       get terms_api_path(parent_object)
@@ -80,7 +89,7 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
   describe 'POST /agreement_term' do
     it 'can POST and create a user agreement' do
       expect(OpenWithPermission::TermsAgreement.count).to eq 1
-      post agreement_term_url(params)
+      post agreement_term_url(params), headers: headers
       expect(response).to have_http_status(201)
       term = OpenWithPermission::TermsAgreement.first
       expect(OpenWithPermission::TermsAgreement.count).to eq 2
@@ -88,14 +97,18 @@ RSpec.describe '/api/permission_sets/po/terms', type: :request, prep_metadata_so
       expect(term.permission_set_term).to eq terms
     end
     it 'throws error if user not found' do
-      post agreement_term_url(invalid_user_params)
+      post agreement_term_url(invalid_user_params), headers: headers
       expect(response).to have_http_status(400)
       expect(response.body).to eq("{\"title\":\"User not found.\"}")
     end
     it 'throws error if permission set term not found' do
-      post agreement_term_url(invalid_term_params)
+      post agreement_term_url(invalid_term_params), headers: headers
       expect(response).to have_http_status(400)
       expect(response.body).to eq("{\"title\":\"Term not found.\"}")
+    end
+    it 'throws error if auth token is invalid' do
+      post agreement_term_url(invalid_term_params), headers: invalid_headers
+      expect(response).to have_http_status(204)
     end
   end
 


### PR DESCRIPTION
# Summary
Adds expectation of an authentication token for Open with Permission post requests.

# Related Ticket
[#2877](https://github.com/yalelibrary/YUL-DC/issues/2877)
