### PR TITLE
Preservica Use Case 1

### DIFF
--- a/app/models/preservica/information_object.rb
+++ b/app/models/preservica/information_object.rb
@@ -3,6 +3,8 @@
 class Preservica::InformationObject
   include Preservica::PreservicaObject
 
+  attr_accessor :title, :structural_object_child_type
+
   def self.where(options)
     preservica_client = options[:preservica_client] || PreservicaClient.new(admin_set_key: options[:admin_set_key])
     Preservica::InformationObject.new(preservica_client, options[:id])

--- a/app/models/preservica/structural_object.rb
+++ b/app/models/preservica/structural_object.rb
@@ -29,12 +29,18 @@ class Preservica::StructuralObject
     total_results = structural_object_children.at("Paging")&.at("TotalResults")&.text.to_i
     loop do
       structural_object_children.xpath('/ChildrenResponse/Children/Child').each do |child_ref|
-        information_object_id = child_ref.xpath('@ref').text
-        children << Preservica::InformationObject.new(@preservica_client, information_object_id)
+        children << information_object_from_child(child_ref)
       end
       break if children.count >= total_results || !structural_object_children.xpath('/ChildrenResponse/Children/Child').count.positive?
       structural_object_children = Nokogiri::XML(@preservica_client.structural_object_children(id, children.count)).remove_namespaces!
     end
     children
+  end
+
+  def information_object_from_child(child_ref)
+    information_object = Preservica::InformationObject.new(@preservica_client, child_ref.xpath('@ref').text)
+    information_object.title = child_ref.xpath('@title').text
+    information_object.structural_object_child_type = child_ref.xpath('@type').text
+    information_object
   end
 end

--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -37,7 +37,7 @@ class PreservicaImageService
       if @pattern == :pattern_one
         structural_object = Preservica::StructuralObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)
         begin
-          @information_objects = structural_object.information_objects
+          @information_objects = structural_object.information_objects.sort_by { |io| io.title.to_s }
         rescue Net::OpenTimeout, Errno::ECONNREFUSED => e
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end
@@ -52,6 +52,7 @@ class PreservicaImageService
       # raise PreservicaImageServiceError.new("Unable to log in to Preservica", @uri.to_s)
       raise PreservicaImageServiceError.new(e.to_s, @uri.to_s)
     end
+    check_for_non_information_object_children if @pattern == :pattern_one
     begin
       process_information_objects(representation_type)
     rescue StandardError => e
@@ -68,6 +69,16 @@ class PreservicaImageService
   # rubocop:enable Metrics/PerceivedComplexity
 
   # rubocop:disable Layout/LineLength
+  def check_for_non_information_object_children
+    non_information_objects = @information_objects.reject do |information_object|
+      information_object.structural_object_child_type.blank? || information_object.structural_object_child_type == 'IO'
+    end
+    return if non_information_objects.empty?
+    raise PreservicaImageServiceError.new("Structural object contains children that are not information objects (nested folders); this object shape is not supported", @uri.to_s)
+  end
+  # rubocop:enable Layout/LineLength
+
+  # rubocop:disable Layout/LineLength
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -78,6 +89,7 @@ class PreservicaImageService
       raise PreservicaImageServiceError.new("No matching representation found in Preservica", @uri.to_s) if representation.nil?
       content_objects = representation.content_objects
       raise PreservicaImageServiceError.new("No matching content object found in Preservica", @uri.to_s) if content_objects.empty?
+      information_object_images = []
       content_objects.each_with_index do |content_object, index|
         raise PreservicaImageServiceError.new("No active generations found in Preservica", "content object: #{content_object.id}") if content_object.active_generations.empty?
         raise PreservicaImageServiceError.new("No matching bitstreams found in Preservica", content_object.active_generations[0].id.to_s) if content_object.active_generations[0].bitstreams.empty?
@@ -87,13 +99,14 @@ class PreservicaImageService
         end
         next unless tif_bitstream.present?
         raise PreservicaImageServiceError.new("SHA mismatch found in Preservica", "bitstream: #{content_object.active_generations[0].bitstreams[0].id}") if tif_bitstream.sha512_checksum.nil?
