### PR TITLE
Change manual preservica retry to good job configuration

### DIFF
--- a/app/jobs/create_preservica_children_job.rb
+++ b/app/jobs/create_preservica_children_job.rb
@@ -3,7 +3,7 @@
 class CreatePreservicaChildrenJob < ApplicationJob
   FIVE_HUNDRED_MB = 524_288_000
   queue_as :default
-  retry_on Net::HTTPFatalError, Net::HTTPNotFound, Net::ReadTimeout, StandardError, attempts: 3 do |job, exception|
+  retry_on RuntimeError, Net::HTTPFatalError, Net::HTTPNotFound, Net::ReadTimeout, PreservicaImageService::PreservicaImageServiceNetworkError, attempts: 3 do |job, exception|
     parent_arg = job.arguments.first
     parent_oid = parent_arg&.respond_to?(:oid) ? parent_arg.oid : parent_arg&._aj_globalid&.split('/')&.last&.to_i
     parent_object = ParentObject.find_by(oid: parent_oid)

--- a/app/jobs/create_preservica_children_job.rb
+++ b/app/jobs/create_preservica_children_job.rb
@@ -3,6 +3,12 @@
 class CreatePreservicaChildrenJob < ApplicationJob
   FIVE_HUNDRED_MB = 524_288_000
   queue_as :default
+  retry_on Net::HTTPFatalError, Net::HTTPNotFound, Net::ReadTimeout, StandardError, attempts: 3 do |job, exception|
+    parent_arg = job.arguments.first
+    parent_oid = parent_arg&.respond_to?(:oid) ? parent_arg.oid : parent_arg&._aj_globalid&.split('/')&.last&.to_i
+    parent_object = ParentObject.find_by(oid: parent_oid)
+    parent_object&.processing_event("Retrying Child Object Creation - Request error #{exception.message}", "retry")
+  end
 
   def default_priority
     40
@@ -39,6 +45,7 @@ class CreatePreservicaChildrenJob < ApplicationJob
     end
   rescue => e
     parent_object.processing_event("Preservica child creation failed: #{e.message}", "failed")
+    raise
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/jobs/sync_from_preservica_job.rb
+++ b/app/jobs/sync_from_preservica_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SyncFromPreservicaJob < ApplicationJob
-  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, FrozenError, StandardError, attempts: 3 do |job, exception|
+  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, FrozenError, PreservicaImageService::PreservicaImageServiceNetworkError, attempts: 3 do |job, exception|
     batch_arg = job.arguments.first
     batch_process_id = batch_arg&.respond_to?(:id) ? batch_arg.id : batch_arg&._aj_globalid&.split('/')&.last&.to_i
     batch_process = BatchProcess.find_by(id: batch_process_id)

--- a/app/jobs/sync_from_preservica_job.rb
+++ b/app/jobs/sync_from_preservica_job.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class SyncFromPreservicaJob < ApplicationJob
-  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, attempts: 3
+  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, FrozenError, StandardError, attempts: 3 do |job, exception|
+    batch_arg = job.arguments.first
+    batch_process_id = batch_arg&.respond_to?(:id) ? batch_arg.id : batch_arg&._aj_globalid&.split('/')&.last&.to_i
+    batch_process = BatchProcess.find_by(id: batch_process_id)
+    batch_process&.batch_processing_event("Retrying Sync from Preservica - Request error #{exception.message}", "retry")
+  end
   queue_as :default
 
   def default_priority
@@ -12,7 +17,9 @@ class SyncFromPreservicaJob < ApplicationJob
     batch_process.sync_from_preservica
   rescue FrozenError => e
     batch_process.batch_processing_event("Frozen error: #{e.message} at #{e.backtrace.first}", "failed")
+    raise
   rescue => e
     batch_process.batch_processing_event("Setup job failed to save: #{e.message}", "failed")
+    raise
   end
 end

--- a/app/lib/preservica_client.rb
+++ b/app/lib/preservica_client.rb
@@ -15,11 +15,15 @@ class PreservicaClient
   def initialize(args)
     @host = args[:base_url] || "https://#{ENV['PRESERVICA_HOST']}"
     if args[:admin_set_key]
-      credentials = JSON.parse(ENV['PRESERVICA_CREDENTIALS'])[args[:admin_set_key]]
+      raw_credentials = ENV['PRESERVICA_CREDENTIALS']
+      parsed_credentials = raw_credentials.present? ? JSON.parse(raw_credentials) : {}
+      credentials = parsed_credentials[args[:admin_set_key]] || {}
       @username = credentials['username']
       @password = credentials['password']
     end
     login
+  rescue JSON::ParserError
+    raise StandardError, 'Preservica credentials are not valid JSON'
   end
 
   def login

--- a/app/models/concerns/create_parent_object.rb
+++ b/app/models/concerns/create_parent_object.rb
@@ -17,16 +17,13 @@ module CreateParentObject
     parsed_csv.each_with_index do |row, index|
       if row['digital_object_source'].present? && row['preservica_uri'].present? && !row['preservica_uri'].blank?
         begin
