### PR TITLE
Adds back scroll on datatables

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -132,7 +132,7 @@ select.form-select {
   width: 7rem;
 }
 
-table.dataTable {
+.dt-container {
   max-height: calc(100vh - 360px);
 }
 

--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -133,7 +133,7 @@ select.form-select {
 }
 
 .dt-container {
-  max-height: calc(100vh - 360px);
+  max-height: calc(100vh - 225px);
 }
 
 table#batch-processes-datatable {


### PR DESCRIPTION
# Summary
During Bootstrap upgrade the scroll on datatables was lost. This adds back the scrolling capability and loads datatables according to view height of the users window.

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshot
<img width="1379" alt="image" src="https://github.com/user-attachments/assets/886db83b-eb16-4b30-a847-4f1eccae7e13" />
