### PR TITLE
Adds Error Handling for Preservica Parent

### DIFF
--- a/app/models/concerns/create_parent_object.rb
+++ b/app/models/concerns/create_parent_object.rb
@@ -30,9 +30,11 @@ module CreateParentObject
           next
         rescue PreservicaImageService::PreservicaImageServiceError => e
           friendly_msg = if e.message.include?("bad URI")
-                           "The given URI does not match the URI of an entity in Preservica. Please make sure your URI is correct, starts with /structure-object/ or /information-object/, and includes no spaces or line breaks. ------------ Message from System: Skipping row [#{index + 2}] #{e.message}."
+                           "Unable to create parent. The given URI does not match the URI of an entity in Preservica. Please make sure your URI is correct, starts with /structure-object/ or /information-object/, and includes no spaces or line breaks. ------------ Message from System: Skipping row [#{index + 2}] #{e.message}."
+                         elsif e.message.include?("No Information Object with ref but there another type of entity with the ref")
+                           "Unable to create parent. Please check that the Preservica UUID is correct and points to a single directory in Preservica that contains only TIFF files. ------------ Message from System: Skipping row [#{index + 2}] #{e.message}."
                          elsif e.message.include?("entity.does.not.exist")
-                           "The given URI does not match the URI of an entity of this type in Preservica. Please make sure your Preservica URI and object structure type is correct. ------------ Message from System: Skipping row [#{index + 2}] #{e.message}."
+                           "Unable to create parent. The given URI does not match the URI of an entity of this type in Preservica. Please make sure your Preservica URI and object structure type is correct. ------------ Message from System: Skipping row [#{index + 2}] #{e.message}."
                          else
                            e.message
                          end

--- a/spec/models/preservica/preservica_parent_error_spec.rb
+++ b/spec/models/preservica/preservica_parent_error_spec.rb
@@ -120,24 +120,20 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     context 'with some credentials' do
       before do
         user.add_role(:administrator, permission_set)
-        allow_any_instance_of(BatchProcess).to receive(:create_new_parent_csv).and_raise(PreservicaImageService::PreservicaImageServiceError.new(
-"Request error 404 <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><ExtendedMessage>No Information Object with ref but there another type of entity with the ref</ExtendedMessage><MessageKey>entity.does.not.exist</MessageKey></Error> for /structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.", "/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5"
-))
-        # expect(batch_process).to receive(:create_new_parent_csv).and_raise(PreservicaImageService::PreservicaImageServiceError.new("Request error 404 <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><ExtendedMessage>No Information Object with ref but there another type of entity with the ref</ExtendedMessage><MessageKey>entity.does.not.exist</MessageKey></Error> for /structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.", "/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5"))
       end
-      after do
-        user.remove_role(:administrator, permission_set)
-      end
-      xit 'can send an error when the structural object id points to a folder containing a single folder NOT the expected folder containing TIFFs' do
-        expect(batch_process).to receive(:create_new_parent_csv).and_raise(PreservicaImageService::PreservicaImageServiceError.new(
+      it 'can send an error when the structural object id points to a folder containing a single folder NOT the expected folder containing TIFFs' do
+        allow_any_instance_of(PreservicaImageService).to receive(:image_list).and_raise(PreservicaImageService::PreservicaImageServiceError.new(
 "Request error 404 <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><ExtendedMessage>No Information Object with ref but there another type of entity with the ref</ExtendedMessage><MessageKey>entity.does.not.exist</MessageKey></Error> for /structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.", "/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5"
 ))
         expect do
           batch_process.file = preservica_parent_with_permission_set
           batch_process.save
-          expect(batch_process.batch_ingest_events.count).to eq(1)
-          expect(batch_process.batch_ingest_events[0].reason).to eq("Unable to create parent. Please check that the Preservica UUID is correct and points to a single directory in Preservica that contains only TIFF files. ------------ Message from System: Skipping row [2] Request error 404 <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><ExtendedMessage>No Information Object with ref but there another type of entity with the ref</ExtendedMessage><MessageKey>entity.does.not.exist</MessageKey></Error> for /structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5.")
         end.not_to change { ParentObject.count }
+        expect(batch_process.batch_ingest_events.count).to eq(1)
+        expect(batch_process.batch_ingest_events[0].reason).to eq("Skipping row [2] Unable to create parent. Please check that the Preservica UUID is correct and points to a single directory in Preservica that contains only TIFF files. ------------ Message from System: Skipping row [2] Request error 404 <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><ExtendedMessage>No Information Object with ref but there another type of entity with the ref</ExtendedMessage><MessageKey>entity.does.not.exist</MessageKey></Error> for /structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5. for /structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5..")
+      end
+      after do
+        user.remove_role(:administrator, permission_set)
       end
     end
     # rubocop:enable Layout/LineLength


### PR DESCRIPTION
# Summary
Adds a more detailed error message and another condition for responses returned from Preservica.

# Related Ticket
[#3169](https://github.com/yalelibrary/YUL-DC/issues/3169)