### PR TITLE
Show progress during the process

### DIFF
--- a/lib/tasks/load_lb_checksums.rake
+++ b/lib/tasks/load_lb_checksums.rake
@@ -23,7 +23,7 @@ namespace :child_objects do
       end
     end
     Rails.logger.info("Number of child objects in files processed: #{processed_child_objects_count}")
-    Rails.logger.info("Number of child objects not found: #{child_objects_not_found&.size}")
+    Rails.logger.info("Number of child objects not found: #{child_objects_not_found&.count}")
     Rails.logger.info("OIDs of child objects not found: #{child_objects_not_found}")
   end
 end

--- a/lib/tasks/load_lb_checksums.rake
+++ b/lib/tasks/load_lb_checksums.rake
@@ -9,6 +9,7 @@ namespace :child_objects do
       Rails.logger.info("Number of child objects in file: #{File.read(file).each_line.count}")
       open(file) do |f|
         f.each do |line|
+          Rails.logger.info("Number of processed children: #{processed_child_objects_count}")
           fields = Hash[headers.zip(line.strip.split("\t"))]
           child_object = ChildObject.find_by(oid: fields['child_oid'])
           child_objects_not_found << fields['child_oid'] if child_object.nil?
@@ -22,7 +23,7 @@ namespace :child_objects do
       end
     end
     Rails.logger.info("Number of child objects in files processed: #{processed_child_objects_count}")
-    Rails.logger.info("Number of child objects not found: #{child_objects_not_found.size}")
+    Rails.logger.info("Number of child objects not found: #{child_objects_not_found&.size}")
     Rails.logger.info("OIDs of child objects not found: #{child_objects_not_found}")
   end
 end

--- a/lib/tasks/load_lb_checksums.rake
+++ b/lib/tasks/load_lb_checksums.rake
@@ -6,13 +6,14 @@ namespace :child_objects do
     processed_child_objects_count = 0
     child_objects_not_found = []
     Dir[args[:files_glob]].each do |file|
-      Rails.logger.info("Number of child objects in file: #{File.read(file).each_line.count}")
+      line_count = File.read(file).each_line.count
+      Rails.logger.info("Number of child objects in file: #{line_count}")
       open(file) do |f|
         f.each do |line|
           Rails.logger.info("Number of processed children: #{processed_child_objects_count}")
           fields = Hash[headers.zip(line.strip.split("\t"))]
           child_object = ChildObject.find_by(oid: fields['child_oid'])
-          child_objects_not_found << fields['child_oid'] if child_object.nil?
+          child_objects_not_found << fields['child_oid'].to_s if child_object.nil?
           next unless child_object
           child_object.md5_checksum = fields['md5']
           child_object.sha256_checksum = fields['sha256']


### PR DESCRIPTION
# Summary
When running the child object load checksums from ladybird task the first log would appear and then the long wait before the next log caused an assumption that no progress was being made.  This addition will track progress as child objects are processed and ensure the job is actively working.

# Related Ticket
[#2963](https://github.com/yalelibrary/YUL-DC/issues/2963)