### PR TITLE
Skip ILS/Sierra Metadata Updates

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -404,7 +404,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
   def default_fetch(_current_batch_process = current_batch_process, _current_batch_connection = current_batch_connection)
-    # Skip metadata fetch for Sierra and ILS (Voyager) - they use existing metadata
+    # Skip metadata fetch for Sierra and ILS (Voyager)
     if ["sierra", "ils"].include?(authoritative_metadata_source&.metadata_cloud_name)
       processing_event("Metadata fetch skipped for #{authoritative_metadata_source.metadata_cloud_name} data source", "metadata-fetch-skipped")
       return true

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -404,16 +404,17 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
   def default_fetch(_current_batch_process = current_batch_process, _current_batch_connection = current_batch_connection)
+    # Skip metadata fetch for Sierra and ILS (Voyager) - they use existing metadata
+    if ["sierra", "ils"].include?(authoritative_metadata_source&.metadata_cloud_name)
+      processing_event("Metadata fetch skipped for #{authoritative_metadata_source.metadata_cloud_name} data source", "metadata-fetch-skipped")
+      return true
+    end
+
     fetch_results = case authoritative_metadata_source&.metadata_cloud_name
                     when "ladybird"
                       self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self)
-                    when "sierra"
-                      self.sierra_json = MetadataSource.find_by(metadata_cloud_name: "sierra").fetch_record(self)
                     when "alma"
                       self.alma_json = MetadataSource.find_by(metadata_cloud_name: "alma").fetch_record(self)
-                    when "ils"
-                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) unless bib.present?
-                      self.voyager_json = MetadataSource.find_by(metadata_cloud_name: "ils").fetch_record(self)
                     when "aspace"
                       self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) unless aspace_uri.present?
                       begin

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -32,4 +32,57 @@ RSpec.describe SetupMetadataJob, type: :job, prep_admin_sets: true, prep_metadat
       metadata_job.perform(parent_object, batch_process)
     end
   end
+
+  context 'metadata fetch skipping for Voyager and Sierra' do
+    let(:sierra_source) { MetadataSource.find_by(metadata_cloud_name: 'sierra') || FactoryBot.create(:metadata_source, metadata_cloud_name: 'sierra') }
+    let(:ils_source) { MetadataSource.find_by(metadata_cloud_name: 'ils') || FactoryBot.create(:metadata_source, metadata_cloud_name: 'ils') }
+    let(:alma_source) { MetadataSource.find_by(metadata_cloud_name: 'alma') || FactoryBot.create(:metadata_source, metadata_cloud_name: 'alma') }
+
+    it 'skips metadata fetch for Sierra data source' do
+      parent_object.authoritative_metadata_source = sierra_source
+      parent_object.save!
+      
+      allow(parent_object).to receive(:processing_event).and_call_original
+      allow(metadata_job).to receive(:setup_child_object_jobs)
+      
+      metadata_job.perform(parent_object, batch_process)
+      
+      expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for sierra data source", "metadata-fetch-skipped")
+    end
+
+    it 'skips metadata fetch for ILS (Voyager) data source' do
+      parent_object.authoritative_metadata_source = ils_source
+      parent_object.save!
+      
+      allow(parent_object).to receive(:processing_event).and_call_original
+      allow(metadata_job).to receive(:setup_child_object_jobs)
+      
+      metadata_job.perform(parent_object, batch_process)
+      
+      expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for ils data source", "metadata-fetch-skipped")
+    end
+
+    it 'does not skip metadata fetch for other data sources like Alma' do
+      parent_object.authoritative_metadata_source = alma_source
+      parent_object.save!
+      
+      expect(parent_object).not_to receive(:processing_event).with(/Metadata fetch skipped/, "metadata-fetch-skipped")
+      allow(metadata_job).to receive(:setup_child_object_jobs)
+      
+      metadata_job.perform(parent_object, batch_process)
+    end
+
+    it 'continues with normal job flow when metadata fetch is skipped' do
+      parent_object.authoritative_metadata_source = sierra_source
+      parent_object.save!
+      
+      allow(parent_object).to receive(:processing_event).and_call_original
+      allow(metadata_job).to receive(:setup_child_object_jobs).and_call_original
+      
+      metadata_job.perform(parent_object, batch_process)
+      
+      expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for sierra data source", "metadata-fetch-skipped")
+      expect(metadata_job).to have_received(:setup_child_object_jobs).with(parent_object, batch_process)
+    end
+  end
 end

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -41,46 +41,46 @@ RSpec.describe SetupMetadataJob, type: :job, prep_admin_sets: true, prep_metadat
     it 'skips metadata fetch for Sierra data source' do
       parent_object.authoritative_metadata_source = sierra_source
       parent_object.save!
