### PR TITLE
remove net_id validation

### DIFF
--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -51,8 +51,6 @@ class Api::PermissionRequestsController < ApplicationController
       render(json: { "title": "User email is missing" }, status: 400) && (return false)
     elsif request['user_full_name'].blank?
       render(json: { "title": "User name is missing" }, status: 400) && (return false)
-    elsif request['user_netid'].blank?
-      render(json: { "title": "User netid is missing" }, status: 400) && (return false)
     elsif request['user_note'].blank?
       render(json: { "title": "User reason for request is missing" }, status: 400) && (return false)
     elsif request['user_sub'].blank?

--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -44,7 +44,7 @@ class Api::PermissionRequestsController < ApplicationController
     true
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
+   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def valid_json_request(request)
     if request['user_email'].blank?

--- a/app/controllers/api/permission_requests_controller.rb
+++ b/app/controllers/api/permission_requests_controller.rb
@@ -44,7 +44,7 @@ class Api::PermissionRequestsController < ApplicationController
     true
   end
 
-   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def valid_json_request(request)
     if request['user_email'].blank?


### PR DESCRIPTION
## Summary  
Permission Requests no longer need a net_id. Non-Yale users without a net_id can make OwP requests.