### PR TITLE
Moves technical metadata method to SetupMetadataJob

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -78,6 +78,7 @@ class SetupMetadataJob < ApplicationJob
     parent_object.create_child_records if parent_object.from_upstream_for_the_first_time?
     parent_object.save!
     parent_object.reload
+    parent_object.gather_technical_image_metadata
     parent_object.processing_event("Child object records have been created", "child-records-created")
     ptiff_jobs_queued = false
     parent_object.child_objects.each do |child|

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -186,14 +186,14 @@ class ChildObject < ApplicationRecord
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/PerceivedComplexity
   def save_image_metadata
-    cmd = "exiftool -s #{access_primary_path}"
-    stdout, stderr, status = Open3.capture3(cmd)
-    unless status.success?
+    begin
+      cmd = "exiftool -s #{access_primary_path}"
+      stdout, stderr, status = Open3.capture3(cmd)
+    rescue stderr
       # rubocop:disable Layout/LineLength
       parent_object&.processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
       processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
       # rubocop:enable Layout/LineLength
-      return
     end
     formatted_stdout = stdout.split(/\n/).map { |a| a.split('  : ') }.map { |a| [a.first.strip, a.last] }.to_h
     self.image_metadata = formatted_stdout

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -185,31 +185,31 @@ class ChildObject < ApplicationRecord
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/PerceivedComplexity
-  # def save_image_metadata
-  #   begin
-  #     cmd = "exiftool -s #{access_primary_path}"
-  #     stdout, stderr, status = Open3.capture3(cmd)
-  #   rescue stderr
-  #     # rubocop:disable Layout/LineLength
-  #     parent_object&.processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
-  #     processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
-  #     # rubocop:enable Layout/LineLength
-  #   end
-  #   formatted_stdout = stdout.split(/\n/).map { |a| a.split('  : ') }.map { |a| [a.first.strip, a.last] }.to_h
-  #   self.image_metadata = formatted_stdout
-  #   self.x_resolution = formatted_stdout["XResolution"].presence || formatted_stdout["WidthResolution"]
-  #   self.y_resolution = formatted_stdout["YResolution"].presence || formatted_stdout["HeightResolution"]
-  #   # rubocop:disable Layout/LineLength
-  #   self.resolution_unit = formatted_stdout["ResolutionUnit"].presence || formatted_stdout["FocalPlaneResolutionUnit"].presence || formatted_stdout["ResolutionXUnit"].presence || formatted_stdout["ResolutionXLengthUnit"]
-  #   # rubocop:enable Layout/LineLength
-  #   self.color_space = formatted_stdout["ColorSpaceData"].presence || formatted_stdout["ColorSpace"]
-  #   self.compression = formatted_stdout["Compression"]
-  #   self.creator = formatted_stdout["Artist"].presence || formatted_stdout["XPAuthor"]
-  #   self.date_and_time_captured = formatted_stdout["CreateDate"].presence || formatted_stdout["DateTime"].presence || formatted_stdout["DateTimeDigitized"]
-  #   self.make = formatted_stdout["Make"]
-  #   self.model = formatted_stdout["Model"].presence || formatted_stdout["Model2"].presence || formatted_stdout["UniqueCameraModel"].presence || formatted_stdout["LocalizedCameraModel"]
-  #   save!
-  # end
+  def save_image_metadata
+    cmd = "exiftool -s #{access_primary_path}"
+    stdout, stderr, status = Open3.capture3(cmd)
+    unless status.success?
+      # rubocop:disable Layout/LineLength
+      parent_object&.processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
+      processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
+      # rubocop:enable Layout/LineLength
+      return
+    end
+    formatted_stdout = stdout.split(/\n/).map { |a| a.split('  : ') }.map { |a| [a.first.strip, a.last] }.to_h
+    self.image_metadata = formatted_stdout
+    self.x_resolution = formatted_stdout["XResolution"].presence || formatted_stdout["WidthResolution"]
+    self.y_resolution = formatted_stdout["YResolution"].presence || formatted_stdout["HeightResolution"]
+    # rubocop:disable Layout/LineLength
+    self.resolution_unit = formatted_stdout["ResolutionUnit"].presence || formatted_stdout["FocalPlaneResolutionUnit"].presence || formatted_stdout["ResolutionXUnit"].presence || formatted_stdout["ResolutionXLengthUnit"]
+    # rubocop:enable Layout/LineLength
+    self.color_space = formatted_stdout["ColorSpaceData"].presence || formatted_stdout["ColorSpace"]
+    self.compression = formatted_stdout["Compression"]
+    self.creator = formatted_stdout["Artist"].presence || formatted_stdout["XPAuthor"]
+    self.date_and_time_captured = formatted_stdout["CreateDate"].presence || formatted_stdout["DateTime"].presence || formatted_stdout["DateTimeDigitized"]
+    self.make = formatted_stdout["Make"]
+    self.model = formatted_stdout["Model"].presence || formatted_stdout["Model2"].presence || formatted_stdout["UniqueCameraModel"].presence || formatted_stdout["LocalizedCameraModel"]
+    save!
+  end
   # rubocop:enable Layout/LineLength
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -185,31 +185,31 @@ class ChildObject < ApplicationRecord
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/PerceivedComplexity
-  def save_image_metadata
-    begin
-      cmd = "exiftool -s #{access_primary_path}"
-      stdout, stderr, status = Open3.capture3(cmd)
-    rescue stderr
-      # rubocop:disable Layout/LineLength
-      parent_object&.processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
-      processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
-      # rubocop:enable Layout/LineLength
-    end
-    formatted_stdout = stdout.split(/\n/).map { |a| a.split('  : ') }.map { |a| [a.first.strip, a.last] }.to_h
-    self.image_metadata = formatted_stdout
-    self.x_resolution = formatted_stdout["XResolution"].presence || formatted_stdout["WidthResolution"]
-    self.y_resolution = formatted_stdout["YResolution"].presence || formatted_stdout["HeightResolution"]
-    # rubocop:disable Layout/LineLength
-    self.resolution_unit = formatted_stdout["ResolutionUnit"].presence || formatted_stdout["FocalPlaneResolutionUnit"].presence || formatted_stdout["ResolutionXUnit"].presence || formatted_stdout["ResolutionXLengthUnit"]
-    # rubocop:enable Layout/LineLength
-    self.color_space = formatted_stdout["ColorSpaceData"].presence || formatted_stdout["ColorSpace"]
-    self.compression = formatted_stdout["Compression"]
-    self.creator = formatted_stdout["Artist"].presence || formatted_stdout["XPAuthor"]
-    self.date_and_time_captured = formatted_stdout["CreateDate"].presence || formatted_stdout["DateTime"].presence || formatted_stdout["DateTimeDigitized"]
-    self.make = formatted_stdout["Make"]
-    self.model = formatted_stdout["Model"].presence || formatted_stdout["Model2"].presence || formatted_stdout["UniqueCameraModel"].presence || formatted_stdout["LocalizedCameraModel"]
-    save!
-  end
+  # def save_image_metadata
+  #   begin
+  #     cmd = "exiftool -s #{access_primary_path}"
+  #     stdout, stderr, status = Open3.capture3(cmd)
+  #   rescue stderr
+  #     # rubocop:disable Layout/LineLength
+  #     parent_object&.processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
+  #     processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
+  #     # rubocop:enable Layout/LineLength
+  #   end
+  #   formatted_stdout = stdout.split(/\n/).map { |a| a.split('  : ') }.map { |a| [a.first.strip, a.last] }.to_h
+  #   self.image_metadata = formatted_stdout
+  #   self.x_resolution = formatted_stdout["XResolution"].presence || formatted_stdout["WidthResolution"]
+  #   self.y_resolution = formatted_stdout["YResolution"].presence || formatted_stdout["HeightResolution"]
+  #   # rubocop:disable Layout/LineLength
+  #   self.resolution_unit = formatted_stdout["ResolutionUnit"].presence || formatted_stdout["FocalPlaneResolutionUnit"].presence || formatted_stdout["ResolutionXUnit"].presence || formatted_stdout["ResolutionXLengthUnit"]
+  #   # rubocop:enable Layout/LineLength
+  #   self.color_space = formatted_stdout["ColorSpaceData"].presence || formatted_stdout["ColorSpace"]
+  #   self.compression = formatted_stdout["Compression"]
+  #   self.creator = formatted_stdout["Artist"].presence || formatted_stdout["XPAuthor"]
+  #   self.date_and_time_captured = formatted_stdout["CreateDate"].presence || formatted_stdout["DateTime"].presence || formatted_stdout["DateTimeDigitized"]
+  #   self.make = formatted_stdout["Make"]
+  #   self.model = formatted_stdout["Model"].presence || formatted_stdout["Model2"].presence || formatted_stdout["UniqueCameraModel"].presence || formatted_stdout["LocalizedCameraModel"]
+  #   save!
+  # end
   # rubocop:enable Layout/LineLength
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -166,7 +166,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       return self.child_object_count = 0 if ladybird_json["children"].empty? && parent_model != 'simple'
       upsert_child_objects(array_of_child_hashes)
     end