-        @images << { preservica_content_object_uri: representation.content_object_uri(index),
-                     preservica_generation_uri: content_object.active_generations[0].generation_uri,
-                     preservica_bitstream_uri: tif_bitstream.uri,
-                     sha512_checksum: tif_bitstream.sha512_checksum,
-                     bitstream: tif_bitstream,
-                     caption: tif_bitstream.filename }
+        information_object_images << { preservica_content_object_uri: representation.content_object_uri(index),
+                                       preservica_generation_uri: content_object.active_generations[0].generation_uri,
+                                       preservica_bitstream_uri: tif_bitstream.uri,
+                                       sha512_checksum: tif_bitstream.sha512_checksum,
+                                       bitstream: tif_bitstream,
+                                       caption: tif_bitstream.filename }
       end
+      @images.concat(information_object_images.sort_by { |image| image[:caption].to_s })
     end
   end
   # rubocop:enable Metrics/MethodLength

--- a/spec/fixtures/csv/preservica/preservica_ingest_case_one.csv
+++ b/spec/fixtures/csv/preservica/preservica_ingest_case_one.csv
@@ -1,0 +1,2 @@
+oid,admin_set,source,aspace_uri,bib,holding,item,barcode,visibility,digital_object_source,preservica_uri,preservica_representation_type
+,sml,aspace,/repositories/11/archival_objects/200000000,36,holding,item,barcode,Public,Preservica,/preservica/api/entity/structural-objects/eeee0001-0000-4000-8000-000000000001,Preservation

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>cccc0001-0000-4000-8000-000000000001</xip:ContentObject>
+    <xip:FormatGroup>tiff</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0268_0002.tif</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/353</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Tagged Image File Format</xip:FormatName>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0268_0002.tif">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1/bitstreams/1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Bitstream>
+    <xip:Filename>ms_0664_s02_b016_f0268_0002.tif</xip:Filename>
+    <xip:FileSize>310202</xip:FileSize>
+    <xip:Fixities>
+      <xip:Fixity>
+        <xip:FixityAlgorithmRef>SHA512</xip:FixityAlgorithmRef>
+        <xip:FixityValue>
+          1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7
+        </xip:FixityValue>
+      </xip:Fixity>
+    </xip:Fixities>
+  </xip:Bitstream>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1/bitstreams/1
+    </Self>
+    <IntegrityCheckHistory>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1/bitstreams/1/integrity-check-history
+    </IntegrityCheckHistory>
+    <Content>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1/bitstreams/1/content
+    </Content>
+  </AdditionalInformation>
+</BitstreamResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>cccc0002-0000-4000-8000-000000000002</xip:ContentObject>
+    <xip:FormatGroup>tiff</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0268_0001.tif</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/353</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Tagged Image File Format</xip:FormatName>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0268_0001.tif">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1/bitstreams/1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Bitstream>
+    <xip:Filename>ms_0664_s02_b016_f0268_0001.tif</xip:Filename>
+    <xip:FileSize>310202</xip:FileSize>
+    <xip:Fixities>
+      <xip:Fixity>
+        <xip:FixityAlgorithmRef>SHA512</xip:FixityAlgorithmRef>
+        <xip:FixityValue>
+          1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7
+        </xip:FixityValue>
+      </xip:Fixity>
+    </xip:Fixities>
+  </xip:Bitstream>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1/bitstreams/1
+    </Self>
+    <IntegrityCheckHistory>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1/bitstreams/1/integrity-check-history
+    </IntegrityCheckHistory>
+    <Content>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1/bitstreams/1/content
+    </Content>
+  </AdditionalInformation>
+</BitstreamResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>cccc0003-0000-4000-8000-000000000003</xip:ContentObject>
+    <xip:FormatGroup>tiff</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0268_0003.tif</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/353</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Tagged Image File Format</xip:FormatName>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0268_0003.tif">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1/bitstreams/1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Bitstream>
+    <xip:Filename>ms_0664_s02_b016_f0268_0003.tif</xip:Filename>
+    <xip:FileSize>310202</xip:FileSize>
+    <xip:Fixities>
+      <xip:Fixity>
+        <xip:FixityAlgorithmRef>SHA512</xip:FixityAlgorithmRef>
+        <xip:FixityValue>
+          1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7
+        </xip:FixityValue>
+      </xip:Fixity>
+    </xip:Fixities>
+  </xip:Bitstream>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1/bitstreams/1
+    </Self>
+    <IntegrityCheckHistory>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1/bitstreams/1/integrity-check-history
+    </IntegrityCheckHistory>
+    <Content>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1/bitstreams/1/content
+    </Content>
+  </AdditionalInformation>
+</BitstreamResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>cccc0004-0000-4000-8000-000000000004</xip:ContentObject>
+    <xip:FormatGroup>tiff</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0269_0002.tif</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/353</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Tagged Image File Format</xip:FormatName>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0269_0002.tif">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1/bitstreams/1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Bitstream>
+    <xip:Filename>ms_0664_s02_b016_f0269_0002.tif</xip:Filename>
+    <xip:FileSize>1131966</xip:FileSize>
+    <xip:Fixities>
+      <xip:Fixity>
+        <xip:FixityAlgorithmRef>SHA512</xip:FixityAlgorithmRef>
+        <xip:FixityValue>
+          d6e3926fbe14fedbf3a568b6a5dbdb3e8b2312f217daa460a743559d41a688af4a7c701e7bac908fc7e3fd51c505fa01dad9eee96fcfd2666e92c648249edf02
+        </xip:FixityValue>
+      </xip:Fixity>
+    </xip:Fixities>
+  </xip:Bitstream>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1/bitstreams/1
+    </Self>
+    <IntegrityCheckHistory>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1/bitstreams/1/integrity-check-history
+    </IntegrityCheckHistory>
+    <Content>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1/bitstreams/1/content
+    </Content>
+  </AdditionalInformation>
+</BitstreamResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>cccc0005-0000-4000-8000-000000000005</xip:ContentObject>
+    <xip:FormatGroup>tiff</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0269_0001.tif</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/353</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Tagged Image File Format</xip:FormatName>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0269_0001.tif">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Bitstream>
+    <xip:Filename>ms_0664_s02_b016_f0269_0001.tif</xip:Filename>
+    <xip:FileSize>1131966</xip:FileSize>
+    <xip:Fixities>
+      <xip:Fixity>
+        <xip:FixityAlgorithmRef>SHA512</xip:FixityAlgorithmRef>
+        <xip:FixityValue>
+          d6e3926fbe14fedbf3a568b6a5dbdb3e8b2312f217daa460a743559d41a688af4a7c701e7bac908fc7e3fd51c505fa01dad9eee96fcfd2666e92c648249edf02
+        </xip:FixityValue>
+      </xip:Fixity>
+    </xip:Fixities>
+  </xip:Bitstream>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1
+    </Self>
+    <IntegrityCheckHistory>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1/integrity-check-history
+    </IntegrityCheckHistory>
+    <Content>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1/content
+    </Content>
+  </AdditionalInformation>
+</BitstreamResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>dddd0001-0000-4000-8000-000000000001</xip:ContentObject>
+    <xip:FormatGroup>pdf</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0269.pdf</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/276</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Acrobat PDF 1.7 - Portable Document Format</xip:FormatName>
+        <xip:FormatVersion>1.7</xip:FormatVersion>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0269.pdf">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Representations>
+    <Representation type="Access" name="Access-1">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations/Access/1
+    </Representation>
+    <Representation type="Preservation" name="Preservation-1">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations/Preservation/1
+    </Representation>
+  </Representations>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations
+    </Self>
+  </AdditionalInformation>
+</RepresentationsResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations/Preservation.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations/Preservation.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Representation>
+    <xip:InformationObject>aaaa0001-0000-4000-8000-000000000001</xip:InformationObject>
+    <xip:Name>Preservation-1</xip:Name>
+    <xip:Type>Preservation</xip:Type>
+    <xip:ContentObjects>
+      <xip:ContentObject>cccc0001-0000-4000-8000-000000000001</xip:ContentObject>
+      <xip:ContentObject>cccc0002-0000-4000-8000-000000000002</xip:ContentObject>
+      <xip:ContentObject>cccc0003-0000-4000-8000-000000000003</xip:ContentObject>
+    </xip:ContentObjects>
+    <xip:RepresentationFormats/>
+    <xip:RepresentationProperties/>
+  </xip:Representation>
+  <ContentObjects>
+    <ContentObject title="ms_0664_s02_b016_f0268_0002" ref="cccc0001-0000-4000-8000-000000000001" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001
+    </ContentObject>
+    <ContentObject title="ms_0664_s02_b016_f0268_0001" ref="cccc0002-0000-4000-8000-000000000002" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002
+    </ContentObject>
+    <ContentObject title="ms_0664_s02_b016_f0268_0003" ref="cccc0003-0000-4000-8000-000000000003" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003
+    </ContentObject>
+  </ContentObjects>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations/Preservation/1
+    </Self>
+  </AdditionalInformation>
+</RepresentationResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Representations>
+    <Representation type="Access" name="Access-1">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations/Access/1
+    </Representation>
+    <Representation type="Preservation" name="Preservation-1">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations/Preservation/1
+    </Representation>
+  </Representations>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations
+    </Self>
+  </AdditionalInformation>
+</RepresentationsResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations/Preservation.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations/Preservation.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Representation>
+    <xip:InformationObject>aaaa0002-0000-4000-8000-000000000002</xip:InformationObject>
+    <xip:Name>Preservation-1</xip:Name>
+    <xip:Type>Preservation</xip:Type>
+    <xip:ContentObjects>
+      <xip:ContentObject>cccc0004-0000-4000-8000-000000000004</xip:ContentObject>
+      <xip:ContentObject>cccc0005-0000-4000-8000-000000000005</xip:ContentObject>
+      <xip:ContentObject>dddd0001-0000-4000-8000-000000000001</xip:ContentObject>
+    </xip:ContentObjects>
+    <xip:RepresentationFormats/>
+    <xip:RepresentationProperties/>
+  </xip:Representation>
+  <ContentObjects>
+    <ContentObject title="ms_0664_s02_b016_f0269_0002" ref="cccc0004-0000-4000-8000-000000000004" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004
+    </ContentObject>
+    <ContentObject title="ms_0664_s02_b016_f0269_0001" ref="cccc0005-0000-4000-8000-000000000005" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005
+    </ContentObject>
+    <ContentObject title="ms_0664_s02_b016_f0269" ref="dddd0001-0000-4000-8000-000000000001" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001
+    </ContentObject>
+  </ContentObjects>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations/Preservation/1
+    </Self>
+  </AdditionalInformation>
+</RepresentationResponse>

