### PR TITLE
Add more parallels for faster tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           POSTGRES_PASSWORD: password
       - image: seleniarm/standalone-chromium:latest
         name: chrome    
-    parallelism: 4
+    parallelism: 6
     executor: docker/docker
     steps:
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           POSTGRES_PASSWORD: password
       - image: seleniarm/standalone-chromium:latest
         name: chrome    
-    parallelism: 6
+    parallelism: 8
     executor: docker/docker
     steps:
       - setup_remote_docker


### PR DESCRIPTION
# Summary
Load of tests appears to be overwhelming database cleaner gem and it was not clearing records correctly.  This splits the tests into smaller groups to increase clear avenues for tests to use.