### PR TITLE
Fix Preservica Error Undefined Index

### DIFF
--- a/app/models/concerns/create_parent_object.rb
+++ b/app/models/concerns/create_parent_object.rb
@@ -29,7 +29,14 @@ module CreateParentObject
           retry if attempt_count < 4
           next
         rescue PreservicaImageService::PreservicaImageServiceError => e
-          batch_processing_event("Skipping row [#{(index.presence || 0) + 2}] #{e.message}.", "Skipped Row")
+          friendly_msg = if e.message.include?("bad URI")
+                           "The given URI does not match the URI of an entity in Preservica. Please make sure your URI is correct, starts with /structure-object/ or /information-object/, and includes no spaces or line breaks. ------------ Message from System: Skipping row [#{index + 2}] #{e.message}."
+                         elsif e.message.include?("entity.does.not.exist")
+                           "The given URI does not match the URI of an entity of this type in Preservica. Please make sure your Preservica URI and object structure type is correct. ------------ Message from System: Skipping row [#{index + 2}] #{e.message}."
+                         else
+                           e.message
+                         end
+          batch_processing_event("Skipping row [#{index + 2}] #{friendly_msg}.", "Skipped Row")
           next
         end
       else

--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -6,14 +6,7 @@ class PreservicaImageService
     # rubocop:disable Layout/LineLength
     def initialize(msg, id)
       @id = id
-      friendly_msg = if msg.include?("bad URI")
-                       "The given URI does not match the URI of an entity in Preservica. Please make sure your URI is correct, starts with /structure-object/ or /information-object/, and includes no spaces or line breaks. ------------ Message from System: Skipping row [#{index + 2}] #{msg}."
-                     elsif msg.include?("entity.does.not.exist")
-                       "The given URI does not match the URI of an entity of this type in Preservica. Please make sure your Preservica URI and object structure type is correct. ------------ Message from System: Skipping row [#{index + 2}] #{msg}."
-                     else
-                       msg
-                     end
-      super("#{friendly_msg} for #{id}")
+      super("#{msg} for #{id}")
     end
     # rubocop:enable Layout/LineLength
   end


### PR DESCRIPTION
# Summary
A move of messaging for preservica errors caused the undefined variable 'index' error in attempted preservica ingests.  This PR moves these messages back to where they know about index.

# Related Ticket
[#3031](https://github.com/yalelibrary/YUL-DC/issues/3031)