### PR TITLE
Fix Flaky Specs in Management

### DIFF
--- a/spec/datatables/users_datatable_spec.rb
+++ b/spec/datatables/users_datatable_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe UserDatatable, type: :datatable do
   columns = ['netid', 'email', 'deactivated']
 
   describe 'user data tables' do
+    # Datatables get_raw_records returns User.all, any stale User records from other tests in the suite will cause flaky specs.
+    before { User.destroy_all }
+
     it 'can handle an empty model set' do
       output = UserDatatable.new(datatable_sample_params(columns)).data
 

--- a/spec/models/preservica/preservica_child_sync_spec.rb
+++ b/spec/models/preservica/preservica_child_sync_spec.rb
@@ -106,15 +106,12 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
 
     it 'can reingest child objects and keep oids, captions and labels but replace image source location' do
       allow(S3Service).to receive(:s3_exists?).and_return(false)
-      expect(ParentObject.count).to eq 1
-      expect(ChildObject.count).to eq 3
-      po_first = ParentObject.first
-      co_first = ChildObject.first
-      expect(co_first.oid).to eq 1_002_533
-      expect(co_first.caption).to eq 'original first caption'
-      expect(co_first.label).to eq 'original first label'
-      expect(co_first.checksum).to eq 'c314697a5b0fd444e26e7c12a1d8d487545dacfc'
-      expect(po_first.last_preservica_update).to be nil
+      expect(aspace_parent.child_objects.count).to eq 3
+      expect(co_1.oid).to eq 1_002_533
+      expect(co_1.caption).to eq 'original first caption'
+      expect(co_1.label).to eq 'original first label'
+      expect(co_1.checksum).to eq 'c314697a5b0fd444e26e7c12a1d8d487545dacfc'
+      expect(aspace_parent.last_preservica_update).to be nil
       expect(ptf_1.access_primary_path).to eq "spec/fixtures/images/access_primaries/03/33/10/02/53/1002533.tif"
       expect(ptf_2.access_primary_path).to eq "spec/fixtures/images/access_primaries/03/34/10/02/53/1002534.tif"
       expect(ptf_3.access_primary_path).to eq "spec/fixtures/images/access_primaries/03/35/10/02/53/1002535.tif"
@@ -124,12 +121,12 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         reingest_batch_process.file = preservica_reingest
         reingest_batch_process.save!
       end.not_to change { ChildObject.count }
-      po_first = ParentObject.first
-      co_first = ChildObject.first
-      co_second = ChildObject.all[1]
-      co_third = ChildObject.last
+      aspace_parent.reload
+      co_first = co_1.reload
+      co_second = co_2.reload
+      co_third = co_3.reload
 
-      expect(po_first.last_preservica_update).not_to be nil
+      expect(aspace_parent.last_preservica_update).not_to be nil
       expect(co_first.last_preservica_update).not_to be nil
       expect(co_first.sha512_checksum).to eq '1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7'
       expect(co_first.oid).to eq 1_002_533

--- a/spec/models/preservica/preservica_owp_import_spec.rb
+++ b/spec/models/preservica/preservica_owp_import_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     expect do
       batch_process.file = preservica_owp_parent_with_children
       batch_process.save
-    end.to change { ChildObject.count }.from(0).to(3)
-    po_first = ParentObject.first
-    co_first = ChildObject.first
+    end.to change { ChildObject.count }.by(3)
+    po_first = ParentObject.find(200_000_000)
+    co_first = po_first.child_objects.order(:order).first
     expect(co_first.oid).to eq 200_000_001
     expect(co_first.parent_object_oid).to eq 200_000_000
     expect(co_first.order).to eq 1
-    co_last = ChildObject.last
+    co_last = po_first.child_objects.order(:order).last
     expect(co_last.order).to eq 3
     expect(po_first.last_preservica_update).not_to eq nil
     expect(po_first.visibility).to eq "Open with Permission"

--- a/spec/system/parent_object_spec.rb
+++ b/spec/system/parent_object_spec.rb
@@ -82,8 +82,10 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         expect(page.body).to include "continuous"
       end
 
+      # adds an additional expectation to ensure capybara does not visit the showpage before the update has posted. Classic race condition.
       it "can set the rights statement via the UI" do
         click_on("Create Parent object")
+        expect(page).to have_content("Parent object was successfully created")
         click_on("Edit")
         expect(page).to have_field("Rights statement")
         fill_in("Rights statement", with: "This is a rights statement")
@@ -199,6 +201,8 @@ RSpec.describe "ParentObjects", type: :system, prep_metadata_sources: true, prep
         click_on("Edit")
         select 'Sterling', from: "parent_object[admin_set]"
         click_on(UPDATE_PARENT_OBJECT_BUTTON)
+        # adds an additional expectation to ensure capybara does not visit the showpage before the update has posted. Classic race condition.
+        expect(page).to have_content("Parent object was successfully saved")
 
         visit parent_object_path(2_012_036)
         expect(page).to have_content "Sterling"


### PR DESCRIPTION
## Summary  
Addresses flaky specs. Mostly race conditions and adds specific ParentObject/ChildObject variable assignments instead of .all/.first/.last