### PR TITLE
Irreversible Order Error

### DIFF
--- a/app/controllers/batch_processes_controller.rb
+++ b/app/controllers/batch_processes_controller.rb
@@ -5,7 +5,7 @@ class BatchProcessesController < ApplicationController
   before_action :set_batch_process, only: [:show, :edit, :update, :destroy, :download, :download_csv, :download_xml, :download_created, :show_parent, :show_child]
   before_action :set_parent_object, only: [:show_parent, :show_child]
   before_action :find_notes, only: [:show_parent]
-  before_action :latest_failure, only: [:show_parent]
+  before_action :latest_failures, only: [:show_parent]
   before_action :set_child_object, only: [:show_child]
 
   # Allows FontAwesome icons to render in header
@@ -140,15 +140,15 @@ class BatchProcessesController < ApplicationController
     @child_object = ChildObject.find(params[:child_oid])
     @notes = @child_object.notes_for_batch_process(@batch_process)
     # TODO: Find failure related only to child object?
-    @failure = @child_object.latest_failure(@batch_process)
+    @failure = @child_object.latest_failures(@batch_process)
   end
 
   def find_notes
     @notes = @parent_object.notes_for_batch_process(@batch_process) if @parent_object
   end
 
-  def latest_failure
-    @latest_failure = @parent_object.latest_failure(@batch_process) if @parent_object
+  def latest_failures
+    @latest_failures = @parent_object.latest_failures(@batch_process) if @parent_object
   end
 
   def batch_process_params

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -63,8 +63,7 @@ module Statable
     if failures.empty?
       nil
     else
-      # latest = failures.last
-      { reason: failures.all.map(&:reason).join(', '), time: failures.count, count: failures.count }
+      { reason: failures.last[:reason], time: failures.last[:created_at] }
     end
   end
 

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -59,7 +59,7 @@ module Statable
   end
 
   def latest_failure(batch_process)
-    failures = note_records(batch_process).where(status: 'failed')
+    failures = note_records(batch_process).where(status: 'failed').order(:created_at)
     if failures.empty?
       nil
     else

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -60,10 +60,11 @@ module Statable
 
   def latest_failure(batch_process)
     failures = note_records(batch_process).where(status: 'failed').order(:created_at)
+    count = note_records(batch_process).where(status: 'failed').count
     if failures.empty?
       nil
     else
-      { reason: failures.last[:reason], time: failures.last[:created_at] }
+      { reason: failures.all[:reason], time: failures.all[:created_at], count: count }
     end
   end
 

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -28,9 +28,9 @@ module Statable
       "Pending"
     elsif finished_note(notes)
       "Complete"
-    elsif latest_failure(batch_process).nil?
+    elsif latest_failures(batch_process).nil?
       "In progress - no failures"
-    elsif latest_failure(batch_process)
+    elsif latest_failures(batch_process)
       "Failed"
     else
       "Unknown status"
@@ -58,12 +58,12 @@ module Statable
     end
   end
 
-  def latest_failure(batch_process)
+  def latest_failures(batch_process)
     failures = note_records(batch_process).where(status: 'failed').order(:created_at)
     if failures.empty?
       nil
     else
-      { reason: failures.last[:reason], time: failures.last[:created_at] }
+      { reason: failures.pluck(:reason).join(', '), time: failures.pluck(:created_at).join(', ') }
     end
   end
 

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -63,8 +63,8 @@ module Statable
     if failures.empty?
       nil
     else
-      latest = failures.last
-      { reason: latest.reason, time: latest.created_at, count: failures.count }
+      # latest = failures.last
+      { reason: failures.all.map(&:reason).join(', '), time: failures.count, count: failures.count }
     end
   end
 

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -60,11 +60,11 @@ module Statable
 
   def latest_failure(batch_process)
     failures = note_records(batch_process).where(status: 'failed').order(:created_at)
-    count = note_records(batch_process).where(status: 'failed').count
     if failures.empty?
       nil
     else
-      { reason: failures.all[:reason], time: failures.all[:created_at], count: count }
+      latest = failures.last
+      { reason: latest.reason, time: latest.created_at, count: failures.count }
     end
   end
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -247,8 +247,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     child_objects.each do |co|
       co.destroy! unless found_in_preservica(co.sha512_checksum, preservica_children_hash)
     end
-    # reload to clear destroyed children
-    child_objects.reload
     # iterate through preservica and update when local version found
     sync_from_preservica_update_existing_children(preservica_children_hash)
 
@@ -680,7 +678,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def representative_child
     @representative_child = (child_objects.find_by(oid: representative_child_oid) if representative_child_oid)
-    @representative_child ||= child_objects&.first
+    @representative_child ||= child_objects&.order(:order, :oid)&.first
   end
 
   def representative_thumbnail_url

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -247,6 +247,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     child_objects.each do |co|
       co.destroy! unless found_in_preservica(co.sha512_checksum, preservica_children_hash)
     end
+    # reload to clear destroyed children
+    child_objects.reload
     # iterate through preservica and update when local version found
     sync_from_preservica_update_existing_children(preservica_children_hash)
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -678,7 +678,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def representative_child
     @representative_child = (child_objects.find_by(oid: representative_child_oid) if representative_child_oid)
-    @representative_child ||= child_objects&.order(:order, :oid)&.first
+    @representative_child ||= child_objects&.first
   end
 
   def representative_thumbnail_url

--- a/app/views/batch_processes/show_parent.html.erb
+++ b/app/views/batch_processes/show_parent.html.erb
@@ -105,7 +105,7 @@
   </div>
 </div>
 
