### PR TITLE
Updates Batch Process Messages for Child Object Checksum Job

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -243,7 +243,8 @@ module Updatable
       processed_child_objects_count += 1
     end
     batch_processing_event("#{processed_child_objects_count} child objects updated.", "Complete")
-    batch_processing_event("Child objects that were not updated: #{child_objects_not_updated}.", "Complete")
+    batch_processing_event("Child objects that were not updated: #{child_objects_not_updated}.", "Complete") if child_objects_not_updated.any?
+    batch_processing_event("All child objects from csv were updated.", "Complete") if child_objects_not_updated.empty?
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity
@@ -343,6 +344,7 @@ module Updatable
     child_object.current_batch_process = self
     child_object.current_batch_connection = batch_connections.find_or_create_by(connectable: child_object)
     child_object.current_batch_connection.save!
+    batch_processing_event("Child #{child_object.oid} was updated with the #{column_name} checksum value, read from the access primary original image file.", 'update-complete')
     child_object.processing_event("Child #{child_object.oid} was updated with the #{column_name} checksum value, read from the access primary original image file.", 'update-complete')
   end
 

--- a/spec/models/batch_process_update_child_objects_spec.rb
+++ b/spec/models/batch_process_update_child_objects_spec.rb
@@ -150,8 +150,9 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
           expect(updated_child_object.sha512_checksum).to eq tif_sha512_fixity_value
           expect(updated_child_object_two.sha512_checksum).to eq tif_sha512_fixity_value
           expect(updated_child_object_three.sha512_checksum).to eq tif_sha512_fixity_value
-          expect(checksum_batch_process.batch_ingest_events.count).to eq 2
-          expect(checksum_batch_process.batch_ingest_events.first.reason).to eq "3 child objects updated."
+          expect(checksum_batch_process.batch_ingest_events.count).to eq 5
+          expect(checksum_batch_process.batch_ingest_events.first.reason).to eq "Child 10736292 was updated with the sha512 checksum value, read from the access primary original image file."
+          expect(checksum_batch_process.batch_ingest_events[3].reason).to eq "3 child objects updated."
           expect(checksum_batch_process.batch_ingest_events.last.reason).to eq "All child objects from csv were updated."
           expect(updated_child_object.events_for_batch_process(checksum_batch_process).count).to eq 2
           expect(updated_child_object.events_for_batch_process(checksum_batch_process).first.reason).to eq "Child 10736292 was updated with the sha512 checksum value, read from the access primary original image file."

--- a/spec/models/batch_process_update_child_objects_spec.rb
+++ b/spec/models/batch_process_update_child_objects_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
           expect(updated_child_object_three.sha512_checksum).to eq tif_sha512_fixity_value
           expect(checksum_batch_process.batch_ingest_events.count).to eq 2
           expect(checksum_batch_process.batch_ingest_events.first.reason).to eq "3 child objects updated."
-          expect(checksum_batch_process.batch_ingest_events.last.reason).to eq "Child objects that were not updated: []."
+          expect(checksum_batch_process.batch_ingest_events.last.reason).to eq "All child objects from csv were updated."
           expect(updated_child_object.events_for_batch_process(checksum_batch_process).count).to eq 1
           expect(updated_child_object.events_for_batch_process(checksum_batch_process).first.reason).to eq "Child 10736292 has been updated"
           expect(updated_child_object_two.events_for_batch_process(checksum_batch_process).count).to eq 1
@@ -152,7 +152,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true do
           expect(updated_child_object_three.sha512_checksum).to eq tif_sha512_fixity_value
           expect(checksum_batch_process.batch_ingest_events.count).to eq 2
           expect(checksum_batch_process.batch_ingest_events.first.reason).to eq "3 child objects updated."
-          expect(checksum_batch_process.batch_ingest_events.last.reason).to eq "Child objects that were not updated: []."
+          expect(checksum_batch_process.batch_ingest_events.last.reason).to eq "All child objects from csv were updated."
           expect(updated_child_object.events_for_batch_process(checksum_batch_process).count).to eq 2
           expect(updated_child_object.events_for_batch_process(checksum_batch_process).first.reason).to eq "Child 10736292 was updated with the sha512 checksum value, read from the access primary original image file."
           expect(updated_child_object.events_for_batch_process(checksum_batch_process).last.reason).to eq "Child 10736292 has been updated"


### PR DESCRIPTION
# Summary
Clarifies the statement message when no child objects fail to process and adds top level messaging when access primary is read for the correct checksum.

# Related Ticket
[#3236](https://github.com/yalelibrary/YUL-DC/issues/3236)