### PR TITLE
Invalid Byte Sequence UTF-8 Error for Technical Metadata

### DIFF
--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -75,23 +75,15 @@ class SetupMetadataJob < ApplicationJob
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def setup_child_object_jobs(parent_object, current_batch_process)
-    current_child_oid = nil
-    error_location = "create_child_records"
     parent_object.create_child_records if parent_object.from_upstream_for_the_first_time?
-    error_location = "save"
     parent_object.save!
-    error_location = "reload"
     parent_object.reload
     # For METS ingests, technical metadata is gathered after GeneratePtiffJob copies
     # the images from Goobi's location to the pairtree
-    error_location = "gather_technical_image_metadata"
     parent_object.gather_technical_image_metadata unless parent_object.from_mets
-    error_location = "processing_event"
     parent_object.processing_event("Child object records have been created", "child-records-created")
     ptiff_jobs_queued = false
-    error_location = "child_loop"
     parent_object.child_objects.each do |child|
-      current_child_oid = child.oid
       parent_object.current_batch_process&.setup_for_background_jobs(child, nil)
       if child.pyramidal_tiff.height_and_width? && !child.pyramidal_tiff.force_update && S3Service.s3_exists?(child.remote_ptiff_path)
         child.processing_event("PTIFF exists on S3, not converting: #{child.oid}", 'ptiff-ready-skipped')
@@ -104,14 +96,11 @@ class SetupMetadataJob < ApplicationJob
         ptiff_jobs_queued = true
       end
     end
-    current_child_oid = nil
-    error_location = "generate_manifest"
     unless ptiff_jobs_queued
       GenerateManifestJob.perform_later(parent_object, parent_object.current_batch_process, parent_object.current_batch_connection) if parent_object.needs_a_manifest?
     end
   rescue => child_create_error
-    child_info = current_child_oid ? " (child oid: #{current_child_oid})" : ""
-    parent_object.processing_event("UTF error test [#{error_location}]#{child_info}: #{child_create_error.message}", "failed")
+    parent_object.processing_event(child_create_error.message, "failed")
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize

--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -100,7 +100,7 @@ class SetupMetadataJob < ApplicationJob
       GenerateManifestJob.perform_later(parent_object, parent_object.current_batch_process, parent_object.current_batch_connection) if parent_object.needs_a_manifest?
     end
   rescue => child_create_error
-    parent_object.processing_event(child_create_error.message, "failed")
+    parent_object.processing_event("UTF error test: #{child_create_error.message}", "failed")
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize

--- a/app/models/child_object.rb
+++ b/app/models/child_object.rb
@@ -207,7 +207,9 @@ class ChildObject < ApplicationRecord
       processing_event("The child object's image file could not be read. Please contact the Technical Lead for Digital Collections for assistance. ------------ Message from System: Child Object #{oid} failed to gather technical image metadata due to #{stderr} and exited with status: #{status}.", "failed")
       # rubocop:enable Layout/LineLength
     end
-    formatted_stdout = stdout.split(/\n/).map { |a| a.split('  : ') }.map { |a| [a.first.strip, a.last] }.to_h
+    # Scrub invalid UTF-8 bytes from exiftool output (EXIF metadata can contain non-UTF-8 characters)
+    sanitized_stdout = stdout.encode('UTF-8', invalid: :replace, undef: :replace, replace: "\uFFFD")
+    formatted_stdout = sanitized_stdout.split(/\n/).map { |a| a.split('  : ') }.map { |a| [a.first.strip, a.last] }.to_h
     self.image_metadata = formatted_stdout
     self.x_resolution = formatted_stdout["XResolution"].presence || formatted_stdout["WidthResolution"]
     self.y_resolution = formatted_stdout["YResolution"].presence || formatted_stdout["HeightResolution"]


### PR DESCRIPTION
## Summary  
Some Update and Sync jobs were failing for an `invalid byte sequence in UTF-8`. Some technical metadata getting pulled in was not UTF-8 compliant. This PR sanitizes and encodes any invalid characters pulled in from technical metadata. 