### PR TITLE
Frozen Lockfile For CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN groupadd -g 117 goobi && usermod -aG goobi app
 # cached pages / assets to be kept and cleaned the way Rails expects them to be while keeping deployment very fast.
 # The assets/packs get copied back by rsync on app load (see ops/nginx.sh)
 RUN /sbin/setuser app bash -l -c " \
-    SECRET_KEY_BASE=thisisfakesoassetscompile RAILS_ENV=production RAILS_RELATIVE_URL_ROOT=/management DB_ADAPTER=nulldb yarn install --ignore-scripts && \
+    SECRET_KEY_BASE=thisisfakesoassetscompile RAILS_ENV=production RAILS_RELATIVE_URL_ROOT=/management DB_ADAPTER=nulldb yarn install --ignore-scripts --frozen-lockfile && \
     yarn run structure-editor-install && \
     bundle exec rake assets:precompile && \
     mv ./public/assets ./public/assets-new && \


### PR DESCRIPTION
## Summary  
Adds `--frozen-lockfile` to yarn install. This checks that package.json versions are the same versions in yarn.lock. CI builds will fail if they do not match.