### PR TITLE
Fix Setting of Child Object Count

### DIFF
--- a/app/models/concerns/create_parent_object.rb
+++ b/app/models/concerns/create_parent_object.rb
@@ -29,7 +29,7 @@ module CreateParentObject
           retry if attempt_count < 4
           next
         rescue PreservicaImageService::PreservicaImageServiceError => e
-          batch_processing_event("Skipping row [#{index + 2}] #{e.message}.", "Skipped Row")
+          batch_processing_event("Skipping row [#{(index.presence || 0) + 2}] #{e.message}.", "Skipped Row")
           next
         end
       else

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -166,8 +166,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       return self.child_object_count = 0 if ladybird_json["children"].empty? && parent_model != 'simple'
       upsert_child_objects(array_of_child_hashes)
     end
-
-    self.child_object_count = child_objects.size
+    self.child_object_count = ChildObject.where(parent_object_oid: oid).count
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/MethodLength

--- a/spec/models/preservica/preservica_sequential_add_sync_spec.rb
+++ b/spec/models/preservica/preservica_sequential_add_sync_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(File.exist?("spec/fixtures/images/access_primaries/00/03/20/00/00/00/200000003.tif")).to eq true
       expect(co_first.ptiff_conversion_at.present?).to be_truthy
       expect(po_first.child_objects.count).to eq 3
+      expect(po_first.child_object_count).to eq 3
 
       sync_batch_process = BatchProcess.new(batch_action: 'resync with preservica', user: user)
       expect do

--- a/spec/models/preservica/preservica_update_spec.rb
+++ b/spec/models/preservica/preservica_update_spec.rb
@@ -97,10 +97,14 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       co_first.preservica_content_object_uri = nil
       co_second.preservica_content_object_uri = nil
       co_third.preservica_content_object_uri = nil
+      co_first.sha512_checksum = '1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7'
+      co_second.sha512_checksum = '271e6e911a859151b063b9c8ab06861c566160ae1f6ea13e08fb17ff5b94982f226a9557e86560a2aaa1a8cc808e9fe8fe640880c3f6d13e69d6f636c3a5e2b0'
+      co_third.sha512_checksum = 'd6e3926fbe14fedbf3a568b6a5dbdb3e8b2312f217daa460a743559d41a688af4a7c701e7bac908fc7e3fd51c505fa01dad9eee96fcfd2666e92c648249edf02'
       co_first.save
       co_second.save
       co_third.save
       expect(po_first.last_preservica_update).not_to be nil
+      expect(po_first.child_object_count).to eq 3
       expect(co_first.preservica_content_object_uri).to be nil
 
       sync_batch_process = BatchProcess.new(batch_action: 'update parent objects', user: user)
@@ -108,6 +112,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         sync_batch_process.file = preservica_sync
         sync_batch_process.save!
       end.not_to change { ChildObject.count }
+      expect(po_first.child_object_count).to eq 3
       expect(po_first.iiif_manifest['items'].count).to eq 3
       expect(po_first.iiif_manifest['items'][0]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000001"
       expect(po_first.iiif_manifest['items'][1]['id']).to eq "http://localhost/manifests/oid/200000000/canvas/200000002"


### PR DESCRIPTION
# Summary
During some ingests the number of child objects was not being accurately saved to the parent object.  This PR updates how the child object count is set to provide more accurate child records from the database.

# Related Ticket
[#3157](https://github.com/yalelibrary/YUL-DC/issues/3157)