### PR TITLE
Adds Guards to SolrReindexAllJob

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -779,10 +779,14 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
   # rubocop:enable Metrics/PerceivedComplexity
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def should_index?
-    return false if redirect_to.blank? && (child_object_count&.zero? || child_objects.empty?)
+    return false if (redirect_to.blank? && (child_object_count&.zero? || child_objects.empty?)) || (child_object_count&.zero? || child_objects.empty?)
     ['Public', 'Redirect', 'Yale Community Only', 'Open with Permission'].include?(visibility) || redirect_to.present?
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def should_create_manifest_and_pdf?
     !redirect_to.present?

--- a/spec/fixtures/aspace/AS-781087.json
+++ b/spec/fixtures/aspace/AS-781087.json
@@ -1,0 +1,81 @@
+{
+  ""jsonModelType": "ArchiveSpaceSolrRecord",
+  "source": "aspace",
+  "recordType": "archival_object",
+  "uri": "/aspace/repositories/12/archival_objects/781086",
+  "identifier": "/aspace/repositories/12/archival_objects/781086",
+  "localRecordNumber": "YCAL MSS 42",
+  "callNumber": "YCAL MSS 42",
+  "containerGrouping": "Box 25, folder 787-93",
+  "creator": [
+    "Wharton, Edith, 1862-1937"
+  ],
+  "title": [
+    "Grant, Robert"
+  ],
+  "date": [
+    "1905-39"
+  ],
+  "language": [
+    "English"
+  ],
+  "languageCode": [
+    "eng"
+  ],
+  "description": [
+
+  ],
+  "rights": [
+    "The Edith Wharton Collection is the physical property of the Beinecke Rare Book and Manuscript Library. Literary rights, including coyright, belong to the authors or their legal heirs or assigns. For further information, consult the appropriate curator.",
+    "The materials are open for research."
+  ],
+  "orbisBibId": "3435140",
+  "orbisBarcode": "39002075038423",
+  "findingAid": [
+    "http://hdl.handle.net/10079/fa/beinecke.wharton"
+  ],
+  "dateStructured": [
+    "1905/1939"
+  ],
+  "resourceType": "mixed materials",
+  "provenanceUncontrolled": "The collection was formed from gifts from the Edith Wharton Estate (1938-1939), Gaillard Lapsley (1938-1946), Oscar Lichtenberg (1959-1965), Percy Lubbock (1954), Georges Markow-Totevy (1980), and Louis Auchincloss (?), with smaller bequests from numerous other donors (especially John Hugh Smith and Margaret Chanler) and with purchases with Beinecke funds.",
+  "ancestorTitles": [
+    "Personal Correspondence",
+    "Edith Wharton collection (YCAL MSS 42)",
+    "Beinecke Rare Book and Manuscript Library (BRBL)"
+  ],
+  "ancestorDisplayStrings": [
+    "Series II: Personal Correspondence, Dates 1885-1937",
+    "Edith Wharton collection",
+    "Beinecke Rare Book and Manuscript Library (BRBL)"
+  ],
+  "ancestorIdentifiers": [
+    "/aspace/repositories/11/archival_objects/608166",
+    "/aspace/repositories/11/resources/1575",
+    "/aspace/repositories/11"
+  ],
+  "repository": "Beinecke Rare Book and Manuscript Library (BRBL)",
+  "createdBeginDate": [
+    "1905"
+  ],
+  "createdEndDate": [
+    "1939"
+  ],
+  "createdEarliestDate": "1905",
+  "archiveSpaceUri": "/repositories/12/archival_objects/781086",
+  "archivalSort": "00001.00038",
+  "dependentUris": [
+    "/aspace/repositories/11/top_containers/72818",
+    "/aspace/repositories/12/archival_objects/781086",
+    "/aspace/agents/people/62209",
+    "/aspace/repositories/11/archival_objects/608166",
+    "/aspace/repositories/11/resources/1575",
+    "/aspace/repositories/11"
+  ],
+  "children": [
+
+  ],
+  "abstract": [
+    "The Edith Wharton Collection consists of manuscripts, correspondence, photographs, and personal papers relating to the life and career of American author Edith Wharton, as well as letters and research material gathered by Gaillard Lapsley, Percy Lubbock, Oscar Lichtenberg, Georges Markow-Totevy, and Louis Auchincloss."
+  ]
+}

--- a/spec/jobs/solr_reindex_all_job_spec.rb
+++ b/spec/jobs/solr_reindex_all_job_spec.rb
@@ -13,6 +13,81 @@ RSpec.describe SolrReindexAllJob, type: :job, prep_metadata_sources: true, solr:
       solr_reindex_job = described_class.perform_later
       expect(solr_reindex_job.instance_variable_get(:@successfully_enqueued)).to be true
     end