--- a/spec/fixtures/preservica/api/entity/structural-objects/88e52625-0000-4000-8000-00000000bad1/children.xml
+++ b/spec/fixtures/preservica/api/entity/structural-objects/88e52625-0000-4000-8000-00000000bad1/children.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ChildrenResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Children>
+    <Child title="1911 March - Jul" ref="99e52625-0000-4000-8000-00000000bad2" type="SO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/structural-objects/99e52625-0000-4000-8000-00000000bad2
+    </Child>
+    <Child title="[Preservica] ms_0664_s02_b016_f0268" ref="aaaa0001-0000-4000-8000-000000000001" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001
+    </Child>
+  </Children>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/structural-objects/88e52625-0000-4000-8000-00000000bad1/children
+    </Self>
+  </AdditionalInformation>
+</ChildrenResponse>

--- a/spec/fixtures/preservica/api/entity/structural-objects/eeee0001-0000-4000-8000-000000000001/children.xml
+++ b/spec/fixtures/preservica/api/entity/structural-objects/eeee0001-0000-4000-8000-000000000001/children.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ChildrenResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Children>
+    <Child title="[Preservica] ms_0664_s02_b016_f0269" ref="aaaa0002-0000-4000-8000-000000000002" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002
+    </Child>
+    <Child title="[Preservica] ms_0664_s02_b016_f0268" ref="aaaa0001-0000-4000-8000-000000000001" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001
+    </Child>
+  </Children>
+  <Paging>
+    <TotalResults>2</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/structural-objects/eeee0001-0000-4000-8000-000000000001/children
+    </Self>
+  </AdditionalInformation>
+</ChildrenResponse>

