### PR TITLE
Log additional job metrics to AWS Cloudwatch

### DIFF
--- a/app/lib/aws_metrics.rb
+++ b/app/lib/aws_metrics.rb
@@ -9,7 +9,7 @@ class AwsMetrics
   METRIC_DIMENSION_EVENT = 'JobEvent'
   METRIC_FEATURE_FLAG = '|AWS_METRICS|'
   # Class names of jobs allowed to generate metrics
-  LOGGABLE_JOBS = %w[SolrIndexJob SyncFromPreservicaJob GeneratePdfJob GeneratePtiffJob GenerateManifestJob ActivityStreamJob ProblemReportJob].freeze
+  LOGGABLE_JOBS = %w[SolrIndexJob SyncFromPreservicaJob GeneratePdfJob GeneratePtiffJob GenerateManifestJob ActivityStreamJob ProblemReportJob SetupMetadataJob UpdateAllMetadataJob].freeze
 
   def initialize
     @cloudwatch_client = Aws::CloudWatch::Client.new


### PR DESCRIPTION
Log SetupMetadataJob and UpdateAllMetadataJob to metrics.