-<% if @latest_failure %>
+<% if @latest_failures %>
 <table class='table table-responsive table-bordered table-striped' aria-label='Parent Batch Process Failure'>
   <thead class='table-head'>
     <tr>
@@ -115,8 +115,8 @@
   </thead>
   <tbody class='datatable-body'>
     <tr>
-      <td class='reason'><%= @latest_failure[:reason] %></td>
-      <td class='time'><%= @latest_failure[:time] %></td>
+      <td class='reason'><%= @latest_failures[:reason] %></td>
+      <td class='time'><%= @latest_failures[:time] %></td>
     </tr>
   </tbody>
 </table>

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
     end
 
-    xit "can reflect a failure" do
+    it "can reflect a failure" do
       batch_process_with_failure.file = csv_upload
       batch_process_with_failure.save
       batch_process_with_failure.run_callbacks :create

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -122,12 +122,10 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
           batch_connection: parent_object.batch_connections.first
         )
       )
-      # rubocop:disable Layout/LineLength
       batch_process_with_failure.batch_connections.first.update_status
       expect(parent_object.latest_failures(batch_process_with_failure)).to be_an_instance_of Hash
-      expect(parent_object.latest_failures(batch_process_with_failure)[:reason]).to eq("Fake failure 1, Fake failure 2").or eq("Metadata Cloud could not access this descriptive record. Please make sure you have entered the correct information and that the descriptive records are public and/or published. ------------ Message from System: SetupMetadataJob failed to retrieve authoritative metadata. [https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1&mediaType=json]")
+      expect(parent_object.latest_failures(batch_process_with_failure)[:reason]).to include("Fake failure 1").and include("Fake failure 2")
       expect(parent_object.latest_failures(batch_process_with_failure)[:time]).to be
-      # rubocop:enable Layout/LineLength
     end
   end
 end

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       )
       # rubocop:disable Layout/LineLength
       batch_process_with_failure.batch_connections.first.update_status
-      expect(parent_object.latest_failure(batch_process_with_failure)).to be_an_instance_of Hash
-      expect(parent_object.latest_failure(batch_process_with_failure)[:reason]).to eq("Fake failure 2").or eq("Metadata Cloud could not access this descriptive record. Please make sure you have entered the correct information and that the descriptive records are public and/or published. ------------ Message from System: SetupMetadataJob failed to retrieve authoritative metadata. [https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1&mediaType=json]")
-      expect(parent_object.latest_failure(batch_process_with_failure)[:time]).to be
+      expect(parent_object.latest_failures(batch_process_with_failure)).to be_an_instance_of Hash
+      expect(parent_object.latest_failures(batch_process_with_failure)[:reason]).to eq("Fake failure 2").or eq("Metadata Cloud could not access this descriptive record. Please make sure you have entered the correct information and that the descriptive records are public and/or published. ------------ Message from System: SetupMetadataJob failed to retrieve authoritative metadata. [https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1&mediaType=json]")
+      expect(parent_object.latest_failures(batch_process_with_failure)[:time]).to be
       # rubocop:enable Layout/LineLength
     end
   end

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       # rubocop:disable Layout/LineLength
       batch_process_with_failure.batch_connections.first.update_status
       expect(parent_object.latest_failures(batch_process_with_failure)).to be_an_instance_of Hash
-      expect(parent_object.latest_failures(batch_process_with_failure)[:reason]).to eq("Fake failure 2").or eq("Metadata Cloud could not access this descriptive record. Please make sure you have entered the correct information and that the descriptive records are public and/or published. ------------ Message from System: SetupMetadataJob failed to retrieve authoritative metadata. [https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1&mediaType=json]")
+      expect(parent_object.latest_failures(batch_process_with_failure)[:reason]).to eq("Fake failure 1, Fake failure 2").or eq("Metadata Cloud could not access this descriptive record. Please make sure you have entered the correct information and that the descriptive records are public and/or published. ------------ Message from System: SetupMetadataJob failed to retrieve authoritative metadata. [https://metadata-api-uat.library.yale.edu/metadatacloud/api/1.0.1/ladybird/oid/2005512?include-children=1&mediaType=json]")
       expect(parent_object.latest_failures(batch_process_with_failure)[:time]).to be
       # rubocop:enable Layout/LineLength
     end

--- a/spec/models/parent_object_statable_spec.rb
+++ b/spec/models/parent_object_statable_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe ParentObject, type: :model, prep_metadata_sources: true, prep_adm
       end
     end
 
-    it "can reflect a failure" do
+    xit "can reflect a failure" do
       batch_process_with_failure.file = csv_upload
       batch_process_with_failure.save
       batch_process_with_failure.run_callbacks :create


### PR DESCRIPTION
## Summary  
Some Update and SyncFromPreservica Jobs were throwing errors that latest_failure was not able to handle. This was found by looking at the server logs and error was being thrown `ActiveRecord::IrreversibleOrderError: Relation has no current order and table has no primary key to be used as default order`. More specifically, stack trace shows the specific method error is being raised:  
```
App 587 output: /usr/local/rvm/gems/ruby-3.2.8/gems/activerecord-7.0.8.7/lib/active_record/relation/finder_methods.rb:175:in `last'
App 587 output: /home/app/webapp/app/models/concerns/statable.rb:66:in `latest_failure' 
```  
  
Parent BP Showpages will now be accessible if multiple errors are thrown. New code will also now display all errors that are thrown by the batch process, not just the latest one.