### PR TITLE
Hide Metadata Fields when Object is Redirect

### DIFF
--- a/app/controllers/parent_objects_controller.rb
+++ b/app/controllers/parent_objects_controller.rb
@@ -98,7 +98,7 @@ class ParentObjectsController < ApplicationController
                      end
 
       if valid_update && @parent_object.update(parent_object_params)
-        @parent_object.minify if valid_redirect_to_edit?
+        @parent_object.minify if valid_redirect_to_edit? && @parent_object.visibility == "Redirect"
         @parent_object.save!
         queue_parent_metadata_update
         format.html { redirect_to @parent_object, notice: 'Parent object was successfully saved, a full update has been queued.' }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -344,7 +344,7 @@ $( document ).on('turbolinks:load', function() {
 // This will trigger a modal when adding redirect
 $( document ).on('turbolinks:load', function() {
   $('.parent-edit').on('submit', function() {
-    if ( $("#parent_object_redirect_to").val() !== '' && $("#parent_object_redirect_to").length ) {
+    if ( $("#parent_object_redirect_to").val() !== '' && $("#parent_object_redirect_to").length && $("#parent_object_visibility").val() === 'Redirect' ) {
       return confirm('Adding Redirect To information will remove that object from public view.  Do you wish to continue?');
     }
   })

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -47,7 +47,7 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   before_save :check_permission_set
 
   def check_for_redirect
-    if visibility != "Redirect" && will_save_change_to_visibility?
+    if visibility != "Redirect" && will_save_change_to_visibility? && !will_save_change_to_redirect_to?
       self.redirect_to = nil
     elsif redirect_to.present?
       minify

--- a/app/models/parent_object.rb
+++ b/app/models/parent_object.rb
@@ -47,7 +47,11 @@ class ParentObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
   before_save :check_permission_set
 
   def check_for_redirect
-    minify if redirect_to.present?
+    if visibility != "Redirect" && will_save_change_to_visibility?
+      self.redirect_to = nil
+    elsif redirect_to.present?
+      minify
+    end
   end
 
   def minify

--- a/app/views/parent_objects/_form.html.erb
+++ b/app/views/parent_objects/_form.html.erb
@@ -77,6 +77,7 @@
         <%= form.select(:visibility, ["Private", "Public", "Yale Community Only"]) %>
       </div>
     <% end %>
+      <% unless parent_object.visibility == "Redirect" %>
       <div class="col-med-3">
         <% if @visible_permission_sets.present? && (current_user.has_role?(:administrator, parent_object.permission_set) || current_user.has_role?(:sysadmin) || parent_object.permission_set.nil?) %>
           <%= form.label "Permission Set" %>
@@ -96,13 +97,15 @@
             {
             required: false
             },
-            disabled: true) 
+            disabled: true)
           %>
         <% end %>
       </div>
+      <% end %>
   </div>
   <br>
 
+  <% unless parent_object.visibility == "Redirect" %>
   <div class="form-row">
     <div class="col-med-9">
       <%= form.label :sensitive_materials, "Sensitive Materials" %>
@@ -229,6 +232,7 @@
     </div>
   </div>
   <br>
+  <% end %>
   <div class="actions" id="submit-parent">
     <%= form.submit(@parent_object.new_record? ? 'Create Parent object' : 'Save Parent Object And Update Metadata') %>
   </div>

--- a/spec/requests/parent_objects_spec.rb
+++ b/spec/requests/parent_objects_spec.rb
@@ -405,6 +405,18 @@ RSpec.describe "/parent_objects", type: :request, prep_metadata_sources: true, p
       expect(response).to redirect_to(parent_object_url(parent_object))
     end
 
+    it 'can change a redirected object back to a normal visibility' do
+      parent_object = ParentObject.create! valid_attributes
+      patch parent_object_url(parent_object), params: { parent_object: redirect_attributes }
+      parent_object.reload
+      expect(parent_object.visibility).to eq 'Redirect'
+
+      patch parent_object_url(parent_object), params: { parent_object: { visibility: 'Public' } }
+      parent_object.reload
+      expect(parent_object.visibility).to eq 'Public'
+      expect(parent_object.redirect_to).to be_nil
+    end
+
     context "with invalid parameters" do
       it "does not save an improperly formatted url" do
         parent_object = ParentObject.create! valid_attributes


### PR DESCRIPTION
## Summary  
Hide metadata fields when editing a Redirected parent object. Also, allows parents to change visibility if already Redirect. 