### PR TITLE
Ensure only one job is queued for preservica sync

### DIFF
--- a/app/models/concerns/sync_from_preservica.rb
+++ b/app/models/concerns/sync_from_preservica.rb
@@ -67,8 +67,8 @@ module SyncFromPreservica
   def sync_images_preservica(local_children_hash, preservica_children_hash, parent_object)
     # always update
     # if local_children_hash != preservica_children_hash
-    setup_for_background_jobs(parent_object, parent_object.source_name)
     parent_object.sync_from_preservica(local_children_hash, preservica_children_hash)
+    setup_for_background_jobs(parent_object, parent_object.source_name)
     # else
     #   batch_processing_event("Child object count and order is the same.  No update needed.", "Skipped Row")
     # end

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -112,6 +112,7 @@ module Updatable
 
       parent_object.update!(processed_fields)
       parent_object.reload
+      trigger_setup_metadata(parent_object) unless /preservica/i.match?(parent_object.digital_object_source)
 
       sync_single_parent_from_preservica(parent_object, row) if /preservica/i.match?(parent_object.digital_object_source)
 

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -112,7 +112,6 @@ module Updatable
 
       parent_object.update!(processed_fields)
       parent_object.reload
-      trigger_setup_metadata(parent_object)
 
       sync_single_parent_from_preservica(parent_object, row) if /preservica/i.match?(parent_object.digital_object_source)
 

--- a/spec/system/batch_process_update_parent_spec.rb
+++ b/spec/system/batch_process_update_parent_spec.rb
@@ -141,11 +141,11 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
         expect(page).to have_content "Submitted #{today}"
         expect(page).to have_content "Processing Queued Pending"
-        expect(page).to have_content "Metadata Fetched Pending"
-        expect(page).to have_content "Child Records Created Pending"
-        expect(page).to have_content "Manifest Saved Pending"
-        expect(page).to have_content "Solr Indexed Pending"
-        expect(page).to have_content "PDF Generated Pending"
+        expect(page).to have_content "Metadata Fetched #{today}"
+        expect(page).to have_content "Child Records Created #{today}"
+        expect(page).to have_content "Manifest Saved #{today}"
+        expect(page).to have_content "Solr Indexed #{today}"
+        expect(page).to have_content "PDF Generated #{today}"
       end
     end
   end

--- a/spec/system/batch_process_update_parent_spec.rb
+++ b/spec/system/batch_process_update_parent_spec.rb
@@ -141,11 +141,11 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
         expect(page).to have_content "Submitted #{today}"
         expect(page).to have_content "Processing Queued Pending"
-        expect(page).to have_content "Metadata Fetched #{today}"
-        expect(page).to have_content "Child Records Created #{today}"
-        expect(page).to have_content "Manifest Saved #{today}"
-        expect(page).to have_content "Solr Indexed #{today}"
-        expect(page).to have_content "PDF Generated #{today}"
+        expect(page).to have_content "Metadata Fetched Pending"
+        expect(page).to have_content "Child Records Created Pending"
+        expect(page).to have_content "Manifest Saved Pending"
+        expect(page).to have_content "Solr Indexed Pending"
+        expect(page).to have_content "PDF Generated Pending"
       end
     end
   end


### PR DESCRIPTION
# Summary
During the preservica sync process two Setup Metadata Jobs were queued.  This PR ensures that only a single job is queued for the process.

# Related Ticket
[#3270](https://github.com/yalelibrary/YUL-DC/issues/3270)