+
+    context 'with Private visibility, well formed json and child objects' do
+      before do
+        stub_metadata_cloud('AS-781086', 'aspace')
+      end
+      it 'can succeed and notify user but does not index Private object' do
+        private_parent_object_with_well_formed_json = FactoryBot.create(:parent_object, oid: 781_086)
+        private_parent_object_with_well_formed_json.save!
+        child_object = FactoryBot.create(:child_object, parent_object: private_parent_object_with_well_formed_json)
+        child_object.save!
+        private_parent_object_with_well_formed_json.reload
+        solr_service = double
+        expect(SolrService).to receive(:connection).and_return(solr_service)
+        expect(SolrService).to receive(:clean_index_orphans).once
+        expect(solr_service).to receive(:add).with([])
+        expect(solr_service).to receive(:commit)
+        solr_reindex_job = described_class.perform_later
+        expect(solr_reindex_job.instance_variable_get(:@successfully_enqueued)).to be true
+        solr_reindex_job.perform
+        expect(IngestEvent.all.first.reason).to eq 'SolrReindexAllJob successfully completed evaluating 1 parent objects for indexing.'
+      end
+    end
+    context 'with Public visibility, well formed json and child objects' do
+      before do
+        stub_metadata_cloud('AS-2005512', 'aspace')
+      end
+      it 'can succeed and notify user and index parent object' do
+        public_parent_object_with_well_formed_json = FactoryBot.create(:parent_object,
+          oid: 2_005_512,
+          visibility: 'Public',
+          aspace_json: JSON.parse(File.read(File.join(fixture_path, "aspace", "AS-2005512.json"))),
+          authoritative_metadata_source_id: 3)
+        allow_any_instance_of(ParentObject).to receive(:manifest_completed?).and_return(true)
+        public_parent_object_with_well_formed_json.save!
+        child_object = FactoryBot.create(:child_object, parent_object: public_parent_object_with_well_formed_json, oid: 1_489_345)
+        child_object.save!
+        public_parent_object_with_well_formed_json.reload
+        solr_service = double
+        expect(SolrService).to receive(:connection).and_return(solr_service)
+        expect(SolrService).to receive(:clean_index_orphans).once
+        expect(solr_service).to receive(:add).with([public_parent_object_with_well_formed_json.to_solr_full_text.first])
+        expect(solr_service).to receive(:add).with([{ caption_tesim: "MyString", caption_wstsim: "MyString", id: 1_489_345, parent_ssi: 2_005_512, type_ssi: "child" }])
+        expect(solr_service).to receive(:commit).twice
+        solr_reindex_job = described_class.perform_later
+        expect(solr_reindex_job.instance_variable_get(:@successfully_enqueued)).to be true
+        solr_reindex_job.perform
+        expect(IngestEvent.all.first.reason).to eq 'SolrReindexAllJob successfully completed evaluating 1 parent objects for indexing.'
+      end
+    end
+    context 'with malformed json' do
+      before do
+        stub_metadata_cloud('AS-781087', 'aspace')
+      end
+      it 'can fail and notify user' do
+        parent_object_with_malformed_json = FactoryBot.create(:parent_object,
+          oid: 781_087,
+          visibility: 'Public',
+          aspace_json: File.read(File.join(fixture_path, "aspace", "AS-781087.json")),
+          authoritative_metadata_source_id: 3)
+        allow_any_instance_of(ParentObject).to receive(:manifest_completed?).and_return(true)
+        parent_object_with_malformed_json.save!
+        child_object = FactoryBot.create(:child_object, parent_object: parent_object_with_malformed_json, oid: 13_523_416)
+        child_object.save!
+        parent_object_with_malformed_json.reload
+        solr_service = double
+        expect(SolrService).to receive(:connection).and_return(solr_service)
+        expect(SolrService).not_to receive(:clean_index_orphans)
+        expect(solr_service).not_to receive(:add)
+        expect(solr_service).not_to receive(:commit)
+        solr_reindex_job = described_class.perform_later
+        expect(solr_reindex_job.instance_variable_get(:@successfully_enqueued)).to be true
+        solr_reindex_job.perform
+        expect(IngestEvent.all.first.reason).to eq "SolrReindexAllJob failed due to no implicit conversion of String into Array for parent object OID: #{parent_object_with_malformed_json.oid}."
+      end
+    end
   end
 
   context 'with more than limit parent objects' do
@@ -26,12 +101,12 @@ RSpec.describe SolrReindexAllJob, type: :job, prep_metadata_sources: true, solr:
       expect(SolrService).to receive(:connection).and_return(solr_service).twice
       expect(SolrService).to receive(:clean_index_orphans).once
 
-      # 2 * because of the children
-      expect(solr_service).to receive(:add).exactly(2 * total_records / solr_limit).times
-      expect(solr_service).to receive(:commit).exactly(2 * total_records / solr_limit).times
+      expect(solr_service).to receive(:add).exactly(total_records / solr_limit).times
+      expect(solr_service).to receive(:commit).exactly(total_records / solr_limit).times
 
       doc = double
-      expect(doc).to receive(:to_solr_full_text).and_return([nil, [double]]).exactly(total_records).times
+      expect(doc).to receive(:should_index?).and_return(true).exactly(total_records).times
+      expect(doc).to receive(:to_solr_full_text).and_return(double).exactly(total_records).times
 
       parent_object_order = double
       parent_object_order_offset1 = double

--- a/spec/requests/batch_processes_request_spec.rb
+++ b/spec/requests/batch_processes_request_spec.rb
@@ -173,7 +173,6 @@ RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
       get download_template_batch_processes_url(batch_action: "create parent objects")
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("text/csv; charset=utf-8")
-      # byebug
       expect(response.body.to_s).to eq("\xEF\xBB\xBFoid,admin_set,source,aspace_uri,mms_id,alma_holding,alma_item,bib,holding,item,barcode,visibility,permission_set_key,digital_object_source,preservica_uri,preservica_representation_type,extent_of_digitization,digitization_note,digitization_funding_source,sensitive_materials,rights_statement,viewing_direction,display_layout\n")
     end
     # rubocop:enable Layout/LineLength


### PR DESCRIPTION
# Summary
Ensures that this job will not index private visibility parents or parents with no children.

# Related Ticket
[#3202](https://github.com/yalelibrary/YUL-DC/issues/3202)