### PR TITLE
Ensure preservica information is saved to parent before sync

### DIFF
--- a/app/models/concerns/sync_from_preservica.rb
+++ b/app/models/concerns/sync_from_preservica.rb
@@ -85,7 +85,7 @@ module SyncFromPreservica
     elsif parent_object.preservica_uri.nil? && (row.present? && row['preservica_uri'].nil?)
       batch_processing_event("Parent OID: #{row['oid']} does not have a Preservica URI.  Please ensure Preservica URI is saved to parent or included in CSV.", 'Skipped Import')
       false
-    elsif !parent_object.digital_object_source.match(/preservica/i) && (row.present? && row['digital_object_source'].nil?)
+    elsif !parent_object.digital_object_source&.match(/preservica/i) && (row.present? && row['digital_object_source'].nil?)
       batch_processing_event("Parent OID: #{row['oid']} does not have a Preservica digital object source.  Please ensure Digital Object Source is saved to parent or included in CSV.",
 'Skipped Import')
       false

--- a/app/models/concerns/sync_from_preservica.rb
+++ b/app/models/concerns/sync_from_preservica.rb
@@ -85,7 +85,7 @@ module SyncFromPreservica
     elsif parent_object.preservica_uri.nil? && (row.present? && row['preservica_uri'].nil?)
       batch_processing_event("Parent OID: #{row['oid']} does not have a Preservica URI.  Please ensure Preservica URI is saved to parent or included in CSV.", 'Skipped Import')
       false
-    elsif (parent_object.digital_object_source != 'Preservica' || parent_object.digital_object_source != 'preservica') && (row.present? && row['digital_object_source'].nil?)
+    elsif !parent_object.digital_object_source.match(/preservica/i) && (row.present? && row['digital_object_source'].nil?)
       batch_processing_event("Parent OID: #{row['oid']} does not have a Preservica digital object source.  Please ensure Digital Object Source is saved to parent or included in CSV.",
 'Skipped Import')
       false

--- a/app/models/concerns/sync_from_preservica.rb
+++ b/app/models/concerns/sync_from_preservica.rb
@@ -82,14 +82,14 @@ module SyncFromPreservica
     elsif !parent_object.admin_set.preservica_credentials_verified
       batch_processing_event("Admin set #{parent_object.admin_set.key} does not have Preservica credentials set", 'Skipped Import')
       false
-    elsif parent_object.preservica_uri.nil? && row['preservica_uri'].nil?
+    elsif parent_object.preservica_uri.nil? && (row.present? && row['preservica_uri'].nil?)
       batch_processing_event("Parent OID: #{row['oid']} does not have a Preservica URI.  Please ensure Preservica URI is saved to parent or included in CSV.", 'Skipped Import')
       false
-    elsif (parent_object.digital_object_source != 'Preservica' || parent_object.digital_object_source != 'preservica') && row['digital_object_source'].nil?
+    elsif (parent_object.digital_object_source != 'Preservica' || parent_object.digital_object_source != 'preservica') && (row.present? && row['digital_object_source'].nil?)
       batch_processing_event("Parent OID: #{row['oid']} does not have a Preservica digital object source.  Please ensure Digital Object Source is saved to parent or included in CSV.",
 'Skipped Import')
       false
-    elsif parent_object.preservica_representation_type.nil? && row['preservica_representation_type'].nil?
+    elsif parent_object.preservica_representation_type.nil? && (row.present? && row['preservica_representation_type'].nil?)
       batch_processing_event("Parent OID: #{row['oid']} does not have a Preservica representation type.  Please ensure Preservica representation type is saved to parent or included in CSV.",
 'Skipped Import')
       false

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -112,7 +112,7 @@ module Updatable
       parent_object.reload
       trigger_setup_metadata(parent_object)
 
-      sync_from_preservica if parent_object.digital_object_source == 'Preservica' || parent_object.digital_object_source == 'preservica'
+      sync_from_preservica if /preservica/i.match?(parent_object.digital_object_source)
 
       processing_event_for_parent(parent_object)
     end

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -109,6 +109,7 @@ module Updatable
       end
 
       parent_object.update!(processed_fields)
+      parent_object.reload
       trigger_setup_metadata(parent_object)
 
       sync_from_preservica if parent_object.digital_object_source == 'Preservica' || parent_object.digital_object_source == 'preservica'

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -153,7 +153,7 @@
         <td class="key">Preservica Representation Type:</td>
         <td><%= @parent_object.preservica_representation_type %></td>
       </tr>
-      <% if @parent_object.digital_object_source == 'Preservica' || @parent_object.digital_object_source == 'preservica' %>
+      <% if @parent_object.digital_object_source.match(/preservica/i) %>
         <tr class='table-row'>
           <td class="key">Update from Preservica:</td>
           <td><%= link_to 'Synchronize child objects', sync_from_preservica_parent_object_path(@parent_object), method: :post, class: 'btn button update-item-button'%></td>

--- a/app/views/parent_objects/show.html.erb
+++ b/app/views/parent_objects/show.html.erb
@@ -153,7 +153,7 @@
         <td class="key">Preservica Representation Type:</td>
         <td><%= @parent_object.preservica_representation_type %></td>
       </tr>
-      <% if @parent_object.digital_object_source.match(/preservica/i) %>
+      <% if @parent_object.digital_object_source&.match(/preservica/i) %>
         <tr class='table-row'>
           <td class="key">Update from Preservica:</td>
           <td><%= link_to 'Synchronize child objects', sync_from_preservica_parent_object_path(@parent_object), method: :post, class: 'btn button update-item-button'%></td>


### PR DESCRIPTION
# Summary
During 'Edit' of parent object the preservica information was not saved to the parent yet and was failing the check for preservica information and therefor was not calling the `sync_from_preservica` method.  This PR will reload the parent after updating the fields so that this information is available for checking on the parent object.  Additionally, in the validation for the sync there was an assumption that a csv would be present and that is not the case in the 'Edit' workflow so a check was added for presence of the csv before checking the value of the preservica field.

# Related Ticket
[#3053](https://github.com/yalelibrary/YUL-DC/issues/3053)