### PR TITLE
Restore link and datatable styling

### DIFF
--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -172,3 +172,29 @@ table#batch-processes-datatable {
 #parent-object-versions-table .fa-external-link-alt {
   margin-left: 10px;
 }
+
+span.dt-column-order::before, span.dt-column-order::after {
+  opacity: 0.125;
+  line-height: 9px;
+  font-size: 0.8em;
+}
+
+span.dt-column-order::after {
+  content: "\25BC";
+  content: "\25BC"/"";
+  float: right;
+}
+
+span.dt-column-order::before {
+  content: "\25B2";
+  content: "\25B2"/"";
+  float: right;
+}
+
+.dt-orderable-desc[aria-sort="descending"] span.dt-column-order::after {
+  opacity: 1;
+}
+
+.dt-orderable-desc[aria-sort="ascending"] span.dt-column-order::before {
+  opacity: 1;
+}

--- a/app/assets/stylesheets/datatable_pages.scss
+++ b/app/assets/stylesheets/datatable_pages.scss
@@ -103,6 +103,11 @@ DEFAULT DESKTOP STYLING
   a {
     font-family: $standard_font_family;
     font-size: 18px;
+    text-decoration: none;
+  }
+
+  a:active, a:focus, a:hover {
+    text-decoration: underline;
   }
 }
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -146,6 +146,7 @@ $( document ).on('turbolinks:load', function() {
 
     dataTable = $('.is-datatable').dataTable({
       "deferLoading":true,
+      "ordering": true,
       "processing": true,
       "serverSide": true,
       "stateSave": true,


### PR DESCRIPTION
# Summary
Adds back arrows to datatables and removes underlines from not active links.

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshots
<img width="909" alt="image" src="https://github.com/user-attachments/assets/2da95a04-34bc-4087-b286-e41180cd9f55" />
<img width="792" alt="image" src="https://github.com/user-attachments/assets/8eb551fc-4511-46a0-83ba-bb1f4e91b823" />