-    gather_technical_image_metadata
+    # gather_technical_image_metadata
     self.child_object_count = ChildObject.where(parent_object_oid: oid).count
   end
   # rubocop:enable Metrics/PerceivedComplexity

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -166,7 +166,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       return self.child_object_count = 0 if ladybird_json["children"].empty? && parent_model != 'simple'
       upsert_child_objects(array_of_child_hashes)
     end
-    # gather_technical_image_metadata
+    gather_technical_image_metadata
     self.child_object_count = ChildObject.where(parent_object_oid: oid).count
   end
   # rubocop:enable Metrics/PerceivedComplexity

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -166,7 +166,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       return self.child_object_count = 0 if ladybird_json["children"].empty? && parent_model != 'simple'
       upsert_child_objects(array_of_child_hashes)
     end
-    gather_technical_image_metadata
     self.child_object_count = ChildObject.where(parent_object_oid: oid).count
   end
   # rubocop:enable Metrics/PerceivedComplexity

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -205,36 +205,36 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       expect(child_object.batch_connections_for(batch_process)).to eq(batch_connection)
     end
 
-    describe "a new child object" do
-      around do |example|
-        access_host = ENV['ACCESS_PRIMARY_MOUNT']
-        ENV['ACCESS_PRIMARY_MOUNT'] = File.join("spec", "fixtures", "images", "access_primaries")
-        example.run
-        ENV['ACCESS_PRIMARY_MOUNT'] = access_host
-      end
+    # describe "a new child object" do
+    #   around do |example|
+    #     access_host = ENV['ACCESS_PRIMARY_MOUNT']
+    #     ENV['ACCESS_PRIMARY_MOUNT'] = File.join("spec", "fixtures", "images", "access_primaries")
+    #     example.run
+    #     ENV['ACCESS_PRIMARY_MOUNT'] = access_host
+    #   end
 
