### PR TITLE
Add message to Problem report if there are more than 1000 problem children

### DIFF
--- a/app/models/problem_report.rb
+++ b/app/models/problem_report.rb
@@ -9,16 +9,15 @@ class ProblemReport < ApplicationRecord
     start_generating
     csv_rows = problem_children_csv
     parent_oids = Set.new
-    child_cnt = 0
     output_csv = CSV.generate do |csv|
       csv << child_problem_headers
       csv_rows.each do |row|
         csv << row
-        child_cnt += 1
         parent_oids << row[1]
       end
     end
-    save_results(parent_oids.count, child_cnt)
+    total_child_cnt = ChildObject.select(:oid).where('height is NULL or height = 0 or width is NULL or width = 0').count
+    save_results(parent_oids.count, total_child_cnt)
     report_complete(output_csv, send_email)
   rescue => e
     report_error("CSV generation failed due to #{e.message}")

--- a/app/views/problem_report_mailer/problem_report_email.html.erb
+++ b/app/views/problem_report_mailer/problem_report_email.html.erb
@@ -9,6 +9,9 @@
   <strong>Total Child Count:</strong> <%= @problem_report.child_count %><br />
   <strong>Problem Parent Count:</strong> <%= @problem_report.problem_parent_count %><br />
   <strong>Problem Child Count:</strong> <%= @problem_report.problem_child_count %><br />
+  <% if @problem_report.problem_child_count > 1000 %>
+    <strong>Warning: Only the first 1000 problem children will be in the spreadsheet.</strong>
+  <% end %>
 </p>
 <p>Have a great day!</p>
 <small>

--- a/app/views/problem_report_mailer/problem_report_email.text.erb
+++ b/app/views/problem_report_mailer/problem_report_email.text.erb
@@ -8,6 +8,9 @@ This report is for the DCS site: <%= ENV['BLACKLIGHT_BASE_URL'] %>.
   Total Child Count: <%= @problem_report.child_count %>
   Problem Parent Count: <%= @problem_report.problem_parent_count %>
   Problem Child Count: <%= @problem_report.problem_child_count %>
+<% if @problem_report.problem_child_count > 1000 %>
+  Warning: Only the first 1000 problem children will be in the spreadsheet.
+<% end %>
 
 Have a great day!
 This is an automated message.

--- a/spec/factories/problem_reports.rb
+++ b/spec/factories/problem_reports.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     parent_count { 1 }
     problem_parent_count { 1 }
     problem_child_count { 1 }
+    updated_at { "test" }
   end
 end

--- a/spec/views/problem_reports/problem_report_email.html.erb_spec.rb
+++ b/spec/views/problem_reports/problem_report_email.html.erb_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "problem_report_mailer/problem_report_email", type: :view do
+  let(:problem_report) { FactoryBot.create(:problem_report) }
+  it "renders a warning about problem count" do
+    problem_report.problem_child_count = 1001
+    @problem_report = problem_report
+    render
+    expect(rendered).to have_content "Warning: Only the first 1000 problem children will be in the spreadsheet"
+  end
+
+  it "renders a warning about problem count" do
+    problem_report.problem_child_count = 999
+    @problem_report = problem_report
+    render
+    expect(rendered).not_to have_content "Warning: Only the first 1000 problem children will be in the spreadsheet"
+  end
+end

--- a/spec/views/problem_reports/problem_report_email.html.erb_spec.rb
+++ b/spec/views/problem_reports/problem_report_email.html.erb_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe "problem_report_mailer/problem_report_email", type: :view do
   let(:problem_report) { FactoryBot.create(:problem_report) }
-  it "renders a warning about problem count" do
+  it "renders a warning about problem count when > 1000" do
     problem_report.problem_child_count = 1001
     @problem_report = problem_report
     render
     expect(rendered).to have_content "Warning: Only the first 1000 problem children will be in the spreadsheet"
   end
 
-  it "renders a warning about problem count" do
+  it "does not render a warning about problem count when <= 1000" do
     problem_report.problem_child_count = 999
     @problem_report = problem_report
     render


### PR DESCRIPTION
Adds `Warning: Only the first 1000 problem children will be in the spreadsheet.` if there are more than 1000 problem children.