### PR TITLE
Allow PDF Generation for Tiled Images

### DIFF
--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -18,15 +18,13 @@ class GeneratePdfJob < ApplicationJob
     if e.message.include?("Can not read scanlines from a tiled image")
       parent_object.processing_event("Unable to generate PDF: source image is in tiled format and cannot be processed.", "pdf-generation-failed")
       current_batch_process&.batch_processing_event("Unable to generate PDF: source image is in tiled format and cannot be processed.", "pdf-generation-failed")
-      raise
     elsif e.message.include?("Invalid tile byte count")
       parent_object.processing_event("Unable to generate PDF: source image has invalid tile byte count and cannot be processed. Please regenerate the PTIFF.", "pdf-generation-failed")
       current_batch_process&.batch_processing_event("Unable to generate PDF for parent #{parent_object.oid}: source image has invalid tile byte count. Please regenerate the PTIFF.", "failed")
-      raise
     else
       parent_object.processing_event("Unable to generate PDF, #{e.message}", "failed")
-      raise
     end
+    raise
   rescue => e
     parent_object.processing_event("Unable to generate PDF, #{e.message}", "failed")
     raise

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -16,6 +16,10 @@ class GeneratePdfJob < ApplicationJob
   rescue RuntimeError => e
     if e.message.include?("Can not read scanlines from a tiled image")
       parent_object.processing_event("Unable to generate PDF: source image is in tiled format and cannot be processed.", "pdf-generation-failed")
+      current_batch_process&.batch_processing_event("Unable to generate PDF: source image is in tiled format and cannot be processed.", "pdf-generation-failed")
+    elsif e.message.include?("Invalid tile byte count")
+      parent_object.processing_event("Unable to generate PDF: source image has invalid tile byte count and cannot be processed. Please regenerate the PTIFF.", "pdf-generation-failed")
+      current_batch_process&.batch_processing_event("Unable to generate PDF for parent #{parent_object.oid}: source image has invalid tile byte count. Please regenerate the PTIFF.", "failed")
     else
       parent_object.processing_event("Unable to generate PDF, #{e.message}", "failed")
       raise

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -7,6 +7,7 @@ class GeneratePdfJob < ApplicationJob
     10
   end
 
+  # rubocop:disable Metrics/MethodLength
   def perform(parent_object, current_batch_process = parent_object.current_batch_process, current_batch_connection = parent_object.current_batch_connection)
     return unless parent_object.should_create_manifest_and_pdf?
     parent_object.current_batch_process = current_batch_process
@@ -29,3 +30,4 @@ class GeneratePdfJob < ApplicationJob
     raise
   end
 end
+# rubocop:enable Metrics/MethodLength

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -18,9 +18,11 @@ class GeneratePdfJob < ApplicationJob
     if e.message.include?("Can not read scanlines from a tiled image")
       parent_object.processing_event("Unable to generate PDF: source image is in tiled format and cannot be processed.", "pdf-generation-failed")
       current_batch_process&.batch_processing_event("Unable to generate PDF: source image is in tiled format and cannot be processed.", "pdf-generation-failed")
+      raise
     elsif e.message.include?("Invalid tile byte count")
       parent_object.processing_event("Unable to generate PDF: source image has invalid tile byte count and cannot be processed. Please regenerate the PTIFF.", "pdf-generation-failed")
       current_batch_process&.batch_processing_event("Unable to generate PDF for parent #{parent_object.oid}: source image has invalid tile byte count. Please regenerate the PTIFF.", "failed")
+      raise
     else
       parent_object.processing_event("Unable to generate PDF, #{e.message}", "failed")
       raise

--- a/app/models/concerns/pdf_representable.rb
+++ b/app/models/concerns/pdf_representable.rb
@@ -76,7 +76,7 @@ module PdfRepresentable
       "header" => "Yale University Library Digital Collections",
       "properties" => properties,
       "pages" => children,
-      "imageProcessingCommand" => "convert -resize 2000x2000 %s[0] %s"
+      "imageProcessingCommand" => "vipsthumbnail %s --size 2000x2000 -o %s"
     }
     # Don't adjust the processing command to add color space because it was causing problems.  Adjust and uncomment if
     # there is a command change for preprocessing needed:

--- a/spec/models/parent_object_spec.rb
+++ b/spec/models/parent_object_spec.rb
@@ -450,11 +450,11 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
 
       it "generates pdf json with the correct preprocessing command" do
-        expect(parent_object.pdf_generator_json).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] %s"')
+        expect(parent_object.pdf_generator_json).to include('"imageProcessingCommand":"vipsthumbnail %s --size 2000x2000 -o %s"')
       end
 
       it "generates pdf json for checksum with the original preprocessing command" do
-        expect(parent_object.pdf_json("same", :child_modification)).to include('"imageProcessingCommand":"convert -resize 2000x2000 %s[0] %s"')
+        expect(parent_object.pdf_json("same", :child_modification)).to include('"imageProcessingCommand":"vipsthumbnail %s --size 2000x2000 -o %s"')
       end
 
       it "generated pdf json with Extent of Digitization" do


### PR DESCRIPTION
## Summary  
Adds a raise to PDF Runtime Errors. This will raise the error to GoodJobs, which will help locate the error.  
Also, fixes PDF Generation for tiled images that were failing for Runtime Errors. Uses vips instead of ImageMagick for the conversion tool. 