### PR TITLE
Remove ILS/Sierra from BP Create/Update

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -33,7 +33,14 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   CSV_MAXIMUM_ENTRIES = 10_000
 
+  INVALID_BATCH_METADATA_SOURCES = %w[ils sierra].freeze
+  INVALID_METADATA_SOURCE_MESSAGE = "Voyager and Sierra are not valid data sources. Please use a source of alma or aspace and the appropriate alma or aspace identifiers."
+
   # SHARED BY ALL BATCH ACTIONS: ------------------------------------------------------------------- #
+
+  def invalid_metadata_source?(metadata_source)
+    INVALID_BATCH_METADATA_SOURCES.include?(metadata_source)
+  end
 
   # LISTS AVAILABLE BATCH ACTIONS
   # rubocop:disable Layout/LineLength

--- a/app/models/concerns/create_parent_object.rb
+++ b/app/models/concerns/create_parent_object.rb
@@ -15,6 +15,10 @@ module CreateParentObject
     self.admin_set = ''
     sets = admin_set
     parsed_csv.each_with_index do |row, index|
+      if invalid_metadata_source?(row['source'])
+        batch_processing_event("Skipping row [#{index + 2}]. #{self.class::INVALID_METADATA_SOURCE_MESSAGE}", 'Skipped Row')
+        next
+      end
       if row['digital_object_source'].present? && row['preservica_uri'].present? && !row['preservica_uri'].blank?
         begin
           parent_object = CsvRowParentService.new(row, index, current_ability, user).parent_object

--- a/app/models/concerns/updatable.rb
+++ b/app/models/concerns/updatable.rb
@@ -382,10 +382,13 @@ module Updatable
 
   # CHECKS THAT METADATA SOURCE IS VALID - USED BY UPDATE
   def validate_metadata_source(metadata_source, index)
-    if MetadataSource.all_metadata_cloud_names.include?(metadata_source)
+    if invalid_metadata_source?(metadata_source)
+      batch_processing_event("Skipping row [#{index + 2}]. #{self.class::INVALID_METADATA_SOURCE_MESSAGE}", 'Skipped Row')
+      false
+    elsif MetadataSource.all_metadata_cloud_names.include?(metadata_source)
       true
     else
-      batch_processing_event("Skipping row [#{index + 2}] with unknown metadata source: #{metadata_source}.  Accepted values are 'ladybird', 'aspace', 'sierra', or 'ils'.", 'Skipped Row')
+      batch_processing_event("Skipping row [#{index + 2}] with unknown metadata source: #{metadata_source}.  Accepted values are 'ladybird', 'aspace', or 'alma'.", 'Skipped Row')
       false
     end
   end

--- a/spec/fixtures/csv/create_invalid_metadata_source.csv
+++ b/spec/fixtures/csv/create_invalid_metadata_source.csv
@@ -1,0 +1,3 @@
+oid,source,admin_set
+2034600,ils,brbl
+2030006,sierra,brbl

--- a/spec/fixtures/csv/create_invalid_owp_parent.csv
+++ b/spec/fixtures/csv/create_invalid_owp_parent.csv
@@ -1,2 +1,2 @@
 oid,admin_set,source,extent_of_digitization,visibility,permission_set_key,digitization_note,digitization_funding_source,rights_statement,viewing_direction,display_layout
-,brbl,ils,Completely digitized,Open with Permission,,dig note,dig funding source,rights statement,left-to-right,paged
+,brbl,ladybird,Completely digitized,Open with Permission,,dig note,dig funding source,rights statement,left-to-right,paged

--- a/spec/fixtures/csv/parent_no_admin_set.csv
+++ b/spec/fixtures/csv/parent_no_admin_set.csv
@@ -1,2 +1,2 @@
 oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
-,,ils,,,,,,,,,
+,,ladybird,,,,,,,,,

--- a/spec/fixtures/csv/update_example_invalid_metadata_source.csv
+++ b/spec/fixtures/csv/update_example_invalid_metadata_source.csv
@@ -1,0 +1,3 @@
+oid,source,admin_set
+2034600,ils,brbl
+2005512,sierra,brbl

--- a/spec/models/batch_process_create_parent_spec.rb
+++ b/spec/models/batch_process_create_parent_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
   let(:typo_extent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], 'csv', 'aspace_parent_typo_extent.csv')) }
   let(:aspace_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], 'csv', 'aspace_parent.csv')) }
   let(:alma_parent) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], 'csv', 'create_alma_parent.csv')) }
+  let(:invalid_metadata_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], 'csv', 'create_invalid_metadata_source.csv')) }
 
   around do |example|
     original_image_bucket = ENV['S3_SOURCE_BUCKET_NAME']
