### PR TITLE
PDFGeneration rescue

### DIFF
--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -13,6 +13,13 @@ class GeneratePdfJob < ApplicationJob
     parent_object.current_batch_connection = current_batch_connection
     parent_object.generate_pdf
     parent_object.processing_event("PDF has been generated", "pdf-generated")
+  rescue RuntimeError => e
+    if e.message.include?("Can not read scanlines from a tiled image")
+      parent_object.processing_event("Unable to generate PDF: source image is in tiled format and cannot be processed.", "pdf-generation-failed")
+    else
+      parent_object.processing_event("Unable to generate PDF, #{e.message}", "failed")
+      raise
+    end
   rescue => e
     parent_object.processing_event("Unable to generate PDF, #{e.message}", "failed")
     raise


### PR DESCRIPTION
## Summary  
Adds Runtime Error rescue block specifically for "source image is in tiled format and cannot be processed." 