### PR TITLE
Move Datatable Error Reporting

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -223,6 +223,7 @@ $( document ).on('turbolinks:load', function() {
 
     })
     dataTable.api().draw();
+    dataTable.fn.dataTable.ext.errMode = 'throw';
 
     $('.is-datatable').on( 'column-visibility.dt', function ( e, settings, column, state ) {
       // Check for data-destroying because this gets called after turbo links updates document.location and the

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -223,7 +223,7 @@ $( document ).on('turbolinks:load', function() {
 
     })
     dataTable.api().draw();
-    dataTable.fn.dataTable.ext.errMode = 'throw';
+    $.fn.dataTable.ext.errMode = 'throw';
 
     $('.is-datatable').on( 'column-visibility.dt', function ( e, settings, column, state ) {
       // Check for data-destroying because this gets called after turbo links updates document.location and the


### PR DESCRIPTION
# Summary
Moves the error reporting from pop up alerts to reporting in the console.

# Related Ticket
[#3245](https://github.com/yalelibrary/YUL-DC/issues/3245)