### PR TITLE
Update PO when CO updated

### DIFF
--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -227,7 +227,7 @@ class ChildObject < ApplicationRecord
   def queue_parent_metadata_update
     return unless parent_object.present?
     return unless caption_previously_changed? || label_previously_changed? || order_previously_changed?
-    
+
     parent_object.metadata_update = true
     parent_object.setup_metadata_job
   end

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -24,8 +24,8 @@ class ChildObject < ApplicationRecord
   # Does not get called because we use upsert to create children
   # before_create :check_for_size_and_file
 
-  # Queue parent metadata update when child object is successfully updated
-  after_update :queue_parent_metadata_update
+  # Queue parent manifest update when child object is successfully updated
+  after_update :queue_parent_manifest_update
 
   # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewinghint
   # These are added to the manifest on the canvas level
@@ -224,11 +224,10 @@ class ChildObject < ApplicationRecord
 
   private
 
-  def queue_parent_metadata_update
+  def queue_parent_manifest_update
     return unless parent_object.present?
     return unless caption_previously_changed? || label_previously_changed? || order_previously_changed?
-
-    parent_object.metadata_update = true
-    parent_object.setup_metadata_job
+    
+    GenerateManifestJob.perform_later(parent_object, nil, nil)
   end
 end # rubocop:enable  Metrics/ClassLength

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -23,6 +23,9 @@ class ChildObject < ApplicationRecord
 
   # Does not get called because we use upsert to create children
   # before_create :check_for_size_and_file
+  
+  # Queue parent metadata update when child object is successfully updated
+  after_update :queue_parent_metadata_update
 
   # Options from iiif presentation api 2.1 - see https://iiif.io/api/presentation/2.1/#viewinghint
   # These are added to the manifest on the canvas level
@@ -217,5 +220,14 @@ class ChildObject < ApplicationRecord
 
   def batch_connections_for(batch_process)
     batch_connections.where(batch_process: batch_process)
+  end
+
+  private
+
+  def queue_parent_metadata_update
+    return unless parent_object.present?
+    
+    parent_object.metadata_update = true
+    parent_object.setup_metadata_job
   end
 end # rubocop:enable  Metrics/ClassLength

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -227,10 +227,10 @@ class ChildObject < ApplicationRecord
   def queue_parent_manifest_update
     return unless parent_object.present?
     return unless caption_previously_changed? || label_previously_changed? || order_previously_changed?
-    
+
     # Don't trigger during batch operations - they handle manifest generation separately
     return if current_batch_process.present?
-    
+
     GenerateManifestJob.perform_later(parent_object, nil, nil)
   end
 end # rubocop:enable  Metrics/ClassLength

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -227,7 +227,7 @@ class ChildObject < ApplicationRecord
   def queue_parent_manifest_update
     return unless parent_object.present?
     return unless caption_previously_changed? || label_previously_changed? || order_previously_changed?
-    
+
     GenerateManifestJob.perform_later(parent_object, nil, nil)
   end
 end # rubocop:enable  Metrics/ClassLength

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -226,7 +226,8 @@ class ChildObject < ApplicationRecord
 
   def queue_parent_metadata_update
     return unless parent_object.present?
-
+    return unless caption_previously_changed? || label_previously_changed? || order_previously_changed?
+    
     parent_object.metadata_update = true
     parent_object.setup_metadata_job
   end

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -227,7 +227,10 @@ class ChildObject < ApplicationRecord
   def queue_parent_manifest_update
     return unless parent_object.present?
     return unless caption_previously_changed? || label_previously_changed? || order_previously_changed?
-
+    
+    # Don't trigger during batch operations - they handle manifest generation separately
+    return if current_batch_process.present?
+    
     GenerateManifestJob.perform_later(parent_object, nil, nil)
   end
 end # rubocop:enable  Metrics/ClassLength

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -228,7 +228,7 @@ class ChildObject < ApplicationRecord
     return unless parent_object.present?
     return unless caption_previously_changed? || label_previously_changed? || order_previously_changed?
 
-    # Don't trigger during batch operations - they handle manifest generation separately
+    # return if we are already in a BP.
     return if current_batch_process.present?
 
     GenerateManifestJob.perform_later(parent_object, nil, nil)

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -23,7 +23,7 @@ class ChildObject < ApplicationRecord
 
   # Does not get called because we use upsert to create children
   # before_create :check_for_size_and_file
-  
+
   # Queue parent metadata update when child object is successfully updated
   after_update :queue_parent_metadata_update
 
@@ -226,7 +226,7 @@ class ChildObject < ApplicationRecord
 
   def queue_parent_metadata_update
     return unless parent_object.present?
