### PR TITLE
Fixes styling for tables

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -42,6 +42,10 @@ DEFAULT DESKTOP STYLING
   word-wrap: break-word;
 }
 
+#batch-process-datatable {
+  width: 100%;
+}
+
 .col.overflow-auto {
   padding: 0;
 }

--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -37,6 +37,11 @@ DEFAULT DESKTOP STYLING
   margin: 0;
 }
 
+#parent-objects-datatable {
+  table-layout: fixed !important;
+  word-wrap: break-word;
+}
+
 .col.overflow-auto {
   padding: 0;
 }
@@ -69,7 +74,7 @@ DEFAULT DESKTOP STYLING
 }
 
 .is-datatable .row > th {
-  width: 170px;
+  width: 200px;
 }
 
 .is-datatable #search-row {

--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -37,7 +37,7 @@ DEFAULT DESKTOP STYLING
   margin: 0;
 }
 
-#parent-objects-datatable {
+#parent-objects-datatable, #child-objects-datatable {
   table-layout: fixed !important;
   word-wrap: break-word;
 }

--- a/app/assets/stylesheets/parent_objects.scss
+++ b/app/assets/stylesheets/parent_objects.scss
@@ -125,3 +125,9 @@ DEFAULT DESKTOP STYLING
   flex-flow: nowrap;
   column-gap: 10px;
 }
+
+.pre-scrollable {
+  max-height: 400px;
+  overflow-y: auto;
+  overflow-x: auto;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -97,6 +97,8 @@ $( document ).on('turbolinks:load', function() {
       return colVisibilityMap;
     }
 
+    console.log(columns);
+    console.log(columns.slice(1).map((x, index) => index + 1));
     var oldExportAction = function (self, e, dt, button, config) {
       if (button[0].className.indexOf('buttons-csv') >= 0) {
         if ($.fn.dataTable.ext.buttons.csvHtml5.available(dt, config)) {
@@ -152,6 +154,10 @@ $( document ).on('turbolinks:load', function() {
       },
       "pagingType": "full_numbers",
       "bAutoWidth": false, // AutoWidth has issues with hiding and showing columns as startup
+      columnDefs: [
+        { "width": "250px", "targets": [0] },
+        { "width": "200px", "targets": columns.slice(1).map((x, index) => index + 1) } // every column except the first one
+      ],
       "columns": columns,
       "order": columnOrder(columns),
       "lengthMenu": [[50, 100, 500], [50, 100, 500]],

--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -9,7 +9,7 @@
 <div class='row datatable'>
   <div class='col overflow-auto'>
     <table id='permission-requests-datatable' class='is-datatable table table-responsive table-bordered table-striped' aria-label='Permission Requests' data-source='<%= permission_requests_path(format: :json) %>'>
-      <thead class='thead-dark'>
+      <thead class='table-head'>
         <tr>
           <th scope='col'> Request ID </th>
           <th scope='col'> Permission Set Label </th>


### PR DESCRIPTION
# Summary
After bootstrap upgrade additional styling fixes were needed.
- change table header on permission requests page to dark theme
- change column width on parent and child datatable to allow icons to be inline with oid
- fix y-scroll for json and solr sections on parent object show page
- fix to have no x-scroll on batch process show page


# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshots

<details>

<img width="1321" alt="image" src="https://github.com/user-attachments/assets/8de5fca5-f672-4779-a517-bbffda4b0da2" />

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/5e4c9a65-348d-4f07-bf2f-eb7bb592f796" />

<img width="1364" alt="image" src="https://github.com/user-attachments/assets/0605c313-9ff8-4562-a197-0cb7c48c4711" />

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/56283fe7-f2fc-45d4-b8a8-79e45869623c" />


</details>