### PR TITLE
Alma Spec Update

### DIFF
--- a/spec/fixtures/activity_stream/page-0.json
+++ b/spec/fixtures/activity_stream/page-0.json
@@ -6,12 +6,28 @@
     "id": "http://metadata-api-test.library.yale.edu/metadatacloud/streams/activity/collection",
     "type": "OrderedCollection"
   },
-  "totalItems": 939920,
+  "totalItems": 939921,
   "orderedItems": [
     {
       "endTime": "2020-06-12T21:05:20.000+0000",
       "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:05:20.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/item/23233086230008651",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:05:20.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/holding/22233086240008651",
         "type": "Document"
       },
       "type": "Update"

--- a/spec/fixtures/activity_stream/page-1.json
+++ b/spec/fixtures/activity_stream/page-1.json
@@ -6,12 +6,28 @@
     "id": "http://metadata-api-test.library.yale.edu/metadatacloud/streams/activity/collection",
     "type": "OrderedCollection"
   },
-  "totalItems": 939920,
+  "totalItems": 939921,
   "orderedItems": [
     {
       "endTime": "2020-06-12T21:05:51.000+0000",
       "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:05:51.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/item/23233086230008651",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:05:51.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/holding/22233086240008651",
         "type": "Document"
       },
       "type": "Update"

--- a/spec/fixtures/activity_stream/page-2.json
+++ b/spec/fixtures/activity_stream/page-2.json
@@ -6,12 +6,28 @@
     "id": "http://metadata-api-test.library.yale.edu/metadatacloud/streams/activity/collection",
     "type": "OrderedCollection"
   },
-  "totalItems": 939920,
+  "totalItems": 939921,
   "orderedItems": [
     {
       "endTime": "2020-06-12T21:06:22.000+0000",
       "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:06:22.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/item/23233086230008651",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:06:22.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/holding/22233086240008651",
         "type": "Document"
       },
       "type": "Update"

--- a/spec/fixtures/activity_stream/page-3.json
+++ b/spec/fixtures/activity_stream/page-3.json
@@ -6,12 +6,28 @@
     "id": "http://metadata-api-test.library.yale.edu/metadatacloud/streams/activity/collection",
     "type": "OrderedCollection"
   },
-  "totalItems": 939920,
+  "totalItems": 939921,
   "orderedItems": [
     {
       "endTime": "2020-06-12T21:06:53.000+0000",
       "object": {
         "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/aspace/repositories/11/archival_objects/515305",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:06:53.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/item/23233086230008651",
+        "type": "Document"
+      },
+      "type": "Update"
+    },
+    {
+      "endTime": "2020-06-12T21:06:53.000+0000",
+      "object": {
+        "id": "http://metadata-api-test.library.yale.edu/metadatacloud/api/alma/holding/22233086240008651",
         "type": "Document"
       },
       "type": "Update"


### PR DESCRIPTION
# Summary
Adds fixtures and tests for sending digital objects with Alma as the metadata source.

# Related Ticket 
[#3093](https://github.com/yalelibrary/YUL-DC/issues/3093)