### PR TITLE
Mint OIDs with different start points for different clusters

### DIFF
--- a/app/services/oid_minter_service.rb
+++ b/app/services/oid_minter_service.rb
@@ -11,6 +11,8 @@ class OidMinterService
     oids
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def self.initialize_sequence!
     initial_value = if ENV['CLUSTER_NAME'] == 'yul-dc-demo' && ENV['RAILS_ENV'] == 'production'
                       20_000_000
@@ -27,4 +29,6 @@ class OidMinterService
     ActiveRecord::Base.connection.execute("CREATE SEQUENCE IF NOT EXISTS OID_SEQUENCE START WITH #{initial_value};")
     initial_value
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/app/services/oid_minter_service.rb
+++ b/app/services/oid_minter_service.rb
@@ -12,7 +12,17 @@ class OidMinterService
   end
 
   def self.initialize_sequence!
-    initial_value = Rails.application.config.oid_sequence_initial_value
+    initial_value = if ENV['CLUSTER_NAME'] == 'yul-dc-demo'
+                      20_000_000
+                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-test'
+                      40_000_000
+                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-uat'
+                      50_000_000
+                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-prod' || ENV['RAILS_ENV'] == 'development' || ENV['RAILS_ENV'] == 'test'
+                      Rails.application.config.oid_sequence_initial_value
+                    else
+                      60_000_000
+                    end
     # This does nothing if the sequence already exists
     ActiveRecord::Base.connection.execute("CREATE SEQUENCE IF NOT EXISTS OID_SEQUENCE START WITH #{initial_value};")
     initial_value

--- a/app/services/oid_minter_service.rb
+++ b/app/services/oid_minter_service.rb
@@ -12,13 +12,13 @@ class OidMinterService
   end
 
   def self.initialize_sequence!
-    initial_value = if ENV['CLUSTER_NAME'] == 'yul-dc-demo'
+    initial_value = if ENV['CLUSTER_NAME'] == 'yul-dc-demo' && ENV['RAILS_ENV'] == 'production'
                       20_000_000
-                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-test'
+                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-test' && ENV['RAILS_ENV'] == 'production'
                       40_000_000
-                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-uat'
+                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-uat' && ENV['RAILS_ENV'] == 'production'
                       50_000_000
-                    elsif ENV['CLUSTER_NAME'] == 'yul-dc-prod' || ENV['RAILS_ENV'] == 'development' || ENV['RAILS_ENV'] == 'test'
+                    elsif (ENV['CLUSTER_NAME'] == 'yul-dc-prod' && ENV['RAILS_ENV'] == 'production') || ENV['RAILS_ENV'] == 'development' || ENV['RAILS_ENV'] == 'test'
                       Rails.application.config.oid_sequence_initial_value
                     else
                       60_000_000

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
 
   # Set the initial value for the OID sequence.
   # The dev and test environments have very high starting values to distinguish from prod
-  config.oid_sequence_initial_value = 300_000_000
+  config.oid_sequence_initial_value = 100_000_000
 
   config.active_job.queue_adapter = :good_job
 

--- a/spec/services/oid_minter_service_spec.rb
+++ b/spec/services/oid_minter_service_spec.rb
@@ -73,4 +73,28 @@ describe OidMinterService do
       expect(oids[0]).to be >= 30_000_000
     end
   end
+  context 'when in test environment' do
+    around do |example|
+      original_environment_name = ENV['RAILS_ENV']
+      ENV['RAILS_ENV'] = 'test'
+      example.run
+      ENV['RAILS_ENV'] = original_environment_name
+    end
+    it 'initializes the sequence with the expected value' do
+      oids = described_class.generate_oids(1)
+      expect(oids[0]).to be >= 200_000_000
+    end
+  end
+  context 'when in development environment' do
+    around do |example|
+      original_environment_name = ENV['RAILS_ENV']
+      ENV['RAILS_ENV'] = 'development'
+      example.run
+      ENV['RAILS_ENV'] = original_environment_name
+    end
+    it 'initializes the sequence with the expected value' do
+      oids = described_class.generate_oids(1)
+      expect(oids[0]).to be >= 100_000_000
+    end
+  end
 end

--- a/spec/services/oid_minter_service_spec.rb
+++ b/spec/services/oid_minter_service_spec.rb
@@ -25,4 +25,52 @@ describe OidMinterService do
       expect(oids.length).to equal oids.uniq.length
     end
   end
+  context 'when in yul-dc-demo cluster environment' do
+    around do |example|
+      original_cluster_name = ENV['CLUSTER_NAME']
+      ENV['CLUSTER_NAME'] = 'yul-dc-demo'
+      example.run
+      ENV['CLUSTER_NAME'] = original_cluster_name
+    end
+    it 'initializes the sequence with the expected value' do
+      oids = described_class.generate_oids(1)
+      expect(oids[0]).to be >= 20_000_000
+    end
+  end
+  context 'when in yul-dc-test cluster environment' do
+    around do |example|
+      original_cluster_name = ENV['CLUSTER_NAME']
+      ENV['CLUSTER_NAME'] = 'yul-dc-test'
+      example.run
+      ENV['CLUSTER_NAME'] = original_cluster_name
+    end
+    it 'initializes the sequence with the expected value' do
+      oids = described_class.generate_oids(1)
+      expect(oids[0]).to be >= 40_000_000
+    end
+  end
+  context 'when in yul-dc-uat cluster environment' do
+    around do |example|
+      original_cluster_name = ENV['CLUSTER_NAME']
+      ENV['CLUSTER_NAME'] = 'yul-dc-uat'
+      example.run
+      ENV['CLUSTER_NAME'] = original_cluster_name
+    end
+    it 'initializes the sequence with the expected value' do
+      oids = described_class.generate_oids(1)
+      expect(oids[0]).to be >= 50_000_000
+    end
+  end
+  context 'when in yul-dc-prod cluster environment' do
+    around do |example|
+      original_cluster_name = ENV['CLUSTER_NAME']
+      ENV['CLUSTER_NAME'] = 'yul-dc-prod'
+      example.run
+      ENV['CLUSTER_NAME'] = original_cluster_name
+    end
+    it 'initializes the sequence with the expected value' do
+      oids = described_class.generate_oids(1)
+      expect(oids[0]).to be >= 30_000_000
+    end
+  end
 end


### PR DESCRIPTION
# Summary
Changes the starting point for OID minting per each cluster environment.

# Related Ticket
[#3201](https://github.com/yalelibrary/YUL-DC/issues/3201)