### PR TITLE
Remove ILS/Sierra from Admin Set actions

### DIFF
--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -75,6 +75,12 @@ class MetadataSource < ApplicationRecord
     MetadataSource.distinct.pluck(:metadata_cloud_name)
   end
 
+  EXCLUDED_BATCH_CLOUD_NAMES = %w[sierra ils].freeze
+
+  def self.selectable_for_batch
+    MetadataSource.where.not(metadata_cloud_name: EXCLUDED_BATCH_CLOUD_NAMES)
+  end
+
   def url_type
     case metadata_cloud_name
     when "ladybird"

--- a/app/views/admin_sets/_export_all_parents_dialog.html.erb
+++ b/app/views/admin_sets/_export_all_parents_dialog.html.erb
@@ -12,14 +12,14 @@
             <%= link_to('Select All', "#", {class: 'select-all-btn', data: { target_select:'#metadata_source_ids'}}) %>
             <br />
             <%= form.select(:metadata_source_ids,
-                            options_from_collection_for_select(MetadataSource.all,
+                            options_from_collection_for_select(MetadataSource.selectable_for_batch,
                                                                :id, :display_name, []),
                             {},
                             {
                                 class: 'select',
                                 required: true,
                                 multiple: true,
-                                size: [MetadataSource.all.count,5].min}
+                                size: [MetadataSource.selectable_for_batch.count,5].min}
                 )
             %>
           </div>

--- a/app/views/admin_sets/_update_metadata_dialog.html.erb
+++ b/app/views/admin_sets/_update_metadata_dialog.html.erb
@@ -28,14 +28,14 @@
             <%= link_to('Select All', "#", {class: 'select-all-btn', data: { target_select:'#metadata_source_ids'}}) %>
             <br />
             <%= form.select(:metadata_source_ids,
-                            options_from_collection_for_select(MetadataSource.all,
+                            options_from_collection_for_select(MetadataSource.selectable_for_batch,
                                                                :id, :display_name, []),
                             {},
                             {
                                 class: 'select',
                                 required: true,
                                 multiple: true,
-                                size: [MetadataSource.all.count,5].min}
+                                size: [MetadataSource.selectable_for_batch.count,5].min}
                 )
             %>
           </div>


### PR DESCRIPTION
## Summary  
Removes Sierra and ILS from Batch Update Metadata and Export All Parents batch actions from Admin Set showpage