### PR TITLE
Fixes Double BP Messages

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -112,7 +112,6 @@ module Updatable
 
       parent_object.update!(processed_fields)
       parent_object.reload
-      trigger_setup_metadata(parent_object) unless /preservica/i.match?(parent_object.digital_object_source)
 
       sync_single_parent_from_preservica(parent_object, row) if /preservica/i.match?(parent_object.digital_object_source)
 

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -111,8 +111,9 @@ module Updatable
       end
 
       parent_object.update!(processed_fields)
+      metadata_source_changed = parent_object.saved_changes.key?("authoritative_metadata_source_id")
       parent_object.reload
-      trigger_setup_metadata(parent_object) unless /preservica/i.match?(parent_object.digital_object_source) || parent_object.saved_changes.key?("authoritative_metadata_source_id")
+      trigger_setup_metadata(parent_object) unless /preservica/i.match?(parent_object.digital_object_source) || metadata_source_changed
 
       sync_single_parent_from_preservica(parent_object, row) if /preservica/i.match?(parent_object.digital_object_source)
 

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -112,6 +112,7 @@ module Updatable
 
       parent_object.update!(processed_fields)
       parent_object.reload
+      trigger_setup_metadata(parent_object) unless /preservica/i.match?(parent_object.digital_object_source) || parent_object.saved_changes.key?("authoritative_metadata_source_id")
 
       sync_single_parent_from_preservica(parent_object, row) if /preservica/i.match?(parent_object.digital_object_source)
 


### PR DESCRIPTION
## Summary  
Adds additional conditional to method that triggers setup metadata job a second time. Skip second metadata job if the source has changed through the update. 
  
Old Process:  
Update PO triggered  
PO saved
after_save callback triggers setup metadata job
setup metadata job triggers and succeeds when the PO source was changed
trigger_setup_metadata is triggered again in updatable
SetupMetadataJob runs again  
  
NOTE: This is only an issue when the PO source is changed/updated because the after_save callback wont run if the source has not changed.  
  
New Process:  
skip trigger_setup_metadata when the metadata source changed, because the after_save callback already enqueued a SetupMetadataJob for that case. Only calls trigger_setup_metadata when the callback didn't fire (i.e., the metadata source stayed the same).  
  