-          attempt_count ||= 1
           parent_object = CsvRowParentService.new(row, index, current_ability, user).parent_object
           setup_for_background_jobs(parent_object, row['source'])
         rescue CsvRowParentService::BatchProcessingError => e
           batch_processing_event(e.message, e.kind)
           next
         rescue PreservicaImageService::PreservicaImageServiceNetworkError => e
-          batch_processing_event("Retrying row [#{index + 2}] #{e.message}.", "Retrying Row")
-          attempt_count += 1
-          retry if attempt_count < 4
+          batch_processing_event("Problem with network connection for row [#{index + 2}] - #{e.message}.")
           next
         rescue PreservicaImageService::PreservicaImageServiceError => e
           friendly_msg = if e.message.include?("bad URI")

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -224,29 +224,16 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def preservica_copy_to_access(child_hash, co_oid)
-    attempt_count ||= 1
     pairtree_path = Partridge::Pairtree.oid_to_pairtree(co_oid)
     image_mount = ENV['ACCESS_PRIMARY_MOUNT'] || "data"
     directory = format("%02d", pairtree_path.first)
     FileUtils.mkdir_p(File.join(image_mount, directory, pairtree_path))
     access_primary_path = File.join(image_mount, directory, pairtree_path, "#{co_oid}.tif")
     begin
-      attempt_count += 1
       child_hash[:bitstream].download_to_file(access_primary_path)
     rescue StandardError => e
-      if e.message.include?("404") ||
-         e.message.include?("408") ||
-         e.message.include?("502") ||
-         e.message.include?("504") ||
-         e.message.include?("Net::HTTPNotFound") ||
-         e.message.include?("Net::HTTPFatalError") ||
-         e.message.include?("Net::ReadTimeout")
-        retry if attempt_count < 4
-        processing_event("Retrying Child OID: #{co_oid} #{e.message}", "Retrying Row")
-      else
-        processing_event(e.to_s, "failed")
-        raise e.to_s
-      end
+      processing_event(e.to_s, "failed")
+      raise e.to_s
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/preservica/bitstream.rb
+++ b/app/models/preservica/bitstream.rb
@@ -31,36 +31,53 @@ class Preservica::Bitstream
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Layout/LineLength
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def download_to_file(file_name)
     Rails.logger.info "************ bitstream.rb # download_to_file +++ hits download to file method with file: #{file_name} *************"
     co_oid = file_name.scan(/\d+/).last
+    expected_size = size
+    expected_sha512 = sha512_checksum
+    temp_file_name = "#{file_name}.part"
+
+    File.delete(temp_file_name) if File.exist?(temp_file_name)
+
     data_length = 0
-    sha512 = Digest::SHA512. new
-    File.open(file_name, 'wb') do |file|
+    sha512 = Digest::SHA512.new
+    File.open(temp_file_name, 'wb') do |file|
       Rails.logger.info "************ bitstream.rb # download_to_file +++ File.open succeeds in opening file *************"
       preservica_client.get(content_uri) do |chunk|
-        data_length += chunk.length
+        data_length += chunk.bytesize
         no_of_bites = file.write(chunk)
         raise StandardError, "Failed to write to file" if no_of_bites < 1
         Rails.logger.info "************ bitstream.rb # download_to_file +++ File.write wrote #{no_of_bites} bites to file *************"
         sha512 << chunk
       end
+      file.flush
+      file.fsync
     end
     data_sha512 = sha512.hexdigest
-    file_size = File.size?(file_name)
+    file_size = File.size?(temp_file_name)
     Rails.logger.info "************ bitstream.rb # download_to_file +++ counts file size (data_length): #{data_length} *************"
     Rails.logger.info "************ bitstream.rb # download_to_file +++ grabs sha checksum (data_sha512): #{data_sha512} *************"
-    unless data_sha512.casecmp?(sha512_checksum)
+    unless data_sha512.casecmp?(expected_sha512)
       raise StandardError,
-"The checksum for this object is different than the checksum that DCS expected. Please ensure your image folder in Preservica has SHA-512 fixity checksums. ------------ Message from System: Checksum mismatch for Child Object: #{co_oid} - (#{data_sha512} != #{sha512_checksum})"
+"The checksum for this object is different than the checksum that DCS expected. Please ensure your image folder in Preservica has SHA-512 fixity checksums. ------------ Message from System: Checksum mismatch for Child Object: #{co_oid} - (#{data_sha512} != #{expected_sha512})"
     end
