### PR TITLE
Prevents floating of sticky header

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -57,7 +57,7 @@ DEFAULT DESKTOP STYLING
 
 .table-head {
   position: sticky;
-  top: 50px;
+  top: 0;
 }
 
 .table-head th {


### PR DESCRIPTION
# Summary
Locks sticky header at top of div instead of floating in table.

# Related Ticket
[#3026](https://github.com/yalelibrary/YUL-DC/issues/3026)

# Screenshot
<img width="1387" alt="image" src="https://github.com/user-attachments/assets/13c024b9-49c7-4c96-8626-6bc0366a179d" />
