### PR TITLE
Ladybird skip for non-test environments

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -414,8 +414,8 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     fetch_results = case authoritative_metadata_source&.metadata_cloud_name
                     when "ladybird"
                       unless ENV.fetch("RAILS_ENV") == "test"
-                        processing_event("Metadata fetch failed: Ladybird is not available as a metadata source in this environment. Please update the authoritative metadata source.", "failed")
-                        return false
+                        processing_event("Metadata fetch skipped for Ladybird data source. Ladybird is not available as a metadata source in this environment.", "metadata-fetch-skipped")
+                        return true
                       end
                       self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self)
                     when "alma"

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -412,11 +412,15 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     fetch_results = case authoritative_metadata_source&.metadata_cloud_name
                     when "ladybird"
+                      unless ENV.fetch("RAILS_ENV") == "test"
+                        processing_event("Metadata fetch failed: Ladybird is not available as a metadata source in this environment. Please update the authoritative metadata source.", "failed")
+                        return false
+                      end
                       self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self)
                     when "alma"
                       self.alma_json = MetadataSource.find_by(metadata_cloud_name: "alma").fetch_record(self)
                     when "aspace"
-                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) unless aspace_uri.present?
+                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) if ENV.fetch("RAILS_ENV") == "test" && !aspace_uri.present?
                       begin
                         self.aspace_json = MetadataSource.find_by(metadata_cloud_name: "aspace").fetch_record(self)
                       rescue MetadataSource::MetadataCloudNotFoundError

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -403,6 +403,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def default_fetch(_current_batch_process = current_batch_process, _current_batch_connection = current_batch_connection)
     # Skip metadata fetch for Sierra and ILS (Voyager)
     if ["sierra", "ils"].include?(authoritative_metadata_source&.metadata_cloud_name)
@@ -443,6 +444,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def force_private
     self.visibility = "Private"

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe SetupMetadataJob, type: :job, prep_admin_sets: true, prep_metadat
 
         metadata_job.perform(parent_object, batch_process)
 
-        expect(parent_object).not_to have_received(:processing_event).with("Metadata fetch skipped for Ladybird data source. Ladybird is not available as a metadata source in this environment.", "metadata-fetch-skipped")
+        expect(parent_object).not_to have_received(:processing_event).with("Metadata fetch skipped for Ladybird data source. Ladybird is not available as a metadata source in this environment.",
+"metadata-fetch-skipped")
         expect(parent_object.ladybird_json).not_to be_nil
       end
     end
@@ -120,7 +121,8 @@ RSpec.describe SetupMetadataJob, type: :job, prep_admin_sets: true, prep_metadat
 
         metadata_job.perform(parent_object, batch_process)
 
-        expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for Ladybird data source. Ladybird is not available as a metadata source in this environment.", "metadata-fetch-skipped")
+        expect(parent_object).to have_received(:processing_event).with("Metadata fetch skipped for Ladybird data source. Ladybird is not available as a metadata source in this environment.",
+"metadata-fetch-skipped")
         expect(parent_object.ladybird_json).to be_nil
       end
 


### PR DESCRIPTION
## Summary  
Allows Ladybird ingests in Test environment. Logs a skip message to users for all ladybird ingests in demo, uat, and production. 