### PR TITLE
Update Docker Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,17 +16,16 @@ commands:
 
 jobs:
   build-and-push:
-    docker:
-      - image: yalelibraryit/dc-management
     executor: docker/docker
     steps:
       - setup_remote_docker
       - checkout
       - docker/check
-      - run: >
-          docker build <<parameters.image>>:<<parameters.from_tag>> <<parameters.image>>:<<parameters.to_tag>>
-      - run: >
-          docker push <<parameters.image>>:<<parameters.from_tag>> <<parameters.image>>:<<parameters.to_tag>>
+      - docker/build:
+          image: yalelibraryit/dc-blacklight
+          cache_from: yalelibraryit/dc-blacklight:main
+      - docker/push:
+          image: yalelibraryit/dc-blacklight
   run-tests:
     docker:
       # Image pulled from registry
@@ -129,7 +128,7 @@ jobs:
           tag: $CIRCLE_TAG
 
 orbs:
-  docker: circleci/docker@1.0.1
+  docker: circleci/docker@3.0.1
 version: 2.1
 workflows:
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
       - checkout
       - docker/check
       - docker/build:
-          image: yalelibraryit/dc-blacklight
-          cache_from: yalelibraryit/dc-blacklight:main
+          image: yalelibraryit/dc-management
+          cache_from: yalelibraryit/dc-management:main
       - docker/push:
-          image: yalelibraryit/dc-blacklight
+          image: yalelibraryit/dc-management
   run-tests:
     docker:
       # Image pulled from registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           tag: $CIRCLE_TAG
 
 orbs:
-  docker: circleci/docker@3.0.1
+  docker: circleci/docker@2.6.0
 version: 2.1
 workflows:
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,17 @@ commands:
 
 jobs:
   build-and-push:
+    docker:
+      - image: yalelibraryit/dc-management
     executor: docker/docker
     steps:
       - setup_remote_docker
       - checkout
       - docker/check
-      - docker/build:
-          image: yalelibraryit/dc-management
-          cache_from: yalelibraryit/dc-management:main
-      - docker/push:
-          image: yalelibraryit/dc-management
+      - run: >
+          docker build <<parameters.image>>:<<parameters.from_tag>> <<parameters.image>>:<<parameters.to_tag>>
+      - run: >
+          docker push <<parameters.image>>:<<parameters.from_tag>> <<parameters.image>>:<<parameters.to_tag>>
   run-tests:
     docker:
       # Image pulled from registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           tag: $CIRCLE_TAG
 
 orbs:
-  docker: circleci/docker@2.6.0
+  docker: circleci/docker@3.0.1
 version: 2.1
 workflows:
   commit:


### PR DESCRIPTION
# Summary
Updates docker orb for CircleCI to use newer run syntax instead of deprecated deploy syntax.  This PR removes a warning from the CircleCI dashboard.

# Related Ticket
[#3164](https://github.com/yalelibrary/YUL-DC/issues/3164)