### PR TITLE
Assigns new batch action to reindex job

### DIFF
--- a/app/jobs/solr_reindex_all_job.rb
+++ b/app/jobs/solr_reindex_all_job.rb
@@ -15,7 +15,7 @@ class SolrReindexAllJob < ApplicationJob
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/PerceivedComplexity
-  def perform(start_position = 0, current_batch_process = BatchProcess.new)
+  def perform(start_position = 0, current_batch_process = BatchProcess.new(batch_action: 'reindex all parents'))
     solr = SolrService.connection
     current_batch_process.user = User.system_user
     current_batch_process.save!

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -38,7 +38,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # LISTS AVAILABLE BATCH ACTIONS
   # rubocop:disable Layout/LineLength
   def self.batch_actions
-    ['create parent objects', 'update parent objects', 'update child objects caption and label', 'delete parent objects', 'delete child objects', 'export all parent objects by admin set', 'export parent metadata', 'export child oids', 'reassociate child oids', 'recreate child oid ptiffs', 'update fulltext status', 'resync with preservica', 'activity stream updates']
+    ['create parent objects', 'update parent objects', 'update child objects caption and label', 'delete parent objects', 'delete child objects', 'export all parent objects by admin set', 'export parent metadata', 'export child oids', 'reassociate child oids', 'recreate child oid ptiffs', 'reindex all parents', 'update fulltext status', 'resync with preservica', 'activity stream updates']
   end
   # rubocop:enable Layout/LineLength
 

--- a/app/views/batch_processes/_form.html.erb
+++ b/app/views/batch_processes/_form.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <div class='form-group' >
       <%= f.label :batch_action %>
-      <%= f.select(:batch_action, BatchProcess.batch_actions.map {|option| [option.split.map(&:capitalize).join(' '), option]}, {prompt:'Select Batch Action'}, { :class => 'form-control', required: true }) %>
+      <%= f.select(:batch_action, BatchProcess.batch_actions.reject{|ba| ba === 'reindex all parents'}.map {|option| [option.split.map(&:capitalize).join(' '), option]}, {prompt:'Select Batch Action'}, { :class => 'form-control', required: true }) %>
       <%= link_to("Download Template", "#", class:"download_batch_process_template", target: "_blank")%>
     </div>
     <div class='form-group' >


### PR DESCRIPTION
# Summary
Gives SolrReindexAllJob it's own batch action.

# Related Ticket
[#3204](https://github.com/yalelibrary/YUL-DC/issues/3204)

# Screenshot

<img width="1478" height="208" alt="image" src="https://github.com/user-attachments/assets/cba6065f-f0ef-475e-94a0-b54a22f9b78f" />
