### PR TITLE
Correct styling and pagination

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -120,6 +120,10 @@ DEFAULT DESKTOP STYLING
   }
 }
 
+.dt-paging {
+  padding-top: .25rem;
+}
+
 .clear-filters-button {
   margin-right: 8px
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -201,6 +201,8 @@ $( document ).on('turbolinks:load', function() {
       // Check dataTables documentation to learn more about
       // available options.
       initComplete: function () {
+        $('.dt-info').appendTo('.main-content');
+        $('.dt-paging').appendTo('.main-content');
         if (hasSearch) onColumnsUpdate(this);
       },
       stateLoaded: function (e, setting, data) {

--- a/app/views/management/_service_display.html.erb
+++ b/app/views/management/_service_display.html.erb
@@ -2,7 +2,7 @@
 <div class="container">
   <h3> Containers </h3>
   <table class="table table-bordered table-responsive table-striped" aria-label="Containers">
-    <thead class="thead-dark">
+    <thead class="table-dark">
       <tr>
         <th scope="col"> Service </th>
         <th scope="col"> Docker Repository </th>
@@ -31,7 +31,7 @@
   </table>
   <h3> Base URLs</h3>
     <table class="table table-bordered table-responsive table-striped" aria-label="Base URLs">
-      <thead class="thead-dark">
+      <thead class="table-dark">
       <tr>
         <th scope="col"> Service </th>
         <th scope="col"> URL </th>
@@ -60,7 +60,7 @@
   </table>
     <h3> Storage </h3>
     <table class="table table-bordered table-responsive table-striped" aria-label="Storage">
-      <thead class="thead-dark">
+      <thead class="table-dark">
       <tr>
         <th scope="col"> Service </th>
         <th scope="col"> Name </th>


### PR DESCRIPTION
# Summary
During bootstrap 5 upgrade a few changes were needed - one to adjust the table heading class and another to move the pagination out of the datatable.

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)