### PR TITLE
Test addition of parallel variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           # Excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
-            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            PARALLEL_NUMBER="${CIRCLE_NODE_INDEX}" cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
       - run:
           name: Stash Coverage Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           # Excludes tests that require Yale VPN access
           command: |
             mkdir /tmp/test-results
-            PARALLEL_NUMBER="${CIRCLE_NODE_INDEX}" cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            cd /home/app/webapp && bundle exec rspec --tag ~vpn_only:true $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
       - run:
           name: Stash Coverage Results
           command: |

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,7 +7,7 @@ Capybara.default_driver = :rack_test
 # Capybara.server = :puma, { Silent: false }
 ENV['WEB_HOST'] ||= `hostname -s`.strip
 
-options = Selenium::WebDriver::Chrome::Options.new(args: %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400])
+options = Selenium::WebDriver::Chrome::Options.new(args: %w[headless disable-gpu no-sandbox whitelisted-ips window-size=1400,1400 disable-dev-shm-usage])
 options.add_argument(
   "--enable-features=NetworkService,NetworkServiceInProcess"
 )

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,7 +7,7 @@ Capybara.default_driver = :rack_test
 # Capybara.server = :puma, { Silent: false }
 ENV['WEB_HOST'] ||= `hostname -s`.strip
 
-options = Selenium::WebDriver::Chrome::Options.new(args: %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400])
+options = Selenium::WebDriver::Chrome::Options.new(args: %w[disable-gpu no-sandbox whitelisted-ips window-size=1400,1400 disable-dev-shm-usage])
 options.add_argument(
   "--enable-features=NetworkService,NetworkServiceInProcess"
 )


### PR DESCRIPTION
# Summary
Over past several weeks, CI has failed due to Invalid session ids for selenium, or more simply, the inability to find the correct spot to run the tests.  These changes should alleviate the need to rerun specs due to this failure.