-    raise StandardError, "Data size did not match for Child Object: #{co_oid} - (#{data_length} != #{size})" unless data_length == size
-    raise StandardError, "File sizes do not match for Child Object: #{co_oid} - (#{file_size} != #{size})" unless file_size == size
-    # could also check: Digest::SHA512.file(file_name).hexdigest == sha512_checksum, but probably not necessary
+    raise StandardError, "Data size did not match for Child Object: #{co_oid} - (#{data_length} != #{expected_size})" unless data_length == expected_size
+    raise StandardError, "File sizes do not match for Child Object: #{co_oid} - (#{file_size} != #{expected_size})" unless file_size == expected_size
+
+    File.delete(file_name) if File.exist?(file_name)
+    File.rename(temp_file_name, file_name)
+  rescue StandardError
+    File.delete(temp_file_name) if File.exist?(temp_file_name)
+    raise
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Layout/LineLength
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def xml
     @xml ||= Nokogiri::XML(preservica_client.content_object_generation_bitstream(@content_id, @generation_id, @id)).remove_namespaces!

--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -33,27 +33,18 @@ class PreservicaImageService
   # rubocop:disable Metrics/PerceivedComplexity
   def image_list(representation_type)
     @images = []
-    attempt_count ||= 1
     begin
       if @pattern == :pattern_one
         structural_object = Preservica::StructuralObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)
         begin
-          attempt_count += 1
           @information_objects = structural_object.information_objects
-        rescue Net::HTTPFatalError, Net::HTTPNotFound, Net::ReadTimeout => e
-          sleep 30
-          retry if attempt_count < 4
-          raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         rescue Net::OpenTimeout, Errno::ECONNREFUSED => e
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end
       elsif @pattern == :pattern_two
         begin
-          attempt_count += 1
           @information_objects = [Preservica::InformationObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)]
         rescue Net::HTTPFatalError, Net::HTTPNotFound, Net::ReadTimeout => e
-          sleep 30
-          retry if attempt_count < 4
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end
       end

--- a/spec/jobs/create_preservica_children_job_spec.rb
+++ b/spec/jobs/create_preservica_children_job_spec.rb
@@ -3,14 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, prep_metadata_sources: true do
-  def with_good_job_external_mode
-    original_queue_adapter = described_class.queue_adapter
-    described_class.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
-    yield
-  ensure
-    described_class.queue_adapter = original_queue_adapter
-  end
-
   def run_create_preservica_children_retry_jobs
     GoodJob.perform_inline
     3.times do
@@ -29,13 +21,35 @@ RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, p
   let(:parent_object) do
     FactoryBot.create(:parent_object,
                       oid: 2_034_600,
-                      admin_set: AdminSet.first,
+                      admin_set: AdminSet.find_by(key: 'brbl'),
                       authoritative_metadata_source: MetadataSource.first,
                       digital_object_source: "Preservica",
-                      preservica_uri: "/structural-objects/test-uuid",
+                      preservica_uri: "/preservica/api/entity/structural-objects/7fe35e8c-c21a-444a-a2e2-e3c926b519c5",
                       preservica_representation_type: "Access")
   end
   let(:job) { described_class.new }
+
+  around do |example|
+    preservica_host = ENV['PRESERVICA_HOST']
+    preservica_creds = ENV['PRESERVICA_CREDENTIALS']
+    access_host = ENV['ACCESS_PRIMARY_MOUNT']
+
+    ENV['PRESERVICA_HOST'] = 'testpreservica'
+    ENV['PRESERVICA_CREDENTIALS'] = '{"brbl": {"username":"xxxxx", "password":"xxxxx"}}'
+    ENV['ACCESS_PRIMARY_MOUNT'] = File.join('spec', 'fixtures', 'images', 'access_primaries')
+
+    example.run
+  ensure
+    ENV['PRESERVICA_HOST'] = preservica_host
+    ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
+    ENV['ACCESS_PRIMARY_MOUNT'] = access_host
+  end
+
+  before do
+    stub_preservica_login
+    stub_preservica_fixtures_set_of_three_changing_generation
+    stub_preservica_tifs_set_of_three
+  end
 
   it 'enqueues the job successfully' do
     active_job = described_class.perform_later(parent_object, batch_process)
@@ -85,7 +99,7 @@ RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, p
   end
 
   it 'logs failed processing event on first retryable failure' do
-    allow(parent_object).to receive(:create_child_records).and_raise(StandardError, 'Something went wrong')
+    allow(parent_object).to receive(:create_child_records).and_raise(RuntimeError, 'Something went wrong')
     allow(parent_object).to receive(:processing_event)
     allow(parent_object).to receive(:child_objects).and_return([])
     allow(parent_object).to receive(:needs_a_manifest?).and_return(false)
@@ -105,7 +119,8 @@ RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, p
       parent_object.current_batch_process = batch_process
       parent_object.current_batch_connection = batch_connection
 
-      allow_any_instance_of(ParentObject).to receive(:create_child_records).and_raise(StandardError, 'Something went wrong')
+      allow_any_instance_of(ParentObject).to receive(:create_child_records)
+        .and_raise(PreservicaImageService::PreservicaImageServiceNetworkError.new('Net::ReadTimeout', 'sample.com/uri'))
       allow_any_instance_of(ParentObject).to receive(:gather_technical_image_metadata)
       allow_any_instance_of(ParentObject).to receive(:child_objects).and_return([])
       allow_any_instance_of(ParentObject).to receive(:needs_a_manifest?).and_return(false)
