### PR TITLE
Fix rows on parent edit page

### DIFF
--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -119,3 +119,9 @@ DEFAULT DESKTOP STYLING
 .update-item-button {
   color: $black;
 }
+
+.form-row {
+  display: flex;
+  flex-flow: nowrap;
+  column-gap: 10px;
+}


### PR DESCRIPTION
# Summary
Restores parent edit page back to pre bootstrap upgrade formatting

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshots

<details>

## Before fix / post upgrade
<img width="900" alt="image" src="https://github.com/user-attachments/assets/9cb682ad-d453-4cde-b866-e21cc6d8119c" />


## After fix
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/2d913441-13ba-463b-9dff-777d72a137dc" />


</details>