### PR TITLE
Disable PostInstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,9 @@ RUN groupadd -g 117 goobi && usermod -aG goobi app
 # cached pages / assets to be kept and cleaned the way Rails expects them to be while keeping deployment very fast.
 # The assets/packs get copied back by rsync on app load (see ops/nginx.sh)
 RUN /sbin/setuser app bash -l -c " \
-    SECRET_KEY_BASE=thisisfakesoassetscompile RAILS_ENV=production RAILS_RELATIVE_URL_ROOT=/management DB_ADAPTER=nulldb yarn install && bundle exec rake assets:precompile && \
+    SECRET_KEY_BASE=thisisfakesoassetscompile RAILS_ENV=production RAILS_RELATIVE_URL_ROOT=/management DB_ADAPTER=nulldb yarn install --ignore-scripts && \
+    yarn run structure-editor-install && \
+    bundle exec rake assets:precompile && \
     mv ./public/assets ./public/assets-new && \
     mv ./public/packs ./public/packs-new"
 


### PR DESCRIPTION
## Summary  
Adds `ignore-scripts` to package installation to prevent any malicious scripts.