-    
+
     parent_object.metadata_update = true
     parent_object.setup_metadata_job
   end

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -42,32 +42,29 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
   end
 
   describe "updating a child object" do
-    it "queues parent metadata update when caption changes" do
-      expect(parent_object).to receive(:setup_metadata_job)
+    it "queues parent manifest update when caption changes" do
+      expect(GenerateManifestJob).to receive(:perform_later).with(parent_object, nil, nil)
       child_object.update(caption: "Updated caption")
-      expect(parent_object.metadata_update).to be true
     end
 
-    it "queues parent metadata update when label changes" do
-      expect(parent_object).to receive(:setup_metadata_job)
+    it "queues parent manifest update when label changes" do
+      expect(GenerateManifestJob).to receive(:perform_later).with(parent_object, nil, nil)
       child_object.update(label: "Updated label")
-      expect(parent_object.metadata_update).to be true
     end
 
-    it "queues parent metadata update when order changes" do
-      expect(parent_object).to receive(:setup_metadata_job)
+    it "queues parent manifest update when order changes" do
+      expect(GenerateManifestJob).to receive(:perform_later).with(parent_object, nil, nil)
       child_object.update(order: 5)
-      expect(parent_object.metadata_update).to be true
     end
 
-    it "does not queue parent metadata update when other fields change" do
-      expect(parent_object).not_to receive(:setup_metadata_job)
+    it "does not queue parent manifest update when other fields change" do
+      expect(GenerateManifestJob).not_to receive(:perform_later)
       child_object.update(width: 500)
-      expect(parent_object.metadata_update).to be_falsy
     end
 
-    it "does not queue parent metadata update when parent is missing" do
+    it "does not queue parent manifest update when parent is missing" do
       child_without_parent = described_class.new(oid: "999999")
+      expect(GenerateManifestJob).not_to receive(:perform_later)
       expect { child_without_parent.update(caption: "Updated caption") }.not_to raise_error
     end
   end

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       expect(GenerateManifestJob).not_to receive(:perform_later)
       expect { child_without_parent.update(caption: "Updated caption") }.not_to raise_error
     end
+
+    it "does not queue parent manifest update during batch operations" do
+      batch_process = FactoryBot.create(:batch_process, batch_action: 'update child objects caption and label')
+      child_object.current_batch_process = batch_process
+      expect(GenerateManifestJob).not_to receive(:perform_later)
+      child_object.update(caption: "Updated caption")
+    end
   end
 
   describe "a child object that already has a remote ptiff" do

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -41,6 +41,37 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
     end
   end
 
+  describe "updating a child object" do
+    it "queues parent metadata update when caption changes" do
+      expect(parent_object).to receive(:setup_metadata_job)
+      child_object.update(caption: "Updated caption")
+      expect(parent_object.metadata_update).to be true
+    end
+
+    it "queues parent metadata update when label changes" do
+      expect(parent_object).to receive(:setup_metadata_job)
+      child_object.update(label: "Updated label")
+      expect(parent_object.metadata_update).to be true
+    end
+
+    it "queues parent metadata update when order changes" do
+      expect(parent_object).to receive(:setup_metadata_job)
+      child_object.update(order: 5)
+      expect(parent_object.metadata_update).to be true
+    end
+
+    it "does not queue parent metadata update when other fields change" do
+      expect(parent_object).not_to receive(:setup_metadata_job)
+      child_object.update(width: 500)
+      expect(parent_object.metadata_update).to be_falsy
+    end
+
+    it "does not queue parent metadata update when parent is missing" do
+      child_without_parent = described_class.new(oid: "999999")
+      expect { child_without_parent.update(caption: "Updated caption") }.not_to raise_error
+    end
+  end
+
   describe "a child object that already has a remote ptiff" do
     around do |example|
       access_primary_mount = ENV["ACCESS_PRIMARY_MOUNT"]

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
     end
 
     it "does not queue parent manifest update during batch operations" do
-      batch_process = FactoryBot.create(:batch_process, batch_action: 'update child objects caption and label')
+      user = FactoryBot.create(:user)
+      batch_process = FactoryBot.create(:batch_process, batch_action: 'update child objects caption and label', user: user)
       child_object.current_batch_process = batch_process
       expect(GenerateManifestJob).not_to receive(:perform_later)
       child_object.update(caption: "Updated caption")


### PR DESCRIPTION
Caption and Label updates were not updating in Blacklight unless the PO went through a metadata update. This PR runs a PO metatdata/manifest update whenever a child object is updated. 