### PR TITLE
MetsDirectoryScan Cron Job

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -27,6 +27,10 @@ Rails.application.configure do
       cron: '15 0 * * *',
       class: 'ChildObjectIntegrityCheckJob'
     },
+    mets_directory_scan: {
+      cron: '0 23 * * *',
+      class: 'MetsDirectoryScanJob'
+    },
     update_permission_requests: {
       cron: '15 0 * * *',
       class: 'UpdatePermissionRequestsJob'

--- a/spec/jobs/mets_directory_scan_job_spec.rb
+++ b/spec/jobs/mets_directory_scan_job_spec.rb
@@ -21,4 +21,9 @@ RSpec.describe MetsDirectoryScanJob, type: :job do
   it "has correct queue" do
     expect(mets_directory_scan_job.queue_name).to eq('default')
   end
+
+  it "is scheduled to run nightly at 7:00 pm ET (23:00 UTC)" do
+    entry = GoodJob::CronEntry.all.find { |e| e.key == :mets_directory_scan }
+    expect(entry.instance_variable_get(:@params)).to eq({ cron: "0 23 * * *", class: "MetsDirectoryScanJob", key: :mets_directory_scan })
+  end
 end


### PR DESCRIPTION
## Summary  
Adds nightly (7:00 pm ET (23:00 UTC)) cron job to management. 'Start Goobi Scan' button on the Batch Processes page still in place.