### PR TITLE
Update database cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'coveralls_reborn', require: false
-  gem 'database_cleaner-active_record'
+  gem 'database_cleaner-active_record', '~> 2.2.0'
   gem 'ffaker'
   gem 'selenium-webdriver', '~> 4.14.0'
   gem 'shoulda-matchers', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       rexml
     crass (1.0.6)
     daemons (1.4.1)
-    database_cleaner-active_record (2.1.0)
+    database_cleaner-active_record (2.2.0)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
@@ -529,7 +529,7 @@ DEPENDENCIES
   coderay (~> 1.1, >= 1.1.3)
   coveralls_reborn
   daemons
-  database_cleaner-active_record
+  database_cleaner-active_record (~> 2.2.0)
   devise
   factory_bot_rails
   ffaker


### PR DESCRIPTION
# Summary
On main there were a number of specs causing CI to fail for what appeared to be conflicts with the records stored during the test's run.  There was an update with the latest release of the database cleaner gem that resolves some bugs and this PR upgrades database_cleaner-active_record to v2.2.0 in the hopes that it will make tests less flappy.  


![image](https://github.com/user-attachments/assets/cbc65b22-aade-436b-b7b7-03be72b80e39)