@@ -119,7 +134,24 @@ RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, p
                              .where(status: 'retry')
                              .pluck(:reason)
 
-      expect(reasons).to include('Retrying Child Object Creation - Request error Something went wrong')
+      expect(reasons).to include('Retrying Child Object Creation - Request error Net::ReadTimeout for sample.com/uri')
     end
+  end
+
+  it 'does not retry on PreservicaImageServiceError' do
+    error = PreservicaImageService::PreservicaImageServiceError.new('No matching representation found in Preservica', '/preservica/api/entity')
+    allow(parent_object).to receive(:create_child_records).and_raise(error)
+    allow(parent_object).to receive(:processing_event)
+    allow(parent_object).to receive(:child_objects).and_return([])
+    allow(parent_object).to receive(:needs_a_manifest?).and_return(false)
+
+    expect do
+      described_class.perform_now(parent_object, batch_process)
+    end.to raise_error(PreservicaImageService::PreservicaImageServiceError)
+
+    expect(parent_object).to have_received(:processing_event)
+      .with("Preservica child creation failed: #{error.message}", 'failed')
+    expect(parent_object).not_to have_received(:processing_event)
+      .with(a_string_starting_with('Retrying Child Object Creation - Request error'), 'retry')
   end
 end

--- a/spec/jobs/create_preservica_children_job_spec.rb
+++ b/spec/jobs/create_preservica_children_job_spec.rb
@@ -3,6 +3,27 @@
 require 'rails_helper'
 
 RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, prep_metadata_sources: true do
+  def with_good_job_external_mode
+    original_queue_adapter = described_class.queue_adapter
+    described_class.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+    yield
+  ensure
+    described_class.queue_adapter = original_queue_adapter
+  end
+
+  def run_create_preservica_children_retry_jobs
+    GoodJob.perform_inline
+    3.times do
+      scheduled_jobs = GoodJob::Job.where(job_class: 'CreatePreservicaChildrenJob')
+                                   .where(finished_at: nil)
+                                   .where("scheduled_at > ?", Time.current)
+      break if scheduled_jobs.none?
+
+      scheduled_jobs.find_each { |job| job.update!(scheduled_at: Time.current) }
+      GoodJob.perform_inline
+    end
+  end
+
   let(:user) { FactoryBot.create(:user) }
   let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
   let(:parent_object) do
@@ -60,6 +81,45 @@ RSpec.describe CreatePreservicaChildrenJob, type: :job, prep_admin_sets: true, p
     it 'logs a child-records-created event' do
       job.perform(parent_object, batch_process)
       expect(parent_object).to have_received(:processing_event).with("Child object records have been created", "child-records-created")
+    end
+  end
+
+  it 'logs failed processing event on first retryable failure' do
+    allow(parent_object).to receive(:create_child_records).and_raise(StandardError, 'Something went wrong')
+    allow(parent_object).to receive(:processing_event)
+    allow(parent_object).to receive(:child_objects).and_return([])
+    allow(parent_object).to receive(:needs_a_manifest?).and_return(false)
+
+    expect do
+      described_class.perform_now(parent_object, batch_process)
+    end.not_to raise_error
+
+    expect(parent_object).to have_received(:processing_event)
+      .with('Preservica child creation failed: Something went wrong', 'failed')
+  end
+
+  it 'logs retry callback message when retries are exhausted' do
+    with_good_job_external_mode do
+      GoodJob::Job.where(job_class: 'CreatePreservicaChildrenJob').delete_all
+      batch_connection = batch_process.batch_connections.find_or_create_by!(connectable: parent_object)
+      parent_object.current_batch_process = batch_process
+      parent_object.current_batch_connection = batch_connection
+
+      allow_any_instance_of(ParentObject).to receive(:create_child_records).and_raise(StandardError, 'Something went wrong')
+      allow_any_instance_of(ParentObject).to receive(:gather_technical_image_metadata)
+      allow_any_instance_of(ParentObject).to receive(:child_objects).and_return([])
+      allow_any_instance_of(ParentObject).to receive(:needs_a_manifest?).and_return(false)
+      allow(ParentObject).to receive(:find_by).with(oid: parent_object.oid).and_return(parent_object)
+
+      described_class.perform_later(parent_object, batch_process, batch_connection)
+      run_create_preservica_children_retry_jobs
+
+      reasons = parent_object.reload
+                             .events_for_batch_process(batch_process)
+                             .where(status: 'retry')
+                             .pluck(:reason)
+
+      expect(reasons).to include('Retrying Child Object Creation - Request error Something went wrong')
     end
   end
 end

--- a/spec/jobs/sync_from_preservica_job_spec.rb
+++ b/spec/jobs/sync_from_preservica_job_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
 
       expect do
         described_class.new.perform(batch_process)
