### PR TITLE
Allows Goobi Tech Metadata for Ingests

### DIFF
--- a/app/jobs/generate_ptiff_job.rb
+++ b/app/jobs/generate_ptiff_job.rb
@@ -22,6 +22,8 @@ class GeneratePtiffJob < ApplicationJob
     # mocks there to see if it passes
     if child_object.parent_object.from_mets
       raise "Copy to pair tree failed for child object: #{child_object.oid}" unless child_object.copy_to_access_primary_pairtree
+      # Gather technical metadata now that the image is at access_primary_path
+      child_object.save_image_metadata
     end
     is_recreate_job = child_object.current_batch_process&.batch_action == 'recreate child oid ptiffs'
     success = child_object.convert_to_ptiff!(is_recreate_job)

--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -78,7 +78,9 @@ class SetupMetadataJob < ApplicationJob
     parent_object.create_child_records if parent_object.from_upstream_for_the_first_time?
     parent_object.save!
     parent_object.reload
-    parent_object.gather_technical_image_metadata
+    # For METS ingests, technical metadata is gathered after GeneratePtiffJob copies
+    # the images from Goobi's location to the pairtree
+    parent_object.gather_technical_image_metadata unless parent_object.from_mets
     parent_object.processing_event("Child object records have been created", "child-records-created")
     ptiff_jobs_queued = false
     parent_object.child_objects.each do |child|


### PR DESCRIPTION
## Summary  
Adds technical metadata gathering to GeneratePtiff for mets objects specifically. This is because mets ingests needs to complete the Ptiff Generation first _before_ gathering the technical metadata. Non-mets ingests remains the same and gathers technical metadata during the SetupMetadataJob. 