### PR TITLE
adds rescue for frozen attribute

### DIFF
--- a/app/jobs/sync_from_preservica_job.rb
+++ b/app/jobs/sync_from_preservica_job.rb
@@ -10,6 +10,8 @@ class SyncFromPreservicaJob < ApplicationJob
 
   def perform(batch_process)
     batch_process.sync_from_preservica
+  rescue FrozenError => e
+    batch_process.batch_processing_event("Frozen error: #{e.message} at #{e.backtrace.first}", "failed")
   rescue => e
     batch_process.batch_processing_event("Setup job failed to save: #{e.message}", "failed")
   end


### PR DESCRIPTION
## Summary  
Adds a rescue in SyncFromPreservicaJob to display the backtrace where the error happened. This will help pinpoint the exact method it fails on.