### PR TITLE
Skip Blank Metadata Values

### DIFF
--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -176,7 +176,7 @@ class IiifPresentationV3
         end
       end
 
-      values << metadata_pair(hash[:label], value) if value
+      values << metadata_pair(hash[:label], value) if value.present?
     end
     values
   end


### PR DESCRIPTION
## Summary  
When a metadata field was deleted, an empty string remained which was being displayed in the UV panel. This PR now checks if metadata values are present before building the values. 