-      end.not_to raise_error
+      end.to raise_error(StandardError, error_message)
     end
   end
 end

--- a/spec/jobs/sync_from_preservica_job_spec.rb
+++ b/spec/jobs/sync_from_preservica_job_spec.rb
@@ -4,8 +4,26 @@ require 'rails_helper'
 
 RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, prep_admin_sets: true do
   include ActiveSupport::Testing::TaggedLogging
-  before do
-    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+
+  def with_good_job_external_mode
+    original_queue_adapter = described_class.queue_adapter
+    described_class.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+    yield
+  ensure
+    described_class.queue_adapter = original_queue_adapter
+  end
+
+  def run_sync_from_preservica_retry_jobs
+    GoodJob.perform_inline
+    3.times do
+      scheduled_jobs = GoodJob::Job.where(job_class: 'SyncFromPreservicaJob')
+                                   .where(finished_at: nil)
+                                   .where("scheduled_at > ?", Time.current)
+      break if scheduled_jobs.none?
+
+      scheduled_jobs.find_each { |job| job.update!(scheduled_at: Time.current) }
+      GoodJob.perform_inline
+    end
   end
 
   let(:user) { FactoryBot.create(:user) }
@@ -32,6 +50,32 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
     expect(job_file).to include('attempts: 3')
   end
 
+  it 'logs failed batch processing event on first retryable failure' do
+    allow(batch_process).to receive(:sync_from_preservica).and_raise(StandardError.new('Something went wrong'))
+    allow(batch_process).to receive(:batch_processing_event)
+
+    expect do
+      described_class.perform_now(batch_process)
+    end.not_to raise_error
+
+    expect(batch_process).to have_received(:batch_processing_event)
+      .with('Setup job failed to save: Something went wrong', 'failed')
+  end
+
+  it 'logs retry batch processing event when retries are exhausted' do
+    with_good_job_external_mode do
+      GoodJob::Job.where(job_class: 'SyncFromPreservicaJob').delete_all
+      allow_any_instance_of(BatchProcess).to receive(:sync_from_preservica).and_raise(StandardError.new('Something went wrong'))
+      allow(BatchProcess).to receive(:find_by).with(id: batch_process.id).and_return(batch_process)
+
+      described_class.perform_later(batch_process)
+      run_sync_from_preservica_retry_jobs
+
+      reasons = batch_process.batch_ingest_events.where(status: 'retry').pluck(:reason)
+      expect(reasons).to include('Retrying Sync from Preservica - Request error Something went wrong')
+    end
+  end
+
   context 'when sync_from_preservica raises an exception' do
     let(:error_message) { 'Something went wrong' }
     let(:error) { StandardError.new(error_message) }
@@ -45,6 +89,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
       expect(batch_process).to receive(:batch_processing_event)
         .with("Setup job failed to save: #{error_message}", "failed")
 
+      # this bypasses ActiveJob's retry mechanism by using perform instead of perform_later
       expect do
         described_class.new.perform(batch_process)
       end.to raise_error(StandardError, error_message)

--- a/spec/jobs/sync_from_preservica_job_spec.rb
+++ b/spec/jobs/sync_from_preservica_job_spec.rb
@@ -5,14 +5,6 @@ require 'rails_helper'
 RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, prep_admin_sets: true do
   include ActiveSupport::Testing::TaggedLogging
 
-  def with_good_job_external_mode
-    original_queue_adapter = described_class.queue_adapter
-    described_class.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
-    yield
-  ensure
-    described_class.queue_adapter = original_queue_adapter
-  end
-
   def run_sync_from_preservica_retry_jobs
     GoodJob.perform_inline
     3.times do
@@ -28,8 +20,22 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
 
   let(:user) { FactoryBot.create(:user) }
   let(:batch_process) { FactoryBot.create(:batch_process, user: user) }
+  let(:preservica_sync_valid) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], 'csv', 'preservica', 'preservica_sync.csv')) }
+
+  around do |example|
+    preservica_host = ENV['PRESERVICA_HOST']
+    preservica_creds = ENV['PRESERVICA_CREDENTIALS']
+    ENV['PRESERVICA_HOST'] = 'testpreservica'
+    ENV['PRESERVICA_CREDENTIALS'] = '{"brbl": {"username":"xxxxx", "password":"xxxxx"}}'
+    example.run
+  ensure
+    ENV['PRESERVICA_HOST'] = preservica_host
+    ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
+  end
 
   it 'increments the job queue by one' do
+    batch_process.file = preservica_sync_valid
+    batch_process.save!
     resync_preservica_job = described_class.perform_later(batch_process)
     expect(resync_preservica_job.instance_variable_get(:@successfully_enqueued)).to eq true
   end
@@ -51,7 +57,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
   end
 
   it 'logs failed batch processing event on first retryable failure' do
