### PR TITLE
Total Records Cache

### DIFF
--- a/app/datatables/application_datatable.rb
+++ b/app/datatables/application_datatable.rb
@@ -2,4 +2,16 @@
 
 class ApplicationDatatable < AjaxDatatablesRails::ActiveRecord
   self.nulls_last = true
+
+  private
+
+  def records_filtered_count
+    return records_total_count unless searching?
+
+    super
+  end
+
+  def searching?
+    datatable.searchable? || search_columns.any?
+  end
 end

--- a/app/datatables/child_object_datatable.rb
+++ b/app/datatables/child_object_datatable.rb
@@ -70,4 +70,20 @@ class ChildObjectDatatable < ApplicationDatatable
   def get_raw_records
     ChildObject.accessible_by(@current_ability, :read)
   end
+  # rubocop:enable Naming/AccessorMethodName
+
+  # How long to cache the total record count.
+  TOTAL_COUNT_CACHE_TTL = 10.minutes
+
+  private
+
+  def records_total_count
+    Rails.cache.fetch(total_count_cache_key, expires_in: TOTAL_COUNT_CACHE_TTL) do
+      super
+    end
+  end
+
+  def total_count_cache_key
+    ['child_object_datatable/total_count', Digest::MD5.hexdigest(get_raw_records.to_sql)].join('/')
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -209,8 +209,7 @@ $( document ).on('turbolinks:load', function() {
       initComplete: function () {
         $('.dt-info').appendTo('.main-content');
         $('.dt-paging').appendTo('.main-content');
-        if (hasSearch) onColumnsUpdate(this);
-        
+
         // Add handler for column visibility changes
         $(document).on('click', '.dt-button-collection .dropdown-item', function() {
           $(this).toggleClass('active');
@@ -222,6 +221,8 @@ $( document ).on('turbolinks:load', function() {
       }
 
     })
+
+    if (hasSearch) onColumnsUpdate(dataTable);
     dataTable.api().draw();
     $.fn.dataTable.ext.errMode = 'throw';
 

--- a/spec/datatables/child_object_datatable_spec.rb
+++ b/spec/datatables/child_object_datatable_spec.rb
@@ -43,4 +43,45 @@ RSpec.describe ChildObjectDatatable, type: :datatable, prep_metadata_sources: tr
       DT_RowId: 10_736_292
     )
   end
+
+  describe 'record count optimizations' do
+    let(:ability) { Ability.new(user) }
+    let(:view_mock) { child_object_datatable_view_mock }
+
+    before do
+      stub_metadata_cloud('2004628')
+      admin_set = AdminSet.find_by_key('brbl')
+      @parent_object = FactoryBot.create(:parent_object, admin_set: admin_set)
+      FactoryBot.create(:child_object, oid: 10_736_292, parent_object: @parent_object, caption: 'MyString')
+    end
+
+    it 'reuses the total count for the filtered count when no search is active' do
+      json = ChildObjectDatatable.new(datatable_sample_params(columns), view_context: view_mock, current_ability: ability).as_json
+
+      expect(json[:recordsTotal]).to eq(2)
+      expect(json[:recordsFiltered]).to eq(json[:recordsTotal])
+    end
+
+    it 'computes a reduced filtered count when a search is active, leaving the total intact' do
+      FactoryBot.create(:child_object, oid: 22_222_222, parent_object: @parent_object, caption: 'UniqueCaptionXYZ')
+      searching_params = datatable_sample_params(columns)
+      searching_params['search']['value'] = 'UniqueCaptionXYZ'
+
+      json = ChildObjectDatatable.new(searching_params, view_context: view_mock, current_ability: ability).as_json
+
+      expect(json[:recordsTotal]).to eq(3)
+      expect(json[:recordsFiltered]).to eq(1)
+    end
+
+    it 'serves the total count from cache, independent of new records within the TTL window' do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      build_count = -> { ChildObjectDatatable.new(datatable_sample_params(columns), view_context: view_mock, current_ability: ability).as_json[:recordsTotal] }
+
+      expect(build_count.call).to eq(2)
+      FactoryBot.create(:child_object, oid: 33_333_333, parent_object: @parent_object)
+
+      # A new row now exists, but the cached count is served until the entry expires.
+      expect(build_count.call).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary  
Cache total records count on child object datatable to help the table load faster after initial load. First load will take the normal amount of time, but subsequent loads should be quicker for 10 minutes. This does not affect objects from being viewed in the datatable. It only caches the total records count below the table to prevent .count queries on the entire table on each page load. 