### PR TITLE
Adds CSP overrides for edit and show

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -8,6 +8,15 @@ class BatchProcessesController < ApplicationController
   before_action :latest_failure, only: [:show_parent]
   before_action :set_child_object, only: [:show_child]
 
+  # Allows FontAwesome icons to render in header
+  content_security_policy(only: [:index, :show]) do |policy|
+    policy.script_src :self, :unsafe_inline
+    policy.script_src_attr  :self, :unsafe_inline
+    policy.script_src_elem  :self, :unsafe_inline
+    policy.style_src :self, :unsafe_inline
+    policy.style_src_elem :self, :unsafe_inline
+  end
+  
   def index
     @batch_process = BatchProcess.new
     # force user to choose action in form

--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -16,7 +16,7 @@ class BatchProcessesController < ApplicationController
     policy.style_src :self, :unsafe_inline
     policy.style_src_elem :self, :unsafe_inline
   end
-  
+
   def index
     @batch_process = BatchProcess.new
     # force user to choose action in form

--- a/app/controllers/child_objects_controller.rb
+++ b/app/controllers/child_objects_controller.rb
@@ -6,7 +6,7 @@ class ChildObjectsController < ApplicationController
   load_and_authorize_resource except: [:new, :create, :update_checksum]
 
   # Allows FontAwesome icons to render on child object datatable
-  content_security_policy(only: :index) do |policy|
+  content_security_policy(only: [:index, :show, :edit]) do |policy|
     policy.script_src :self, :unsafe_inline
     policy.script_src_attr  :self, :unsafe_inline
     policy.script_src_elem  :self, :unsafe_inline

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -7,7 +7,7 @@ class ParentObjectsController < ApplicationController
   load_and_authorize_resource except: [:solr_document, :new, :create, :update_metadata, :all_metadata, :reindex, :select_thumbnail, :update_manifests, :update_digital_objects]
 
   # Allows FontAwesome icons to render on datatable and show pages
-  content_security_policy(only: [:index, :show]) do |policy|
+  content_security_policy(only: [:index, :show, :edit]) do |policy|
     policy.script_src :self, :unsafe_inline
     policy.script_src_attr  :self, :unsafe_inline
     policy.script_src_elem  :self, :unsafe_inline


### PR DESCRIPTION
# Summary
CSP config blocked Font Awesome icon in header from loading properly.  This adds override for CSP for batch process, child object, and parent object pages.

# Related Ticket
https://github.com/yalelibrary/YUL-DC/issues/2977

# Screenshots

<details> 

## Before
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/bf799789-0395-4a95-95f9-ab9d4d27fac4" />



## After
<img width="1386" alt="image" src="https://github.com/user-attachments/assets/e8c4a7e7-819c-4384-bd64-e12fb93bbf50" />



</details>