### PR TITLE
502 Gateway Error for Digital Object Source Preservica

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -48,7 +48,6 @@ class ParentObjectsController < ApplicationController
     batch_process_of_one
     respond_to do |format|
       if @parent_object.save
-        queue_parent_metadata_update
         format.html { redirect_to @parent_object, notice: 'Parent object was successfully created.' }
         format.json { render :show, status: :created, location: @parent_object }
       else

--- a/app/jobs/create_preservica_children_job.rb
+++ b/app/jobs/create_preservica_children_job.rb
@@ -5,6 +5,10 @@ class CreatePreservicaChildrenJob < ApplicationJob
   retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, attempts: 3
   queue_as :default
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
   def perform(parent_object, current_batch_process, current_batch_connection = parent_object.current_batch_connection)
     parent_object.current_batch_process = current_batch_process
     parent_object.current_batch_connection = current_batch_connection
@@ -34,4 +38,8 @@ class CreatePreservicaChildrenJob < ApplicationJob
     parent_object.processing_event("Preservica child creation failed: #{e.message}", "failed")
     raise
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/app/jobs/create_preservica_children_job.rb
+++ b/app/jobs/create_preservica_children_job.rb
@@ -2,7 +2,6 @@
 
 class CreatePreservicaChildrenJob < ApplicationJob
   FIVE_HUNDRED_MB = 524_288_000
-  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, attempts: 3
   queue_as :default
 
   # rubocop:disable Metrics/AbcSize
@@ -36,7 +35,6 @@ class CreatePreservicaChildrenJob < ApplicationJob
     end
   rescue => e
     parent_object.processing_event("Preservica child creation failed: #{e.message}", "failed")
-    raise
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/jobs/create_preservica_children_job.rb
+++ b/app/jobs/create_preservica_children_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CreatePreservicaChildrenJob < ApplicationJob
+  FIVE_HUNDRED_MB = 524_288_000
+  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, attempts: 3
+  queue_as :default
+
+  def perform(parent_object, current_batch_process, current_batch_connection = parent_object.current_batch_connection)
+    parent_object.current_batch_process = current_batch_process
+    parent_object.current_batch_connection = current_batch_connection
+    parent_object.create_child_records
+    parent_object.save!
+    parent_object.reload
+    parent_object.gather_technical_image_metadata
+    parent_object.processing_event("Child object records have been created", "child-records-created")
+    ptiff_jobs_queued = false
+    parent_object.child_objects.each do |child|
+      current_batch_process&.setup_for_background_jobs(child, nil)
+      if child.pyramidal_tiff.height_and_width? && !child.pyramidal_tiff.force_update && S3Service.s3_exists?(child.remote_ptiff_path)
+        child.processing_event("PTIFF exists on S3, not converting: #{child.oid}", 'ptiff-ready-skipped')
+      else
+        path = Pathname.new(child.access_primary_path)
+        file_size = File.exist?(path) ? File.size(path) : 0
+        GeneratePtiffJob.set(queue: :large_ptiff).perform_later(child, current_batch_process) if file_size > FIVE_HUNDRED_MB
+        GeneratePtiffJob.perform_later(child, current_batch_process) if file_size <= FIVE_HUNDRED_MB
+        child.processing_event("Ptiff Queued", "ptiff-queued")
+        ptiff_jobs_queued = true
+      end
+    end
+    unless ptiff_jobs_queued
+      GenerateManifestJob.perform_later(parent_object, current_batch_process, current_batch_connection) if parent_object.needs_a_manifest?
+    end
+  rescue => e
+    parent_object.processing_event("Preservica child creation failed: #{e.message}", "failed")
+    raise
+  end
+end

--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -75,6 +75,13 @@ class SetupMetadataJob < ApplicationJob
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def setup_child_object_jobs(parent_object, current_batch_process)
+    if parent_object.from_upstream_for_the_first_time? &&
+       (parent_object.digital_object_source == "Preservica" || parent_object.digital_object_source == "preservica")
+      parent_object.save! # Save metadata from default_fetch before deferring to separate job
+      CreatePreservicaChildrenJob.perform_later(parent_object, current_batch_process, parent_object.current_batch_connection)
+      parent_object.processing_event("Preservica child object creation has been queued", "processing-queued")
+      return
+    end
     parent_object.create_child_records if parent_object.from_upstream_for_the_first_time?
     parent_object.save!
     parent_object.reload

--- a/app/jobs/setup_metadata_job.rb
+++ b/app/jobs/setup_metadata_job.rb
@@ -77,6 +77,7 @@ class SetupMetadataJob < ApplicationJob
   def setup_child_object_jobs(parent_object, current_batch_process)
     if parent_object.from_upstream_for_the_first_time? &&
        (parent_object.digital_object_source == "Preservica" || parent_object.digital_object_source == "preservica")
+      parent_object.metadata_update = nil # Clear to prevent after_save from re-queuing SetupMetadataJob
       parent_object.save! # Save metadata from default_fetch before deferring to separate job
       CreatePreservicaChildrenJob.perform_later(parent_object, current_batch_process, parent_object.current_batch_connection)
       parent_object.processing_event("Preservica child object creation has been queued", "processing-queued")