-    allow(batch_process).to receive(:sync_from_preservica).and_raise(StandardError.new('Something went wrong'))
+    allow(batch_process).to receive(:sync_from_preservica).and_raise(RuntimeError.new('Something went wrong'))
     allow(batch_process).to receive(:batch_processing_event)
 
     expect do
@@ -65,20 +71,36 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
   it 'logs retry batch processing event when retries are exhausted' do
     with_good_job_external_mode do
       GoodJob::Job.where(job_class: 'SyncFromPreservicaJob').delete_all
-      allow_any_instance_of(BatchProcess).to receive(:sync_from_preservica).and_raise(StandardError.new('Something went wrong'))
+      allow_any_instance_of(BatchProcess).to receive(:sync_from_preservica)
+        .and_raise(PreservicaImageService::PreservicaImageServiceNetworkError.new('Net::ReadTimeout', 'sample.com/uri'))
       allow(BatchProcess).to receive(:find_by).with(id: batch_process.id).and_return(batch_process)
 
       described_class.perform_later(batch_process)
       run_sync_from_preservica_retry_jobs
 
       reasons = batch_process.batch_ingest_events.where(status: 'retry').pluck(:reason)
-      expect(reasons).to include('Retrying Sync from Preservica - Request error Something went wrong')
+      expect(reasons).to include('Retrying Sync from Preservica - Request error Net::ReadTimeout for sample.com/uri')
     end
+  end
+
+  it 'does not retry on PreservicaImageServiceError' do
+    error = PreservicaImageService::PreservicaImageServiceError.new('No matching representation found in Preservica', '/preservica/api/entity')
+    allow(batch_process).to receive(:sync_from_preservica).and_raise(error)
+    allow(batch_process).to receive(:batch_processing_event)
+
+    expect do
+      described_class.perform_now(batch_process)
+    end.to raise_error(PreservicaImageService::PreservicaImageServiceError)
+
+    expect(batch_process).to have_received(:batch_processing_event)
+      .with("Setup job failed to save: #{error.message}", 'failed')
+    expect(batch_process).not_to have_received(:batch_processing_event)
+      .with(a_string_starting_with('Retrying Sync from Preservica - Request error'), 'retry')
   end
 
   context 'when sync_from_preservica raises an exception' do
     let(:error_message) { 'Something went wrong' }
-    let(:error) { StandardError.new(error_message) }
+    let(:error) { RuntimeError.new(error_message) }
 
     before do
       allow(batch_process).to receive(:sync_from_preservica).and_raise(error)
@@ -92,7 +114,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
       # this bypasses ActiveJob's retry mechanism by using perform instead of perform_later
       expect do
         described_class.new.perform(batch_process)
-      end.to raise_error(StandardError, error_message)
+      end.to raise_error(RuntimeError, error_message)
     end
   end
 end

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   let(:preservica_parent_with_children_and_data) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "preservica", "preservica_parent_with_children_and_data.csv")) }
 
   def with_good_job_external_mode
-    original_queue_adapter = ActiveJob::Base.queue_adapter
+    original_queue_adapter = described_class.queue_adapter
     ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
     yield
   ensure
-    ActiveJob::Base.queue_adapter = original_queue_adapter
+    described_class.queue_adapter = original_queue_adapter
   end
 
   def run_create_preservica_children_retry_jobs

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   let(:preservica_parent_no_sha_pattern_2) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "preservica", "preservica_parent_no_sha_pattern_2.csv")) }
   let(:preservica_parent_with_children_and_data) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "preservica", "preservica_parent_with_children_and_data.csv")) }
 
+  def with_good_job_external_mode
+    original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+    yield
+  ensure
+    ActiveJob::Base.queue_adapter = original_queue_adapter
+  end
+
+  def run_create_preservica_children_retry_jobs
+    GoodJob.perform_inline
+    GoodJob::Job.where(job_class: 'CreatePreservicaChildrenJob')
+                .where(finished_at: nil)
+                .where("scheduled_at > ?", Time.current)
+                .find_each { |job| job.update!(scheduled_at: Time.current) }
+    GoodJob.perform_inline
+  end
+
   around do |example|
     preservica_host = ENV['PRESERVICA_HOST']
     preservica_creds = ENV['PRESERVICA_CREDENTIALS']
@@ -247,8 +264,8 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     expect do
       batch_process.file = preservica_parent_with_children
       batch_process.save
-      expect(batch_process.batch_ingest_events.count).to eq(3)
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Retrying row [2] Net::ReadTimeout for sample.com/uri.")
+      expect(batch_process.batch_ingest_events.count).to eq(1)
+      expect(batch_process.batch_ingest_events[0].reason).to eq("Problem with network connection for row [2] - Net::ReadTimeout for sample.com/uri.")
     end.to change { ChildObject.count }.by(0)
   end
 
