### PR TITLE
Integrity Check Errors

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -128,7 +128,7 @@ class ChildObject < ApplicationRecord
   end
 
   def access_file_size
-    File.size(access_master_path)
+    File.exist?(access_master_path) ? File&.size(access_master_path) : nil
   end
 
   def remote_access_master_path

--- a/app/models/concerns/integrity_checkable.rb
+++ b/app/models/concerns/integrity_checkable.rb
@@ -26,18 +26,13 @@ module IntegrityCheckable
 
         add_admin_set_to_bp(sets, co)
 
-        if co.access_master_exists?
-          if co&.file_size&.positive?
-            if co&.checksum_matches?
-              co.parent_object.processing_event("Integrity check complete for Child Object: #{co.oid}", 'review-complete')
-              co.processing_event("Child Object: #{co.oid} - file exists and checksum matches.", 'review-complete')
-            else
-              co.parent_object.processing_event("Integrity check complete for Child Object: #{co.oid}", 'failed')
-              co.processing_event("The Child Object: #{co.oid} - has a checksum mismatch. The checksum of the image file saved to this child oid does not match the checksum of the image file in the database. This may mean that the image has been corrupted. Please verify integrity of image for Child Object: #{co.oid} - by manually comparing the checksum values and update record as necessary.", 'failed')
-            end
+        if co.access_master_exists? 
+          if co&.checksum_matches?
+            co.parent_object.processing_event("Integrity check complete for Child Object: #{co.oid}", 'review-complete')
+            co.processing_event("Child Object: #{co.oid} - file exists and checksum matches.", 'review-complete')
           else
             co.parent_object.processing_event("Integrity check complete for Child Object: #{co.oid}", 'failed')
-            co.processing_event("Child Object: #{co.oid} - has a file size of 0. Please verify image for Child Object: #{co.oid}.", 'failed')
+            co.processing_event("The Child Object: #{co.oid} - has a checksum mismatch. The checksum of the image file saved to this child oid does not match the checksum of the image file in the database. This may mean that the image has been corrupted. Please verify integrity of image for Child Object: #{co.oid} - by manually comparing the checksum values and update record as necessary.", 'failed')
           end
         else
           co.parent_object.processing_event("Integrity check complete for Child Object: #{co.oid}", 'failed')

--- a/app/models/concerns/integrity_checkable.rb
+++ b/app/models/concerns/integrity_checkable.rb
@@ -26,7 +26,7 @@ module IntegrityCheckable
 
         add_admin_set_to_bp(sets, co)
 
-        if co.access_master_exists? 
+        if co.access_master_exists?
           if co&.checksum_matches?
             co.parent_object.processing_event("Integrity check complete for Child Object: #{co.oid}", 'review-complete')
             co.processing_event("Child Object: #{co.oid} - file exists and checksum matches.", 'review-complete')


### PR DESCRIPTION
## Summary  
Removed conditional for a file size of 0 since not all objects have a file_size. file_size is only present on ladybird objects and objects that have ran through the Update512ChecksumJob. File presence is checked through `access_master_exists?`  
  
"File not found" errors on demo are valid. File presence checks work on UAT when tifs are located in the expected location. 