### PR TITLE
Adds Time Delay to Preservica Retry Process

### DIFF
--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -31,7 +31,6 @@ class PreservicaImageService
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Lint/UselessAssignment
   def image_list(representation_type)
     @images = []
     attempt_count ||= 1
@@ -54,6 +53,7 @@ class PreservicaImageService
           @information_objects = [Preservica::InformationObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)]
         rescue Net::HTTPFatalError, Net::ReadTimeout => e
           sleep 30
+          retry if attempt_count < 4
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end
       end
@@ -75,7 +75,6 @@ class PreservicaImageService
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Lint/UselessAssignment
 
   # rubocop:disable Layout/LineLength
   # rubocop:disable Metrics/AbcSize

--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -31,6 +31,7 @@ class PreservicaImageService
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Lint/UselessAssignment
   def image_list(representation_type)
     @images = []
     attempt_count ||= 1
@@ -41,6 +42,7 @@ class PreservicaImageService
           attempt_count += 1
           @information_objects = structural_object.information_objects
         rescue Net::HTTPFatalError, Net::ReadTimeout => e
+          sleep 30
           retry if attempt_count < 4
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         rescue Net::OpenTimeout, Errno::ECONNREFUSED => e
@@ -51,7 +53,7 @@ class PreservicaImageService
           attempt_count += 1
           @information_objects = [Preservica::InformationObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)]
         rescue Net::HTTPFatalError, Net::ReadTimeout => e
-          retry if attempt_count < 4
+          sleep 30
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end
       end
@@ -73,6 +75,7 @@ class PreservicaImageService
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Lint/UselessAssignment
 
   # rubocop:disable Layout/LineLength
   # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
# Summary
This PR will add a 30 second delay to the retry process for Preservica ingests.

# Related Ticket 
[#3130](https://github.com/yalelibrary/YUL-DC/issues/3031)