@@ -273,21 +290,33 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
         bitstream: Preservica::Bitstream.new("Preservica Client", "ae328d84-e429-4d46-a865-9ee11157b488", "1", "1", "mss_29_s03_b092_f0019.TIF"),
         caption: "mss_29_s03_b092_f0019.tif" }
     ]
-    call_count ||= 1
+    call_count = 0
+    retry_failures = 0
     allow(S3Service).to receive(:s3_exists?).and_return(false)
     allow_any_instance_of(PreservicaImageService).to receive(:image_list).with('Preservation') do
       call_count += 1
-      call_count <= 2 ? raise(PreservicaImageService::PreservicaImageServiceNetworkError.new('Net::ReadTimeout', 'sample.com/uri')) : images
+      if ParentObject.exists?(200_000_000) && retry_failures < 2
+        retry_failures += 1
+        raise(PreservicaImageService::PreservicaImageServiceNetworkError.new('Net::ReadTimeout', 'sample.com/uri'))
+      end
+
+      images
     end
-    expect do
-      batch_process.file = preservica_parent_with_children_and_data
-      batch_process.save
-      expect(batch_process.batch_ingest_events[0].reason).to eq("Retrying row [2] Net::ReadTimeout for sample.com/uri.")
-    end.to change { ChildObject.count }.by(0)
-    expect(call_count).to eq(4) # 3 retries and then eventual success
-    po = ParentObject.find(200_000_000)
-    expect(po.digitization_note).to eq 'A note about digitization'
-    expect(po.digitization_funding_source).to eq 'Digitization Funding Source'
-    expect(po.rights_statement).to eq 'A rights statement.'
+    with_good_job_external_mode do
+      expect do
+        batch_process.file = preservica_parent_with_children_and_data
+        batch_process.save
+      end.to change { ChildObject.count }.by(0)
+
+      run_create_preservica_children_retry_jobs
+
+      expect(call_count).to be >= 3
+      po = ParentObject.find(200_000_000)
+      reasons = po.events_for_batch_process(batch_process).map(&:reason)
+      expect(reasons).to include("Preservica child creation failed: Net::ReadTimeout for sample.com/uri")
+      expect(po.digitization_note).to eq 'A note about digitization'
+      expect(po.digitization_funding_source).to eq 'Digitization Funding Source'
+      expect(po.rights_statement).to eq 'A rights statement.'
+    end
   end
 end

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -21,14 +21,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   let(:preservica_parent_no_sha_pattern_2) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "preservica", "preservica_parent_no_sha_pattern_2.csv")) }
   let(:preservica_parent_with_children_and_data) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "preservica", "preservica_parent_with_children_and_data.csv")) }
 
-  def with_good_job_external_mode
-    original_queue_adapter = described_class.queue_adapter
-    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
-    yield
-  ensure
-    described_class.queue_adapter = original_queue_adapter
-  end
-
   def run_create_preservica_children_retry_jobs
     GoodJob.perform_inline
     GoodJob::Job.where(job_class: 'CreatePreservicaChildrenJob')

--- a/spec/models/preservica/preservica_child_error_spec.rb
+++ b/spec/models/preservica/preservica_child_error_spec.rb
@@ -213,22 +213,34 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
   end
 
   it 'can send an error when there is a checksum mismatch with pattern 1' do
+    stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157c600/generations/1/bitstreams/1/content").to_return(
+      status: 200,
+      body: File.open(File.join(fixture_paths[0], "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157c600/generations/1/bitstreams/1/content.tiff"), 'rb')
+    )
+
     expect do
       batch_process.file = preservica_parent_checksum_mismatch_pattern_1
       batch_process.save
       po = ParentObject.find(200_000_000)
       expect(po.events_for_batch_process(batch_process).count).to be > 1
-      expect(po.events_for_batch_process(batch_process)[1].reason).to eq("execution expired").or eq("Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443)").or eq("Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known)").or eq("Failed to open TCP connection to testpreservica:443 (execution expired)")
+      reason = po.events_for_batch_process(batch_process)[1].reason
+      expect(reason).to start_with("The checksum for this object is different than the checksum that DCS expected. Please ensure your image folder in Preservica has SHA-512 fixity checksums. ------------ Message from System: Checksum mismatch for Child Object:")
     end.to change { ChildObject.count }.by(0)
   end
 
   it 'can send an error when there is a checksum mismatch with pattern 2' do
+    stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157c600/generations/1/bitstreams/1/content").to_return(
+      status: 200,
+      body: File.open(File.join(fixture_paths[0], "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157c600/generations/1/bitstreams/1/content.tiff"), 'rb')
+    )
+
     expect do
       batch_process.file = preservica_parent_checksum_mismatch_pattern_2
       batch_process.save
       po = ParentObject.find(200_000_000)
       expect(po.events_for_batch_process(batch_process).count).to be > 1
