### PR TITLE
Adds CSP exceptions for font awesome icons

### DIFF
--- a/app/controllers/activity_stream_logs_controller.rb
+++ b/app/controllers/activity_stream_logs_controller.rb
@@ -9,7 +9,7 @@ class ActivityStreamLogsController < ApplicationController
     policy.style_src :self, :unsafe_inline
     policy.style_src_elem :self, :unsafe_inline
   end
- 
+
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable SafeNavigationChain
   def index

--- a/app/controllers/activity_stream_logs_controller.rb
+++ b/app/controllers/activity_stream_logs_controller.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class ActivityStreamLogsController < ApplicationController
+  # Allows FontAwesome icons to render
+  content_security_policy(only: :index) do |policy|
+    policy.script_src :self, :unsafe_inline
+    policy.script_src_attr  :self, :unsafe_inline
+    policy.script_src_elem  :self, :unsafe_inline
+    policy.style_src :self, :unsafe_inline
+    policy.style_src_elem :self, :unsafe_inline
+  end
+ 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable SafeNavigationChain
   def index

--- a/app/controllers/admin_sets_controller.rb
+++ b/app/controllers/admin_sets_controller.rb
@@ -5,7 +5,7 @@ class AdminSetsController < ApplicationController
   before_action :set_admin_set, only: [:show, :edit, :update, :destroy]
 
   # Allows FontAwesome icons to render
-  content_security_policy(only: :index) do |policy|
+  content_security_policy(only: [:index, :show]) do |policy|
     policy.script_src :self, :unsafe_inline
     policy.script_src_attr  :self, :unsafe_inline
     policy.script_src_elem  :self, :unsafe_inline

--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -7,7 +7,7 @@ class ParentObjectsController < ApplicationController
   load_and_authorize_resource except: [:solr_document, :new, :create, :update_metadata, :all_metadata, :reindex, :select_thumbnail, :update_manifests, :update_digital_objects]
 
   # Allows FontAwesome icons to render on datatable and show pages
-  content_security_policy(only: [:index, :show, :edit]) do |policy|
+  content_security_policy(only: [:index, :show, :edit, :new]) do |policy|
     policy.script_src :self, :unsafe_inline
     policy.script_src_attr  :self, :unsafe_inline
     policy.script_src_elem  :self, :unsafe_inline


### PR DESCRIPTION
# Summary
Adds exceptions for a few more pages so that font awesome icons are not blocked by CSP configurations.

# Related Ticket
[#3057](https://github.com/yalelibrary/YUL-DC/issues/3057)

