### PR TITLE
Adds Line Breaks to Multiple BP Error Messages

### DIFF
--- a/app/assets/stylesheets/batch_processes.scss
+++ b/app/assets/stylesheets/batch_processes.scss
@@ -49,3 +49,9 @@ DEFAULT DESKTOP STYLING
 .download_batch_process_template {
   display: none;
 }
+
+// Failure table styles
+td.reason,
+td.time {
+  white-space: pre-line;
+}

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -63,7 +63,7 @@ module Statable
     if failures.empty?
       nil
     else
-      { reason: failures.pluck(:reason).join("\n"), time: failures.pluck(:created_at).join("\n") }
+      { reason: failures.pluck(:reason).join("\n\n"), time: failures.pluck(:created_at).join("\n\n") }
     end
   end
 


### PR DESCRIPTION
## Summary  
Adds line breaks when there are multiple BP error messages. This will improve readability.  
  
## Screenshot:  
<img width="1446" height="685" alt="image" src="https://github.com/user-attachments/assets/ae5678ad-e24a-48d1-8a15-07cc52e9ae32" />