--- a/spec/jobs/create_preservica_children_job_spec.rb
+++ b/spec/jobs/create_preservica_children_job_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, prep_metadata_sources: true do
+  before do
+    allow(GoodJob).to receive(:preserve_job_records).and_return(true)
+    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
+  let(:parent_object) do
+    FactoryBot.create(:parent_object,
+                      oid: 2_034_600,
+                      admin_set: AdminSet.first,
+                      authoritative_metadata_source: MetadataSource.first,
+                      digital_object_source: "Preservica",
+                      preservica_uri: "/structural-objects/test-uuid",
+                      preservica_representation_type: "Access")
+  end
+  let(:job) { described_class.new }
+
+  it 'enqueues the job successfully' do
+    active_job = described_class.perform_later(parent_object, batch_process)
+    expect(active_job.instance_variable_get(:@successfully_enqueued)).to be true
+  end
+
+  it 'uses the default queue' do
+    expect(described_class.new.queue_name).to eq('default')
+  end
+
+  context 'when performing' do
+    before do
+      allow(parent_object).to receive(:create_child_records)
+      allow(parent_object).to receive(:save!)
+      allow(parent_object).to receive(:reload)
+      allow(parent_object).to receive(:gather_technical_image_metadata)
+      allow(parent_object).to receive(:processing_event)
+      allow(parent_object).to receive(:child_objects).and_return([])
+      allow(parent_object).to receive(:needs_a_manifest?).and_return(false)
+    end
+
+    it 'calls create_child_records on the parent object' do
+      job.perform(parent_object, batch_process)
+      expect(parent_object).to have_received(:create_child_records)
+    end
+
+    it 'saves and reloads the parent object' do
+      job.perform(parent_object, batch_process)
+      expect(parent_object).to have_received(:save!)
+      expect(parent_object).to have_received(:reload)
+    end
+
+    it 'gathers technical image metadata' do
+      job.perform(parent_object, batch_process)
+      expect(parent_object).to have_received(:gather_technical_image_metadata)
+    end
+
+    it 'logs a child-records-created event' do
+      job.perform(parent_object, batch_process)
+      expect(parent_object).to have_received(:processing_event).with("Child object records have been created", "child-records-created")
+    end
+  end
+end

--- a/spec/jobs/setup_metadata_job_spec.rb
+++ b/spec/jobs/setup_metadata_job_spec.rb
@@ -87,6 +87,41 @@ RSpec.describe SetupMetadataJob, type: :job, prep_admin_sets: true, prep_metadat
     end
   end
 
+  context 'first-time Preservica parent object' do
+    let(:preservica_parent) do
+      FactoryBot.create(:parent_object,
+                        oid: 2_034_600,
+                        admin_set: AdminSet.first,
+                        authoritative_metadata_source: MetadataSource.first,
+                        digital_object_source: "Preservica",
+                        preservica_uri: "/structural-objects/test-uuid",
+                        preservica_representation_type: "Access")
+    end
+
+    before do
+      allow(preservica_parent).to receive(:default_fetch).and_return(true)
+      allow(preservica_parent).to receive(:processing_event)
+      allow(preservica_parent).to receive(:from_upstream_for_the_first_time?).and_return(true)
+      allow(preservica_parent).to receive(:save!)
+      allow(CreatePreservicaChildrenJob).to receive(:perform_later)
+    end
+
+    it 'queues CreatePreservicaChildrenJob instead of creating children inline' do
+      metadata_job.perform(preservica_parent, batch_process)
+      expect(CreatePreservicaChildrenJob).to have_received(:perform_later).with(preservica_parent, batch_process, anything)
+    end
+
+    it 'saves metadata before queuing the child creation job' do
+      metadata_job.perform(preservica_parent, batch_process)
+      expect(preservica_parent).to have_received(:save!).at_least(:once)
+    end
+
+    it 'does not call create_child_records inline' do
+      expect(preservica_parent).not_to receive(:create_child_records)
+      metadata_job.perform(preservica_parent, batch_process)
+    end
+  end
+
   context 'Ladybird metadata fetch environment gating' do
     let(:ladybird_source) { MetadataSource.find_by(metadata_cloud_name: 'ladybird') || FactoryBot.create(:metadata_source) }
 

--- a/spec/models/preservica/preservica_retry_spec.rb
+++ b/spec/models/preservica/preservica_retry_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       end.to change { ChildObject.count }.from(0).to(3)
       expect(batch_process.batch_status).to eq "Batch failed"
       po_first = ParentObject.first
-      expect(po_first.events_for_batch_process(batch_process).count).to eq 8
+      expect(po_first.events_for_batch_process(batch_process).count).to eq 9
       expect(po_first.events_for_batch_process(batch_process)[1].reason).to eq("Retrying Child OID: 200000001 Request error 404 Content object bitstreams cannot be downloaded.")
       expect(po_first.last_preservica_update).not_to eq nil
       expect(po_first.child_objects.count).to eq 3


### PR DESCRIPTION
Metadata fetching and Preservica image downloads for first time ingests/objects were happening in the same job: fetched metadata, called the Preservica API to discover children, downloaded all TIF images, and queued PTIFF generation; potentially causing timeout 502 errors.  

This splits the Preservica child creation into its own background job so that metadata fetch completes and saves independently.  
  
CreatePreservicaChildrenJob does the same exact thing create_child_records does, its just in a separate job now. 