### PR TITLE
Asserts id as primary key for versions table

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Version < ApplicationRecord
+  self.primary_key = :id
+end


### PR DESCRIPTION
# Summary
Sets the :id attribute as the primary key for the versions table.

# Related Ticket
[#3267](https://github.com/yalelibrary/YUL-DC/issues/3267)