--- a/spec/models/preservica/preservica_ingest_case_one_spec.rb
+++ b/spec/models/preservica/preservica_ingest_case_one_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Use Case 1: an Archival Object folder (structural object) contains multiple information
+# objects (one per physical folder), each with multiple TIFF content objects in its
+# Preservation representation and a PDF in its Access representation. A single parent
+# is created with the TIFFs from every information object, ordered by information object
+# title and then by filename.
+RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  subject(:batch_process) { BatchProcess.new }
+  let(:admin_set) { AdminSet.find_by(key: 'sml') }
+  let(:user) { FactoryBot.create(:user, uid: "mk2529") }
+  let(:preservica_ingest_case_one) { Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "preservica", "preservica_ingest_case_one.csv")) }
+  let(:expected_captions) do
+    ["ms_0664_s02_b016_f0268_0001.tif",
+     "ms_0664_s02_b016_f0268_0002.tif",
+     "ms_0664_s02_b016_f0268_0003.tif",
+     "ms_0664_s02_b016_f0269_0001.tif",
+     "ms_0664_s02_b016_f0269_0002.tif"]
+  end
+  # content objects are listed out of filename order in the representation fixtures;
+  # the URI at each position must stay paired with the caption at that position
+  let(:expected_content_object_uris) do
+    %w[cccc0002-0000-4000-8000-000000000002
+       cccc0001-0000-4000-8000-000000000001
+       cccc0003-0000-4000-8000-000000000003
+       cccc0005-0000-4000-8000-000000000005
+       cccc0004-0000-4000-8000-000000000004].map do |ref|
+      "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/#{ref}"
+    end
+  end
+
+  around do |example|
+    preservica_host = ENV['PRESERVICA_HOST']
+    preservica_creds = ENV['PRESERVICA_CREDENTIALS']
+    ENV['PRESERVICA_HOST'] = "testpreservica"
+    ENV['PRESERVICA_CREDENTIALS'] = '{"sml": {"username":"xxxxx", "password":"xxxxx"}}'
+    access_host = ENV['ACCESS_PRIMARY_MOUNT']
+    ENV['ACCESS_PRIMARY_MOUNT'] = File.join("spec", "fixtures", "images", "access_primaries")
+    perform_enqueued_jobs do
+      example.run
+    end
+    ENV['PRESERVICA_HOST'] = preservica_host
+    ENV['PRESERVICA_CREDENTIALS'] = preservica_creds
+    ENV['ACCESS_PRIMARY_MOUNT'] = access_host
+  end
+
+  before do
+    user.add_role(:editor, admin_set)
+    login_as(:user)
+    batch_process.user_id = user.id
+    stub_pdfs
+    stub_preservica_aspace_single
+    stub_preservica_login
+    # the Access representations and the PDF content object's bitstream details are
+    # intentionally NOT stubbed - WebMock will error if the ingest ever requests them
+    fixtures = %w[preservica/api/entity/structural-objects/eeee0001-0000-4000-8000-000000000001/children
+                  preservica/api/entity/structural-objects/88e52625-0000-4000-8000-00000000bad1/children
+                  preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations
+                  preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations/Preservation
+                  preservica/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations
+                  preservica/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002/representations/Preservation
+                  preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations
+                  preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1
+                  preservica/api/entity/content-objects/cccc0001-0000-4000-8000-000000000001/generations/1/bitstreams/1
+                  preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations
+                  preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1
+                  preservica/api/entity/content-objects/cccc0002-0000-4000-8000-000000000002/generations/1/bitstreams/1
+                  preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations
+                  preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1
+                  preservica/api/entity/content-objects/cccc0003-0000-4000-8000-000000000003/generations/1/bitstreams/1
+                  preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations
+                  preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1
+                  preservica/api/entity/content-objects/cccc0004-0000-4000-8000-000000000004/generations/1/bitstreams/1
+                  preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations
+                  preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1
+                  preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1
+                  preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations
+                  preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1]
+
+    fixtures.each do |fixture|
+      stub_request(:get, "https://test#{fixture}").to_return(
+        status: 200, body: File.open(File.join(fixture_paths[0], "#{fixture}.xml"))
+      )
+    end
+
+    { "cccc0001-0000-4000-8000-000000000001" => "ae328d84-e429-4d46-a865-9ee11157b486",
+      "cccc0002-0000-4000-8000-000000000002" => "ae328d84-e429-4d46-a865-9ee11157b486",
+      "cccc0003-0000-4000-8000-000000000003" => "ae328d84-e429-4d46-a865-9ee11157b486",
+      "cccc0004-0000-4000-8000-000000000004" => "ae328d84-e429-4d46-a865-9ee11157b487",
+      "cccc0005-0000-4000-8000-000000000005" => "ae328d84-e429-4d46-a865-9ee11157b487" }.each do |content_object, tif_source|
+      stub_request(:get, "https://testpreservica/api/entity/content-objects/#{content_object}/generations/1/bitstreams/1/content").to_return(
+        status: 200, body: File.open(File.join(fixture_paths[0], "preservica/api/entity/content-objects/#{tif_source}/generations/1/bitstreams/1/content.tif"), 'rb')
+      )
+    end
+  end
+
+  def access_primary_path(oid)
+    pairtree_path = Partridge::Pairtree.oid_to_pairtree(oid)
+    File.join(ENV['ACCESS_PRIMARY_MOUNT'], format("%02d", pairtree_path.first), pairtree_path, "#{oid}.tif")
+  end
+
+  it 'builds an ordered, pdf-free image list from a multi-folder structural object' do
+    image_service = PreservicaImageService.new("/structural-objects/eeee0001-0000-4000-8000-000000000001", "sml")
+    image_list = image_service.image_list("Preservation")
+    expect(image_list.count).to eq 5
+    expect(image_list.map { |image| image[:caption] }).to eq expected_captions
+    expect(image_list.map { |image| image[:preservica_content_object_uri] }).to eq expected_content_object_uris
+  end
+
+  it 'raises a clear error when the structural object contains nested folders' do
+    image_service = PreservicaImageService.new("/structural-objects/88e52625-0000-4000-8000-00000000bad1", "sml")
+    expect do
+      image_service.image_list("Preservation")
+    end.to raise_error(PreservicaImageService::PreservicaImageServiceError, /not information objects/)
+  end
+
+  it 'creates a single parent with ordered children from every information object' do
+    expected_oids = (200_000_001..200_000_005).to_a
+    expected_oids.each do |oid|
+      File.delete(access_primary_path(oid)) if File.exist?(access_primary_path(oid))
+    end
+    allow(S3Service).to receive(:s3_exists?).and_return(false)
+
+    expect do
+      batch_process.file = preservica_ingest_case_one
+      batch_process.save
+    end.to change { ChildObject.count }.by(5)
+
+    parent_object = ParentObject.find(200_000_000)
+    child_objects = parent_object.child_objects.order(:order)
+    expect(child_objects.map(&:caption)).to eq expected_captions
+    expect(child_objects.map(&:order)).to eq [1, 2, 3, 4, 5]
+    expect(child_objects.map(&:preservica_content_object_uri)).to eq expected_content_object_uris
+    expect(child_objects.map(&:caption)).to all(end_with(".tif"))
+    expect(parent_object.child_object_count).to eq 5
+    expect(parent_object.last_preservica_update).not_to eq nil
+    expect(child_objects.first.sha512_checksum).to eq "1932c08c4670d5010fac6fa363ad5d9be7a4e7d743757ba5eefbbe8e3f9b2fb89b1604c1e527cfae6f47a91a60845268e91d2723aa63a90dd4735f75017569f7"
+    expected_oids.each do |oid|
+      expect(File.exist?(access_primary_path(oid))).to eq true
+    end
+  ensure
+    expected_oids&.each do |oid|
+      File.delete(access_primary_path(oid)) if File.exist?(access_primary_path(oid))
+    end
+  end
+end

