### PR TITLE
Format link to image

### DIFF
--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -390,7 +390,7 @@ class IiifPresentationV3
     metadata_values <<  metadata_pair('Image Caption', child.caption) if child.caption
     if child.oid
       metadata_values << metadata_pair('Link to this Image',
-"<span><a href='https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}' aria-label='Link to this image'>#{child.oid}</a></span>")
+"<span><a href='https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}' aria-label='Link to this image'>https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}</a></span>")
     end
     canvas['metadata'] = metadata_values
     canvas

--- a/app/models/iiif_presentation_v3.rb
+++ b/app/models/iiif_presentation_v3.rb
@@ -388,7 +388,10 @@ class IiifPresentationV3
     metadata_values <<  metadata_pair('Image ID', child.oid.to_s) if child.oid
     metadata_values <<  metadata_pair('Image Label', child.label) if child.label
     metadata_values <<  metadata_pair('Image Caption', child.caption) if child.caption
-    metadata_values <<  metadata_pair('Link to this Image', "https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}") if child.oid
+    if child.oid
+      metadata_values << metadata_pair('Link to this Image',
+"<span><a href='https://collections.library.yale.edu/catalog/#{@oid}?child_oid=#{child.oid}' aria-label='Link to this image'>#{child.oid}</a></span>")
+    end
     canvas['metadata'] = metadata_values
     canvas
   end

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -217,6 +217,14 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["behavior"].first).to eq "individuals"
     end
 
+    it "has a link to the specific image / child oid in metadata" do
+      expect(iiif_presentation.manifest["items"][0]["metadata"].class).to eq Array
+      expect(iiif_presentation.manifest["items"][0]["metadata"].select { |k| true if k["label"]["en"][0] == "Link to this Image" }).not_to be_empty
+      values = iiif_presentation.manifest["items"][0]["metadata"].select { |k| true if k["label"]["en"][0] == "Link to this Image" }.first["value"]
+      expect(values).not_to be_empty
+      expect(values['none'].first).to include("<span><a href='https://collections.library.yale.edu/catalog/16172421?child_oid=16188699' aria-label='Link to this image'>16188699</a></span>")
+    end
+
     it "includes behavior on the canvas when included on the child_object" do
       co = ChildObject.find(16_188_699)
       co.update(viewing_hint: "non-paged")

--- a/spec/models/iiif_presentation_spec_v3.rb
+++ b/spec/models/iiif_presentation_spec_v3.rb
@@ -222,7 +222,7 @@ RSpec.describe IiifPresentationV3, prep_metadata_sources: true do
       expect(iiif_presentation.manifest["items"][0]["metadata"].select { |k| true if k["label"]["en"][0] == "Link to this Image" }).not_to be_empty
       values = iiif_presentation.manifest["items"][0]["metadata"].select { |k| true if k["label"]["en"][0] == "Link to this Image" }.first["value"]
       expect(values).not_to be_empty
-      expect(values['none'].first).to include("<span><a href='https://collections.library.yale.edu/catalog/16172421?child_oid=16188699' aria-label='Link to this image'>16188699</a></span>")
+      expect(values['none'].first).to include("<span><a href='https://collections.library.yale.edu/catalog/16172421?child_oid=16188699' aria-label='Link to this image'>https://collections.library.yale.edu/catalog/16172421?child_oid=16188699</a></span>")
     end
 
     it "includes behavior on the canvas when included on the child_object" do


### PR DESCRIPTION
# Summary
Reformats the link to the specific image so that it is clickable.

# Related Ticket
[#3298](https://github.com/yalelibrary/YUL-DC/issues/3298)

