### PR TITLE
Make header row on datatables sticky

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -55,6 +55,11 @@ DEFAULT DESKTOP STYLING
   }
 }
 
+.table-head {
+  position: sticky;
+  top: 50px;
+}
+
 .table-head th {
   background-color: $table_head;
   color: $white;


### PR DESCRIPTION
# Summary
Makes header row sticky on datatables.

# Related Ticket
[#3026](https://github.com/yalelibrary/YUL-DC/issues/3026)

# Screenshot
<img width="688" alt="image" src="https://github.com/user-attachments/assets/bd00f116-472c-4dfa-ab33-dcd1ef7c8d68" />
