### PR TITLE
Bump GoodJob version for error backtrace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,10 @@ gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bootstrap', '~> 5.3'
 gem 'coderay', '~> 1.1', '>= 1.1.3'
+# can remove concurrent-ruby pin after upgrade to Rails 7.1 - fixes https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
+gem 'concurrent-ruby', '1.3.4'
 gem 'devise'
 gem 'github_changelog_generator'
-gem 'good_job', '~> 3.17'
 gem 'honeybadger', '~> 4.0'
 gem 'http', '~> 5.1'
 gem 'iiif-presentation', '~> 1.0'
@@ -97,3 +98,5 @@ group :test do
   gem 'shoulda-matchers', '~> 4.0'
   gem 'timecop'
 end
+
+gem "good_job", "= 3.28.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,8 +170,8 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.6.20240107)
-    erubi (1.13.0)
-    et-orbi (1.2.11)
+    erubi (1.13.1)
+    et-orbi (1.3.0)
       tzinfo
     execjs (2.10.0)
     factory_bot (6.4.5)
@@ -194,7 +194,7 @@ GEM
       rake
     fiber-annotation (0.2.0)
     fiber-local (1.0.0)
-    fugit (1.11.1)
+    fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     geo_coord (0.2.0)
@@ -209,7 +209,7 @@ GEM
       rake (>= 10.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (3.22.0)
+    good_job (3.28.0)
       activejob (>= 6.0.0)
       activerecord (>= 6.0.0)
       concurrent-ruby (>= 1.0.2)
@@ -227,7 +227,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     iiif-presentation (1.3.0)
       activesupport (>= 3.2.18)
@@ -263,7 +263,7 @@ GEM
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    loofah (2.23.1)
+    loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -275,7 +275,7 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    minitest (5.25.4)
+    minitest (5.25.5)
     msgpack (1.7.2)
     multi_json (1.15.0)
     net-imap (0.4.20)
@@ -288,9 +288,9 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.18.9-x86_64-darwin)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     noticed (1.6.3)
       http (>= 4.0.0)
@@ -331,12 +331,12 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.14)
+    rack (2.2.17)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-proxy (0.7.7)
       rack
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rails (7.0.8.7)
       actioncable (= 7.0.8.7)
@@ -352,7 +352,7 @@ GEM
       activesupport (= 7.0.8.7)
       bundler (>= 1.15.0)
       railties (= 7.0.8.7)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -371,7 +371,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -506,7 +506,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   x86_64-darwin-21
@@ -525,6 +525,7 @@ DEPENDENCIES
   cancancan
   capybara (>= 2.15)
   coderay (~> 1.1, >= 1.1.3)
+  concurrent-ruby (= 1.3.4)
   coveralls_reborn
   daemons
   database_cleaner-active_record (~> 2.2.0)
@@ -532,7 +533,7 @@ DEPENDENCIES
   factory_bot_rails
   ffaker
   github_changelog_generator
-  good_job (~> 3.17)
+  good_job (= 3.28.0)
   honeybadger (~> 4.0)
   http (~> 5.1)
   iiif-presentation (~> 1.0)

--- a/db/migrate/20250915190648_create_good_job_execution_error_backtrace.rb
+++ b/db/migrate/20250915190648_create_good_job_execution_error_backtrace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionErrorBacktrace < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :error_backtrace)
+      end
+    end
+
+    add_column :good_job_executions, :error_backtrace, :text, array: true
+  end
+end

--- a/db/migrate/20250915190649_create_index_good_job_jobs_for_candidate_lookup.rb
+++ b/db/migrate/20250915190649_create_index_good_job_jobs_for_candidate_lookup.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_job_jobs_for_candidate_lookup)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 2025_05_28_222739) do
-
+ActiveRecord::Schema[7.0].define(version: 2025_09_15_190649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -169,6 +167,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_28_222739) do
     t.datetime "finished_at", precision: nil
     t.text "error"
     t.integer "error_event", limit: 2
+    t.text "error_backtrace", array: true
     t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
   end
 
@@ -216,6 +215,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_28_222739) do
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
@@ -282,12 +282,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_28_222739) do
     t.text "extent_of_full_text", default: "None"
     t.jsonb "sierra_json"
     t.datetime "last_sierra_update", precision: nil
-    t.string "sensitive_materials"
     t.jsonb "alma_json"
     t.datetime "last_alma_update"
     t.string "mms_id"
     t.string "alma_holding"
     t.string "alma_item"
+    t.string "sensitive_materials"
     t.index ["admin_set_id"], name: "index_parent_objects_on_admin_set_id"
     t.index ["alma_holding"], name: "index_parent_objects_on_alma_holding"
     t.index ["alma_item"], name: "index_parent_objects_on_alma_item"


### PR DESCRIPTION
# Summary
Upgrades to GoodJob v3.28.0 so as to include backtrace information on errors.

# Related Ticket
[#3031](https://github.com/yalelibrary/YUL-DC/issues/3031)

# Screenshots

<details>

<img width="1990" height="860" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/0a2edb33-fbbf-47bf-a6e0-c9f91579ce79" />


<img width="1978" height="1866" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/b5929df1-73b0-46a9-9d0c-dbe6e1d17bea" />


</details>