### PR TITLE
Add rescue and retry to Preservica ingest

### DIFF
--- a/app/models/concerns/create_parent_object.rb
+++ b/app/models/concerns/create_parent_object.rb
@@ -14,6 +14,7 @@ module CreateParentObject
   def create_new_parent_csv
     self.admin_set = ''
     sets = admin_set
+    attempt_count = 0
     parsed_csv.each_with_index do |row, index|
       if row['digital_object_source'].present? && row['preservica_uri'].present? && !row['preservica_uri'].blank?
         begin
@@ -21,6 +22,11 @@ module CreateParentObject
           setup_for_background_jobs(parent_object, row['source'])
         rescue CsvRowParentService::BatchProcessingError => e
           batch_processing_event(e.message, e.kind)
+          next
+        rescue PreservicaImageService::PreservicaImageServiceNetworkError => e
+          batch_processing_event("Retrying row [#{index + 2}] #{e.message}.", "Retrying Row")
+          attempt_count += 1
+          retry if attempt_count < 4
           next
         rescue PreservicaImageService::PreservicaImageServiceError => e
           if e.message.include?("bad URI")

--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -27,19 +27,31 @@ class PreservicaImageService
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def image_list(representation_type)
     @images = []
+    attempt_count = 0
     begin
       if @pattern == :pattern_one
         structural_object = Preservica::StructuralObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)
         begin
           @information_objects = structural_object.information_objects
+        rescue Net::ReadTimeout => e
+          attempt_count += 1
+          retry if attempt_count < 4
+          raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         rescue Net::OpenTimeout, Errno::ECONNREFUSED => e
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end
       elsif @pattern == :pattern_two
-        @information_objects = [Preservica::InformationObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)]
+        begin
+          @information_objects = [Preservica::InformationObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)]
+        rescue Net::ReadTimeout => e
+          attempt_count += 1
+          retry if attempt_count < 4
+          raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
+        end
       end
     rescue StandardError => e
       # raise PreservicaImageServiceError.new("Unable to log in to Preservica", @uri.to_s)
@@ -57,6 +69,7 @@ class PreservicaImageService
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
 
   # rubocop:disable Layout/LineLength

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -240,4 +240,15 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     end.to change { ChildObject.count }.by(0)
   end
   # rubocop:enable Layout/LineLength
+
+  it 'can retry on Net::ReadTimeout with pattern 1' do
+    allow_any_instance_of(PreservicaImageService).to receive(:image_list).with('Preservation').and_raise(PreservicaImageService::PreservicaImageServiceNetworkError.new('Net::ReadTimeout',
+'sample.com/uri'))
+    expect do
+      batch_process.file = preservica_parent_with_children
+      batch_process.save
+      expect(batch_process.batch_ingest_events.count).to eq(4)
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Retrying row [2] Net::ReadTimeout for sample.com/uri.")
+    end.to change { ChildObject.count }.by(0)
+  end
 end


### PR DESCRIPTION
# Summary
On occasion, pulling images from Preservica takes a long time and a Net::ReadTimeout is received from the instance.  In this case the process should retry 3 times before ceasing operation.

# Related Ticket
[#3061](https://github.com/yalelibrary/YUL-DC/issues/3061) 