### PR TITLE
Adds New Error to Preservica Rescue

### DIFF
--- a/app/jobs/sync_from_preservica_job.rb
+++ b/app/jobs/sync_from_preservica_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SyncFromPreservicaJob < ApplicationJob
-  retry_on RuntimeError, Net::ReadTimeout, attempts: 3
+  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, attempts: 3
   queue_as :default
 
   def default_priority

--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -40,7 +40,7 @@ class PreservicaImageService
         begin
           attempt_count += 1
           @information_objects = structural_object.information_objects
-        rescue Net::ReadTimeout => e
+        rescue Net::HTTPFatalError, Net::ReadTimeout => e
           retry if attempt_count < 4
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         rescue Net::OpenTimeout, Errno::ECONNREFUSED => e
@@ -50,7 +50,7 @@ class PreservicaImageService
         begin
           attempt_count += 1
           @information_objects = [Preservica::InformationObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)]
-        rescue Net::ReadTimeout => e
+        rescue Net::HTTPFatalError, Net::ReadTimeout => e
           retry if attempt_count < 4
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end


### PR DESCRIPTION
# Summary
Adds the Net Http fatal class to the errors that will be caught and handled by the retry pattern for the Preservica image ingests.

# Related Ticket
[#3031](https://github.com/yalelibrary/YUL-DC/issues/3031)