### PR TITLE
Tech Metadata to Showpage

### DIFF
--- a/app/views/child_objects/_tech_metadata_json.html.erb
+++ b/app/views/child_objects/_tech_metadata_json.html.erb
@@ -1,0 +1,3 @@
+<div class="pre-scrollable">
+  <%= formatted_json(@child_object.image_metadata) %>
+</div>

--- a/app/views/child_objects/show.html.erb
+++ b/app/views/child_objects/show.html.erb
@@ -118,6 +118,11 @@
 </p>
 
 <p>
+  <strong>Technical Image Metadata:</strong>
+  <%= render 'tech_metadata_json', child_object: @child_object %>
+</p>
+
+<p>
   <strong>PTiff Download:</strong>
   <%= link_to 'Click to Download', S3Service.presigned_url(@child_object.remote_ptiff_path, 600) %>
 </p>

--- a/app/views/child_objects/show.html.erb
+++ b/app/views/child_objects/show.html.erb
@@ -73,6 +73,51 @@
 <% end %>
 
 <p>
+  <strong>X Resolution:</strong>
+  <%= @child_object.x_resolution %>
+</p>
+
+<p>
+  <strong>Y Resolution:</strong>
+  <%= @child_object.y_resolution %>
+</p>
+
+<p>
+  <strong>Resolution Unit:</strong>
+  <%= @child_object.resolution_unit %>
+</p>
+
+<p>
+  <strong>Color Space:</strong>
+  <%= @child_object.color_space %>
+</p>
+
+<p>
+  <strong>Compression:</strong>
+  <%= @child_object.compression %>
+</p>
+
+<p>
+  <strong>Artist:</strong>
+  <%= @child_object.creator %>
+</p>
+
+<p>
+  <strong>Date and Time Captured:</strong>
+  <%= @child_object.date_and_time_captured %>
+</p>
+
+<p>
+  <strong>Make:</strong>
+  <%= @child_object.make %>
+</p>
+
+<p>
+  <strong>Model:</strong>
+  <%= @child_object.model %>
+</p>
+
+<p>
   <strong>PTiff Download:</strong>
   <%= link_to 'Click to Download', S3Service.presigned_url(@child_object.remote_ptiff_path, 600) %>
 </p>


### PR DESCRIPTION
## Summary  
Adds child object's tech metadata to showpage.  
  
## Screenshot:  
<img width="1775" height="1040" alt="image" src="https://github.com/user-attachments/assets/4789aace-8bb8-4a64-a15e-138eb733f253" />
