### PR TITLE
Adds error handling to SolrReindexAllJob

### DIFF
--- a/app/jobs/solr_reindex_all_job.rb
+++ b/app/jobs/solr_reindex_all_job.rb
@@ -43,6 +43,7 @@ class SolrReindexAllJob < ApplicationJob
     end
     SolrService.clean_index_orphans if last_job
   rescue => e
+    SolrReindexAllJob.perform_later(start_position + parent_objects.count) unless last_job
     current_batch_process.batch_processing_event("SolrReindexAllJob failed due to #{e.message}", "failed")
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/jobs/solr_reindex_all_job.rb
+++ b/app/jobs/solr_reindex_all_job.rb
@@ -11,9 +11,14 @@ class SolrReindexAllJob < ApplicationJob
     500
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
   def perform(start_position = 0, current_batch_process = BatchProcess.new)
     solr = SolrService.connection
+    current_batch_process.user = User.system_user
+    current_batch_process.save!
     # Groups of limit
     parent_objects = ParentObject.order(:oid).offset(start_position).limit(SolrReindexAllJob.job_limit)
     last_job = parent_objects.count < SolrReindexAllJob.job_limit
@@ -24,6 +29,12 @@ class SolrReindexAllJob < ApplicationJob
           results, child_results = parent_object.to_solr_full_text
           child_documents += child_results unless child_results.nil?
           results
+                 rescue => e
+                   # rubocop:disable Lint/UselessAssignment
+                   current_batch_connection = parent_object.current_batch_connection
+                   # rubocop:enable Lint/UselessAssignment
+                   parent_object.processing_event("SolrReindexAllJob failed due to #{e.message} for parent object OID: #{parent_object.oid}.")
+                   return nil # if errors will convert parent to nil and compact later removes them
         end.compact)
         solr.commit
         reindex_child_documents(solr, child_documents)
@@ -34,7 +45,10 @@ class SolrReindexAllJob < ApplicationJob
   rescue => e
     current_batch_process.batch_processing_event("SolrReindexAllJob failed due to #{e.message}", "failed")
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def reindex_child_documents(solr, child_documents)
     child_documents.each_slice(SolrReindexAllJob.solr_batch_limit) do |child_documents_group|

--- a/app/models/concerns/delayable.rb
+++ b/app/models/concerns/delayable.rb
@@ -22,11 +22,11 @@ module Delayable
 "%SolrIndexJob%", "%#{self.class}/#{oid}", "%#{self.class}/#{oid}\n%")
   end
 
-  def solr_reindex_jobs
-    GoodJob::Job.where("job_class LIKE ?", "%SolrReindexAllJob%")
+  def active_solr_reindex_jobs
+    GoodJob::Job.where("finished_at IS NULL AND job_class LIKE ?", "%SolrReindexAllJob%")
   end
 
-  module_function :solr_reindex_jobs
+  module_function :active_solr_reindex_jobs
 
   def delayed_jobs_deletion
     delayed_jobs.destroy_all

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -109,7 +109,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.cannot_reindex
-    return true unless Delayable.solr_reindex_jobs.empty?
+    return true unless Delayable.active_solr_reindex_jobs.empty?
   end
 
   # Returns true if last_ladybird_update has changed from nil to some value, indicating initial ladybird fetch

--- a/spec/models/concerns/delayable_spec.rb
+++ b/spec/models/concerns/delayable_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Delayable, prep_metadata_sources: true, prep_admin_sets: true do
       expect(GoodJob::Job.count).to eq 3
       expect(parent_object.setup_metadata_jobs.count).to eq 1
       expect(parent_object.setup_metadata_jobs.first['job_class']).to eq('SetupMetadataJob')
-      expect(Delayable.solr_reindex_jobs.count).to eq 1
-      expect(Delayable.solr_reindex_jobs.first['job_class']).to eq('SolrReindexAllJob')
+      expect(Delayable.active_solr_reindex_jobs.count).to eq 1
+      expect(Delayable.active_solr_reindex_jobs.first['job_class']).to eq('SolrReindexAllJob')
     end
 
     it 'will destroy all jobs from a given parent object when the parent object is destroyed' do


### PR DESCRIPTION
# Summary
Adds error handling to SolrReindexAllJob and makes query method for that job more specific to only include jobs that have not yet completed, eliminating the inclusion of jobs that have failed or finished.

# Related Ticket
[#3204](https://github.com/yalelibrary/YUL-DC/issues/3204)  