-      before do
-        stub_metadata_cloud("2004628")
-        parent_object
-        allow(parent_object).to receive(:ladybird_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ladybird", "#{parent_object.oid}.json"))))
-      end
+    #   before do
+    #     stub_metadata_cloud("2004628")
+    #     parent_object
+    #     allow(parent_object).to receive(:ladybird_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ladybird", "#{parent_object.oid}.json"))))
+    #   end
 
-      it "has technical image metadata upon creation" do
-        parent_object.create_child_records
-        new_child = parent_object.child_objects.first
-        expect(new_child.oid).to eq 1_042_003
-        expect(new_child.image_metadata).not_to be_nil
-        expect(new_child.x_resolution).to eq "28.35000048"
-        expect(new_child.y_resolution).to eq "28.35000048"
-        expect(new_child.resolution_unit).to eq "cm"
-        expect(new_child.color_space).to eq "RGB"
-        expect(new_child.compression).to eq "Uncompressed"
-        expect(new_child.creator).to eq nil
-        expect(new_child.date_and_time_captured).to eq nil
-        expect(new_child.make).to eq nil
-        expect(new_child.model).to eq nil
-      end
-    end
+    #   it "has technical image metadata upon creation" do
+    #     parent_object.create_child_records
+    #     new_child = parent_object.child_objects.first
+    #     expect(new_child.oid).to eq 1_042_003
+    #     expect(new_child.image_metadata).not_to be_nil
+    #     expect(new_child.x_resolution).to eq "28.35000048"
+    #     expect(new_child.y_resolution).to eq "28.35000048"
+    #     expect(new_child.resolution_unit).to eq "cm"
+    #     expect(new_child.color_space).to eq "RGB"
+    #     expect(new_child.compression).to eq "Uncompressed"
+    #     expect(new_child.creator).to eq nil
+    #     expect(new_child.date_and_time_captured).to eq nil
+    #     expect(new_child.make).to eq nil
+    #     expect(new_child.model).to eq nil
+    #   end
+    # end
 
     describe "full text availability" do
       before do

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -221,6 +221,7 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
 
       it "has technical image metadata upon creation" do
         parent_object.create_child_records
+        parent_object.gather_technical_image_metadata
         new_child = parent_object.child_objects.first
         expect(new_child.oid).to eq 1_042_003
         expect(new_child.image_metadata).not_to be_nil

--- a/spec/models/child_object_spec.rb
+++ b/spec/models/child_object_spec.rb
@@ -205,36 +205,36 @@ RSpec.describe ChildObject, type: :model, prep_metadata_sources: true do
       expect(child_object.batch_connections_for(batch_process)).to eq(batch_connection)
     end
 
-    # describe "a new child object" do
-    #   around do |example|
-    #     access_host = ENV['ACCESS_PRIMARY_MOUNT']
-    #     ENV['ACCESS_PRIMARY_MOUNT'] = File.join("spec", "fixtures", "images", "access_primaries")
-    #     example.run
-    #     ENV['ACCESS_PRIMARY_MOUNT'] = access_host
-    #   end
+    describe "a new child object" do
+      around do |example|
+        access_host = ENV['ACCESS_PRIMARY_MOUNT']
+        ENV['ACCESS_PRIMARY_MOUNT'] = File.join("spec", "fixtures", "images", "access_primaries")
+        example.run
+        ENV['ACCESS_PRIMARY_MOUNT'] = access_host
+      end
 
-    #   before do
-    #     stub_metadata_cloud("2004628")
-    #     parent_object
-    #     allow(parent_object).to receive(:ladybird_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ladybird", "#{parent_object.oid}.json"))))
-    #   end
+      before do
+        stub_metadata_cloud("2004628")
+        parent_object
+        allow(parent_object).to receive(:ladybird_json).and_return(JSON.parse(File.read(File.join(fixture_path, "ladybird", "#{parent_object.oid}.json"))))
+      end
 
-    #   it "has technical image metadata upon creation" do
-    #     parent_object.create_child_records
-    #     new_child = parent_object.child_objects.first
-    #     expect(new_child.oid).to eq 1_042_003
-    #     expect(new_child.image_metadata).not_to be_nil
-    #     expect(new_child.x_resolution).to eq "28.35000048"
-    #     expect(new_child.y_resolution).to eq "28.35000048"
-    #     expect(new_child.resolution_unit).to eq "cm"
-    #     expect(new_child.color_space).to eq "RGB"
-    #     expect(new_child.compression).to eq "Uncompressed"
-    #     expect(new_child.creator).to eq nil
-    #     expect(new_child.date_and_time_captured).to eq nil
-    #     expect(new_child.make).to eq nil
-    #     expect(new_child.model).to eq nil
-    #   end
-    # end
+      it "has technical image metadata upon creation" do
+        parent_object.create_child_records
+        new_child = parent_object.child_objects.first
+        expect(new_child.oid).to eq 1_042_003
+        expect(new_child.image_metadata).not_to be_nil
+        expect(new_child.x_resolution).to eq "28.35000048"
+        expect(new_child.y_resolution).to eq "28.35000048"
+        expect(new_child.resolution_unit).to eq "cm"
+        expect(new_child.color_space).to eq "RGB"
+        expect(new_child.compression).to eq "Uncompressed"
+        expect(new_child.creator).to eq nil
+        expect(new_child.date_and_time_captured).to eq nil
+        expect(new_child.make).to eq nil
+        expect(new_child.model).to eq nil
+      end
+    end
 
     describe "full text availability" do
       before do

--- a/spec/models/preservica/preservica_import_spec.rb
+++ b/spec/models/preservica/preservica_import_spec.rb
@@ -87,6 +87,11 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     end.to change { ChildObject.count }.from(0).to(3)
     po_first = ParentObject.first
     co_first = ChildObject.first
+    expect(co_first.image_metadata).not_to be_nil
+    expect(co_first.x_resolution).to eq "72"
+    expect(co_first.y_resolution).to eq "72"
+    expect(co_first.resolution_unit).to eq "inches"
+    expect(co_first.compression).to eq "PackBits"
     expect(co_first.oid).to eq 200_000_001
     expect(co_first.parent_object_oid).to eq 200_000_000
     expect(co_first.order).to eq 1


### PR DESCRIPTION
## Summary  
Moves the technical metadata gathering to the SetupMetadataJob. This prevents race conditions that otherwise breaks CI for selenium timeouts. 