-      expect(po.events_for_batch_process(batch_process)[1].reason).to eq("execution expired").or eq("Failed to open TCP connection to testpreservica:443 (Connection refused - connect(2) for \"testpreservica\" port 443)").or eq("Failed to open TCP connection to testpreservica:443 (getaddrinfo: Name or service not known)").or eq("Failed to open TCP connection to testpreservica:443 (execution expired)")
+      reason = po.events_for_batch_process(batch_process)[1].reason
+      expect(reason).to start_with("The checksum for this object is different than the checksum that DCS expected. Please ensure your image folder in Preservica has SHA-512 fixity checksums. ------------ Message from System: Checksum mismatch for Child Object:")
     end.to change { ChildObject.count }.by(0)
   end
 

--- a/spec/models/preservica/preservica_retry_spec.rb
+++ b/spec/models/preservica/preservica_retry_spec.rb
@@ -3,6 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  def execute_retry_job
+    yield
+    GoodJob.perform_inline
+    GoodJob::Job.where(job_class: 'CreatePreservicaChildrenJob')
+                .where(finished_at: nil)
+                .where("scheduled_at > ?", Time.current)
+                .find_each { |job| job.update!(scheduled_at: Time.current) }
+    GoodJob.perform_inline
+  end
+
   subject(:batch_process) { BatchProcess.new }
   let(:admin_set) { FactoryBot.create(:admin_set, key: 'brbl') }
   let(:admin_set_sml) { FactoryBot.create(:admin_set, key: 'sml') }
@@ -58,31 +68,44 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
 
     stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1/content").to_return(
       status: 404, body: "Content object bitstreams cannot be downloaded."
+    ).then.to_return(
+      status: 200, body: File.open(File.join(fixture_paths[0], "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487/generations/1/bitstreams/1/content.tif"))
     )
     stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1/content").to_return(
-      status: 404, body: "Content object bitstreams cannot be downloaded."
+      status: 200, body: File.open(File.join(fixture_paths[0], "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486/generations/1/bitstreams/1/content.tif"))
     )
     stub_request(:get, "https://testpreservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1/content").to_return(
-      status: 404, body: "Content object bitstreams cannot be downloaded."
+      status: 200, body: File.open(File.join(fixture_paths[0], "preservica/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489/generations/1/bitstreams/1/content.tif"))
     )
   end
 
   context 'user with permission' do
     before do
+      ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
       user.add_role(:editor, admin_set)
       login_as(:user)
     end
 
     it 'can recognize when child is not found in preservica and retry' do
       allow(S3Service).to receive(:s3_exists?).and_return(false)
-      expect do
+      execute_retry_job do
         batch_process.file = preservica_parent_with_children
         batch_process.save
-      end.to change { ChildObject.count }.from(0).to(3)
-      expect(batch_process.batch_status).to eq "Batch failed"
+      end
       po_first = ParentObject.first
-      expect(po_first.events_for_batch_process(batch_process).count).to eq 9
-      expect(po_first.events_for_batch_process(batch_process)[1].reason).to eq("Retrying Child OID: 200000001 Request error 404 Content object bitstreams cannot be downloaded.")
+      retry_reasons = po_first.events_for_batch_process(batch_process).map(&:reason)
+      good_job = GoodJob::Job.where("serialized_params -> 'arguments' @> ?", [{ "_aj_globalid" => "gid://yul-dc-management/ParentObject/#{po_first.id}" }].to_json)
+                            .where(job_class: "CreatePreservicaChildrenJob")
+                            .order(created_at: :desc)
+                            .first
+      expect(retry_reasons).to include("Preservica child creation failed: Request error 404 Content object bitstreams cannot be downloaded.")
+      expect(good_job).not_to be_nil
+      related_jobs = GoodJob::Job.where("serialized_params -> 'arguments' @> ?", [{ "_aj_globalid" => "gid://yul-dc-management/ParentObject/#{po_first.id}" }].to_json)
+                 .where(job_class: "CreatePreservicaChildrenJob")
+      retry_scheduled = related_jobs.where("scheduled_at > created_at").exists? ||
+                        related_jobs.where.not(retried_good_job_id: nil).exists? ||
+                        GoodJob::Job.where(retried_good_job_id: related_jobs.select(:id)).exists?
+      expect(retry_scheduled).to be(true)
       expect(po_first.last_preservica_update).not_to eq nil
       expect(po_first.child_objects.count).to eq 3
       expect(po_first.child_object_count).to eq 3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.include(ParentChildObjectHelper)
   config.include(ActionDispatch::TestProcess::FixtureFile)
+  config.include(GoodJobAdapterHelper)
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]

--- a/spec/support/good_job_adapter_helper.rb
+++ b/spec/support/good_job_adapter_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GoodJobAdapterHelper
+  def with_good_job_external_mode
+    original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+    yield
+  ensure
+    ActiveJob::Base.queue_adapter = original_queue_adapter
+  end
+end


### PR DESCRIPTION
# Summary
Removes the manual retry methods and switches them out for configurations of retry behavior for GoodJob.

# Related Ticket
[#3031](https://github.com/yalelibrary/YUL-DC/issues/3031)