### PR TITLE
Moves DataTables Error Reporting

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -223,6 +223,7 @@ $( document ).on('turbolinks:load', function() {
 
     })
     dataTable.api().draw();
+    dataTable.fn.dataTable.ext.errMode = 'throw';
 
     $('.is-datatable').on( 'column-visibility.dt', function ( e, settings, column, state ) {
       // Check for data-destroying because this gets called after turbo links updates document.location and the


### PR DESCRIPTION
# Summary
Changes the configuration of the datatables error reporting to no longer create an alert module that is visible to all users but will now report any errors into the javascript console log on the page.

# Related Ticket
[#3245](https://github.com/yalelibrary/YUL-DC/issues/3245)