-      
+
       allow(parent_object).to receive(:processing_event).and_call_original
       allow(metadata_job).to receive(:setup_child_object_jobs)
-      
+
       metadata_job.perform(parent_object, batch_process)
-      
+
       expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for sierra data source", "metadata-fetch-skipped")
     end
 
     it 'skips metadata fetch for ILS (Voyager) data source' do
       parent_object.authoritative_metadata_source = ils_source
       parent_object.save!
-      
+
       allow(parent_object).to receive(:processing_event).and_call_original
       allow(metadata_job).to receive(:setup_child_object_jobs)
-      
+
       metadata_job.perform(parent_object, batch_process)
-      
+
       expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for ils data source", "metadata-fetch-skipped")
     end
 
     it 'does not skip metadata fetch for other data sources like Alma' do
       parent_object.authoritative_metadata_source = alma_source
       parent_object.save!
-      
+
       expect(parent_object).not_to receive(:processing_event).with(/Metadata fetch skipped/, "metadata-fetch-skipped")
       allow(metadata_job).to receive(:setup_child_object_jobs)
-      
+
       metadata_job.perform(parent_object, batch_process)
     end
 
     it 'continues with normal job flow when metadata fetch is skipped' do
       parent_object.authoritative_metadata_source = sierra_source
       parent_object.save!
-      
+
       allow(parent_object).to receive(:processing_event).and_call_original
       allow(metadata_job).to receive(:setup_child_object_jobs).and_call_original
-      
+
       metadata_job.perform(parent_object, batch_process)
-      
+
       expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for sierra data source", "metadata-fetch-skipped")
       expect(metadata_job).to have_received(:setup_child_object_jobs).with(parent_object, batch_process)
     end

--- a/spec/lib/activity_stream_reader_spec.rb
+++ b/spec/lib/activity_stream_reader_spec.rb
@@ -351,8 +351,8 @@ RSpec.describe ActivityStreamReader, prep_metadata_sources: true, prep_admin_set
     end
 
     it "queues objects to be updated" do
-      # 3 parent objects
-      expect(SetupMetadataJob).to receive(:perform_later).thrice
+      # 2 parent objects. Skipping voyager since it's not fetched.
+      expect(SetupMetadataJob).to receive(:perform_later).twice
       described_class.update
     end
 
@@ -365,7 +365,7 @@ RSpec.describe ActivityStreamReader, prep_metadata_sources: true, prep_admin_set
       expect(ActivityStreamLog.last.retrieved_records).to eq 4 # 4 relevant records
       asr.process_activity_stream
       expect(ActivityStreamLog.count).to eq 2
-      expect(ActivityStreamLog.last.retrieved_records).to eq 3
+      expect(ActivityStreamLog.last.retrieved_records).to eq 2
     end
 
     context "with records setup for aspace, ils and alma" do
@@ -384,7 +384,7 @@ RSpec.describe ActivityStreamReader, prep_metadata_sources: true, prep_admin_set
         described_class.update
         expect(ActivityStreamLog.count).to eq 2
         expect(ActivityStreamLog.last.activity_stream_items).to be > 2000
-        expect(ActivityStreamLog.last.retrieved_records).to eq 3
+        expect(ActivityStreamLog.last.retrieved_records).to eq 2
       end
     end
 

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -339,7 +339,8 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           expect(po.visibility).to eq "Public"
           expect(po.rights_statement).to include "The use of this image may be subject to"
           expect(po.authoritative_metadata_source.display_name).to eq "Voyager"
