### PR TITLE
Modify excel export header row determination

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -293,7 +293,7 @@ function snake_case(string) {
 
 const format_excel = (xlsx) => {
   let sheet = xlsx.xl.worksheets['sheet1.xml'];
-  let headerRowData = $('row[r=2] c is t', sheet);
+  let headerRowData = $('row[r=1] c is t', sheet);
   let columnHeaderArray = [];
   let formattedHeaders = [];
 


### PR DESCRIPTION
# Summary
Resolves bug where when user exports with Excel file type would produce sheet with an empty first row.

# Related Ticket
[#2923](https://github.com/yalelibrary/YUL-DC/issues/2923)