@@ -145,6 +146,15 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.save
         end.not_to change { ParentObject.count }
         expect(batch_process.batch_ingest_events[0].reason).to eq('Skipping row [2]. Source cannot be blank.')
+      end
+      it 'does not accept a source of ils or sierra and reports the error' do
+        expect do
+          batch_process.file = invalid_metadata_source
+          batch_process.save
+        end.not_to change { ParentObject.count }
+        reasons = batch_process.batch_ingest_events.map(&:reason)
+        expect(reasons).to include('Skipping row [2]. Voyager and Sierra are not valid data sources. Please use a source of alma or aspace and the appropriate alma or aspace identifiers.')
+        expect(reasons).to include('Skipping row [3]. Voyager and Sierra are not valid data sources. Please use a source of alma or aspace and the appropriate alma or aspace identifiers.')
       end
       it 'can fail when aspace is source but no extent of digitization is provided' do
         expect do

--- a/spec/models/batch_process_spec.rb
+++ b/spec/models/batch_process_spec.rb
@@ -277,7 +277,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
         batch_process.file = csv_upload_with_source
         batch_process.save!
         expect(ParentObject.find(2_034_600).authoritative_metadata_source_id).to eq 1
-        expect(ParentObject.find(2_030_006).authoritative_metadata_source_id).to eq 2
         expect(ParentObject.find(2_012_036).authoritative_metadata_source_id).to eq 3
       end
 
@@ -518,7 +517,6 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
           batch_process.file = csv_upload_with_source
           batch_process.save
           expect(ParentObject.find(2_034_600).authoritative_metadata_source_id).to eq 1
-          expect(ParentObject.find(2_030_006).authoritative_metadata_source_id).to eq 2
           expect(ParentObject.find(2_012_036).authoritative_metadata_source_id).to eq 3
         end
 

--- a/spec/models/batch_process_update_parent_spec.rb
+++ b/spec/models/batch_process_update_parent_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
   let(:csv_small) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "update_example.csv")) }
   let(:csv_small_owp) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "update_example_owp.csv")) }
   let(:invalid_ps) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "update_example_invalid_ps.csv")) }
+  let(:invalid_metadata_source) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "update_example_invalid_metadata_source.csv")) }
   let(:blank_ps) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "update_example_blank_ps.csv")) }
   let(:invalid_user_csv) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "update_example_invalid_user.csv")) }
   let(:csv_missing) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "update_example_missing.csv")) }
@@ -258,6 +259,24 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(po_updated.visibility).to eq "Private"
       expect(update_batch_process.batch_ingest_events.first.reason).to eq "Skipping row [2]. Process failed. Permission Set missing from CSV."
       expect(update_batch_process.batch_ingest_events_count).to eq 1
+    end
+
+    it "does not accept a source of ils or sierra and reports the error" do
+      expect do
+        batch_process.file = csv_upload
+        batch_process.save
+        batch_process.create_new_parent_csv
+      end.to change { ParentObject.count }.from(0).to(5).or change { ParentObject.count }.from(0).to(3)
+
+      update_batch_process = described_class.new(batch_action: "update parent objects", user_id: user.id)
+      expect do
+        update_batch_process.file = invalid_metadata_source
+        update_batch_process.save
+        update_batch_process.update_parent_objects
+      end.not_to change { ParentObject.count }
+      reasons = update_batch_process.batch_ingest_events.map(&:reason)
+      expect(reasons).to include('Skipping row [2]. Voyager and Sierra are not valid data sources. Please use a source of alma or aspace and the appropriate alma or aspace identifiers.')
+      expect(reasons).to include('Skipping row [3]. Voyager and Sierra are not valid data sources. Please use a source of alma or aspace and the appropriate alma or aspace identifiers.')
     end
 
     it "does not update successfully if user does not have admin permission to permission set" do

--- a/spec/system/batch_process_update_parent_spec.rb
+++ b/spec/system/batch_process_update_parent_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe BatchProcess, type: :system, prep_metadata_sources: true, prep_ad
 
         visit "/batch_processes/#{BatchProcess.last.id}/"
         expect(page).to have_content "View Messages"
-        expect(page).to have_content "Skipping row [2] with unknown metadata source: bird. Accepted values are 'ladybird', 'aspace', 'sierra', or 'ils'."
+        expect(page).to have_content "Skipping row [2] with unknown metadata source: bird. Accepted values are 'ladybird', 'aspace', or 'alma'."
       end
     end
   end


### PR DESCRIPTION
## Summary  
Skips Batch Process creates and updates for ILS/Sierra objects.