-          expect(po.voyager_json.present?).to be_truthy
+          # Metadata fetch is skipped for ils (voyager)
+          expect(po.voyager_json).to be_nil
           expect(po.bib).to eq "1188135"
           expect(po.holding).to eq "1330141"
           expect(po.item).to eq nil

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -387,22 +387,13 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         expect(parent_object.container_grouping).to eq "Box 3 | Folder 24"
       end
 
-      it "pulls Voyager record from the MetadataCloud when the authoritative_metadata_source is changed to Voyager" do
+      it "skips Voyager metadata fetch when the authoritative_metadata_source is changed to Voyager" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq ladybird
         parent_object.authoritative_metadata_source_id = voyager
         parent_object.save!
         expect(parent_object.reload.authoritative_metadata_source_id).to eq voyager
-        expect(parent_object.voyager_json).not_to be nil
-      end
-
-      it "updates DependentObjects when the authoritative_metadata_source is changed to Voyager" do
-        parent_object.authoritative_metadata_source_id = voyager
-        parent_object.save!
-        expected_uris = ['/ils/bib/4113177', '/ils/holding/4482860', '/ils/item/8090926', '/ils/barcode/39002093768050'].to_set
-        expect(parent_object.reload.dependent_objects.count).to eq expected_uris.count
-        expect(parent_object.dependent_objects.all? { |dobj| dobj.metadata_source == 'ils' }).to be_truthy
-        uris = parent_object.dependent_objects.map(&:dependent_uri).to_set
-        expect(uris).to eq expected_uris
+        # Metadata fetch is skipped for ils (voyager)
+        expect(parent_object.voyager_json).to be nil
       end
 
       it "creates and has a count of ChildObjects" do
@@ -481,11 +472,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
     context "a newly created ParentObject with Voyager as authoritative_metadata_source" do
       let(:parent_object) { described_class.create(oid: "2004628", bib: '3163155', authoritative_metadata_source_id: voyager, admin_set: FactoryBot.create(:admin_set)) }
 
-      it "pulls from the MetadataCloud for Voyager" do
+      it "skips metadata fetch for Voyager (ils) source" do
         expect(parent_object.reload.authoritative_metadata_source_id).to eq voyager
         expect(parent_object.ladybird_json).to be nil
-        expect(parent_object.voyager_json).not_to be nil
-        expect(parent_object.voyager_json).not_to be_empty
+        expect(parent_object.voyager_json).to be nil
         expect(parent_object.aspace_json).to be nil
       end
 

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         parent_object.reload
         expect(parent_object.ladybird_json).not_to be_nil
         expect(parent_object.child_object_count).to eq 2
-        
+
         # Index to Solr
         parent_object.solr_index
         solr = SolrService.connection
@@ -410,26 +410,26 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
         original_solr_doc = response["response"]["docs"].first
         original_title = original_solr_doc["title_tesim"]
         expect(original_title).to eq(["The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1"])
-        
+
         # Generate manifest
         allow(parent_object).to receive(:manifest_completed?).and_return(true)
         parent_object.iiif_presentation.save
         manifest_content = S3Service.download(parent_object.iiif_presentation.manifest_path)
         expect(manifest_content).not_to be_nil
-        
+
         # Change source to ils - fetch is skipped but existing data should remain
         parent_object.authoritative_metadata_source_id = voyager
         parent_object.save!
-        
+
         # Verify source changed
         expect(parent_object.reload.authoritative_metadata_source_id).to eq voyager
-        
+
         # Verify Solr record still exists with ladybird data (unchanged)
         response = solr.get 'select', params: { q: "oid_ssi:#{parent_object.oid}" }
         expect(response["response"]["numFound"]).to eq 1
         updated_solr_doc = response["response"]["docs"].first
         expect(updated_solr_doc["title_tesim"]).to eq(original_title)
-        
+
         # Verify manifest still exists
         manifest_content_after = S3Service.download(parent_object.iiif_presentation.manifest_path)
         expect(manifest_content_after).not_to be_nil


### PR DESCRIPTION
## Summary  
Skip fetching metadata if object is ils or sierra. Solr, manifest, and pdf generation remains unchanged. 