### PR TITLE
BP Parent Object Showpage Error Formatting and Update Table Headers

### DIFF
--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -63,7 +63,7 @@ module Statable
     if failures.empty?
       nil
     else
-      { reason: failures.pluck(:reason).join(', '), time: failures.pluck(:created_at).join(', ') }
+      { reason: failures.pluck(:reason).join("\n"), time: failures.pluck(:created_at).join("\n") }
     end
   end
 

--- a/app/views/batch_processes/show_child.html.erb
+++ b/app/views/batch_processes/show_child.html.erb
@@ -81,7 +81,7 @@
   <table class='table table-responsive table-bordered table-striped' aria-label='Child Batch Process Failure'>
     <thead class='table-head'>
       <tr>
-        <th scope='col'>Message</th>
+        <th scope='col'>Failure Message(s)</th>
         <th scope='col'>Time</th>
       </tr>
     </thead>

--- a/app/views/batch_processes/show_parent.html.erb
+++ b/app/views/batch_processes/show_parent.html.erb
@@ -109,7 +109,7 @@
 <table class='table table-responsive table-bordered table-striped' aria-label='Parent Batch Process Failure'>
   <thead class='table-head'>
     <tr>
-      <th scope='col'>Last Failure Message</th>
+      <th scope='col'>Failure Message(s)</th>
       <th scope='col'>Time</th>
     </tr>
   </thead>


### PR DESCRIPTION
## Summary  
Instead of separating each error message with a "," each error message will be separated by a line break. Also adjusts title of error header