### PR TITLE
Tech Metadata Date and Time Captured datatype change to String

### DIFF
--- a/db/migrate/20260112212248_change_date_and_time_captured.rb
+++ b/db/migrate/20260112212248_change_date_and_time_captured.rb
@@ -1,0 +1,5 @@
+class ChangeDateAndTimeCaptured < ActiveRecord::Migration[7.0]
+  def change
+    change_column :child_objects, :date_and_time_captured, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_12_18_224707) do
+ActiveRecord::Schema[7.0].define(version: 2026_01_12_212248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -91,7 +91,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_18_224707) do
     t.string "color_space"
     t.string "compression"
     t.string "creator"
-    t.datetime "date_and_time_captured"
+    t.string "date_and_time_captured"
     t.string "make"
     t.string "model"
     t.jsonb "image_metadata"


### PR DESCRIPTION
## Summary  
Changes "Date and Time Captured" Tech Metadata to be a string instead of datetime. 