### PR TITLE
Allow Metadata Update when updating Preservica objects 

### DIFF
--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -113,7 +113,7 @@ module Updatable
       parent_object.update!(processed_fields)
       metadata_source_changed = parent_object.saved_changes.key?("authoritative_metadata_source_id")
       parent_object.reload
-      trigger_setup_metadata(parent_object) unless /preservica/i.match?(parent_object.digital_object_source) || metadata_source_changed
+      trigger_setup_metadata(parent_object) unless metadata_source_changed
 
       sync_single_parent_from_preservica(parent_object, row) if /preservica/i.match?(parent_object.digital_object_source)
 


### PR DESCRIPTION
## Summary  
SetupMetadataJob was not being ran for preservica objects being updated via Update BP. This PR removes that guard. 