--- a/spec/models/preservica/preservica_ingest_case_one_spec.rb
+++ b/spec/models/preservica/preservica_ingest_case_one_spec.rb
@@ -2,11 +2,6 @@
 
 require 'rails_helper'
 
-# Use Case 1: an Archival Object folder (structural object) contains multiple information
-# objects (one per physical folder), each with multiple TIFF content objects in its
-# Preservation representation and a PDF in its Access representation. A single parent
-# is created with the TIFFs from every information object, ordered by information object
-# title and then by filename.
 RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
   subject(:batch_process) { BatchProcess.new }
   let(:admin_set) { AdminSet.find_by(key: 'sml') }
@@ -19,8 +14,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
      "ms_0664_s02_b016_f0269_0001.tif",
      "ms_0664_s02_b016_f0269_0002.tif"]
   end
-  # content objects are listed out of filename order in the representation fixtures;
-  # the URI at each position must stay paired with the caption at that position
   let(:expected_content_object_uris) do
     %w[cccc0002-0000-4000-8000-000000000002
        cccc0001-0000-4000-8000-000000000001
@@ -53,8 +46,6 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     stub_pdfs
     stub_preservica_aspace_single
     stub_preservica_login
-    # the Access representations and the PDF content object's bitstream details are
-    # intentionally NOT stubbed - WebMock will error if the ingest ever requests them
     fixtures = %w[preservica/api/entity/structural-objects/eeee0001-0000-4000-8000-000000000001/children
                   preservica/api/entity/structural-objects/88e52625-0000-4000-8000-00000000bad1/children
                   preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations


### PR DESCRIPTION
## Summary  
Prservica ingests can now ingest multiple tiffs from multiple information objects that belong to one structural object. 