### PR TITLE
Frozen Attribute Error on Preservica Resync

### DIFF
--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -414,7 +414,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     fetch_results = case authoritative_metadata_source&.metadata_cloud_name
                     when "ladybird"
-                      unless ENV.fetch("RAILS_ENV", "development") == "test"
+                      unless ENV.fetch("RAILS_ENV") == "test"
                         processing_event("Metadata fetch skipped for Ladybird data source. Ladybird is not available as a metadata source in this environment.", "metadata-fetch-skipped")
                         return true
                       end
@@ -422,7 +422,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
                     when "alma"
                       self.alma_json = MetadataSource.find_by(metadata_cloud_name: "alma").fetch_record(self)
                     when "aspace"
-                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) if ENV.fetch("RAILS_ENV", "development") == "test" && !aspace_uri.present?
+                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) if ENV.fetch("RAILS_ENV") == "test" && !aspace_uri.present?
                       begin
                         self.aspace_json = MetadataSource.find_by(metadata_cloud_name: "aspace").fetch_record(self)
                       rescue MetadataSource::MetadataCloudNotFoundError

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -243,10 +243,17 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def sync_from_preservica(_local_children_hash, preservica_children_hash)
     check_for_sha512_checksum
     Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ hits method with local and preservica children - (local_children_hash keys count): #{_local_children_hash.keys.count} && (preservica_children_hash key count): #{preservica_children_hash.keys.count} *************"
+    Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ preservica_children_hash: #{preservica_children_hash.inspect} *************"
+    preservica_children_hash.each do |key, value|
+      Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ preservica_children_hash key: #{key}, checksum: #{value[:checksum]}, content_uri: #{value[:content_uri]} *************"
+    end
     # iterate through local hashes and remove any children no longer found on preservica
     child_objects.each do |co|
-      co.destroy! unless found_in_preservica(co.sha512_checksum, preservica_children_hash)
+      result = found_in_preservica(co.sha512_checksum, preservica_children_hash)
+      Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ child oid: #{co.oid}, sha512_checksum: #{co.sha512_checksum}, found_in_preservica: #{result} *************"
+      co.destroy! unless result
     end
+    
     child_objects.reset
     # iterate through preservica and update when local version found
     sync_from_preservica_update_existing_children(preservica_children_hash)

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -243,15 +243,9 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def sync_from_preservica(_local_children_hash, preservica_children_hash)
     check_for_sha512_checksum
     Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ hits method with local and preservica children - (local_children_hash keys count): #{_local_children_hash.keys.count} && (preservica_children_hash key count): #{preservica_children_hash.keys.count} *************"
-    Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ preservica_children_hash: #{preservica_children_hash.inspect} *************"
-    preservica_children_hash.each do |key, value|
-      Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ preservica_children_hash key: #{key}, checksum: #{value[:checksum]}, content_uri: #{value[:content_uri]} *************"
-    end
     # iterate through local hashes and remove any children no longer found on preservica
     child_objects.each do |co|
-      result = found_in_preservica(co.sha512_checksum, preservica_children_hash)
-      Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ child oid: #{co.oid}, sha512_checksum: #{co.sha512_checksum}, found_in_preservica: #{result} *************"
-      co.destroy! unless result
+      co.destroy! unless found_in_preservica(co.sha512_checksum, preservica_children_hash)
     end
     child_objects.reset
     # iterate through preservica and update when local version found
@@ -297,7 +291,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def found_in_preservica(local_checksum, preservica_children_hash)
     preservica_children_hash.any? do |_, value|
-      value[:checksum] == local_checksum
+      value[:checksum]&.casecmp(local_checksum)&.zero?
     end
   end
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -253,7 +253,6 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
       Rails.logger.info "************ parent_object.rb # sync_from_preservica +++ child oid: #{co.oid}, sha512_checksum: #{co.sha512_checksum}, found_in_preservica: #{result} *************"
       co.destroy! unless result
     end
-    
     child_objects.reset
     # iterate through preservica and update when local version found
     sync_from_preservica_update_existing_children(preservica_children_hash)

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -291,7 +291,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def found_in_preservica(local_checksum, preservica_children_hash)
     preservica_children_hash.any? do |_, value|
-      value[:checksum]&.casecmp(local_checksum)&.zero?
+      value[:checksum]&.downcase == local_checksum&.downcase
     end
   end
 

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -247,6 +247,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     child_objects.each do |co|
       co.destroy! unless found_in_preservica(co.sha512_checksum, preservica_children_hash)
     end
+    child_objects.reset
     # iterate through preservica and update when local version found
     sync_from_preservica_update_existing_children(preservica_children_hash)
 
@@ -413,7 +414,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     fetch_results = case authoritative_metadata_source&.metadata_cloud_name
                     when "ladybird"
-                      unless ENV.fetch("RAILS_ENV") == "test"
+                      unless ENV.fetch("RAILS_ENV", "development") == "test"
                         processing_event("Metadata fetch skipped for Ladybird data source. Ladybird is not available as a metadata source in this environment.", "metadata-fetch-skipped")
                         return true
                       end
@@ -421,7 +422,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
                     when "alma"
                       self.alma_json = MetadataSource.find_by(metadata_cloud_name: "alma").fetch_record(self)
                     when "aspace"
-                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) if ENV.fetch("RAILS_ENV") == "test" && !aspace_uri.present?
+                      self.ladybird_json = MetadataSource.find_by(metadata_cloud_name: "ladybird").fetch_record(self) if ENV.fetch("RAILS_ENV", "development") == "test" && !aspace_uri.present?
                       begin
                         self.aspace_json = MetadataSource.find_by(metadata_cloud_name: "aspace").fetch_record(self)
                       rescue MetadataSource::MetadataCloudNotFoundError


### PR DESCRIPTION
## Summary  
This PR fixes 2 bugs.  
1.)  After a child is deleted, we immediately perform another sync and preservica update on cached/deleted children, which was the cause of the frozen attribute error. We now reload the child objects before sync_from_preservica_update_existing_children.
2.) Applied downcase to value[:checksum] because we store checksums in downcase and they are capitalized in preservica child hashes, which was causing children to be deleted on resyncs when the checksums are compared. The checksums are now compared in the same case sensitivity. 