### PR TITLE
Adds retries to batch status

### DIFF
--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -201,13 +201,6 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/PerceivedComplexity
 
-  # SETS COMPLETE STATUS FOR RECREATE JOB
-  def are_all_children_complete?(parent_object)
-    child_objects.where(parent_object: parent_object).all? do |co|
-      co.status_for_batch_process(self) == 'Complete'
-    end
-  end
-
   # ASSIGNS PARENT/CHILD OBJECT TO BATCH PROCESS FOR CREATE/DELETE/UPDATE
   def setup_for_background_jobs(object, metadata_source)
     object.authoritative_metadata_source = MetadataSource.find_by(metadata_cloud_name: (metadata_source.presence || 'ladybird')) if object.class == ParentObject
@@ -219,11 +212,15 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # BATCH STATUSES: ------------------------------------------------------------------------------ #
 
   # SETS BATCH STATUS BASED ON CURRENT STATUS
+  # rubocop:disable Metrics/PerceivedComplexity
   def batch_status
     return child_oid_export_status if batch_action == 'export child oids'
     current_status = status_hash
     if single_status(current_status)
       single_status(current_status)
+    elsif current_status[:retry] != 0
+      "#{current_status[:retry]} batch processes have begun the retry process." if current_status[:retry] > 1
+      "#{current_status[:retry]} batch process has begun the retry process." if current_status[:retry] == 1
     elsif current_status[:failed] != 0
       "#{current_status[:failed]} out of #{current_status[:total].to_i} parent objects have a failure."
     elsif current_status[:in_progress] != 0
@@ -232,6 +229,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
       "View Messages"
     end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 
   # SETS BATCH SINGLE STATUS
   def single_status(current_status)
@@ -257,6 +255,38 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # SETS COMPLETE STATUS FOR RECREATE JOB
+  def are_all_children_complete?(parent_object)
+    child_objects.where(parent_object: parent_object).all? do |co|
+      co.status_for_batch_process(self) == 'Complete'
+    end
+  end
+
+  # GETS LIST OF CONNECTED STATUSES FOR PARENT OBJECTS
+  def connected_parent_statuses
+    @connected_parent_statuses ||= batch_connections.where(connectable_type: "ParentObject").map(&:status)
+  end
+
+  # GETS LIST OF CONNECTED STATUSES FOR BATCH PROCESS' OWN INGEST EVENTS
+  def connected_batch_statuses
+    connection = batch_connections.find_by(connectable: self)
+    @connected_batch_statuses ||= IngestEvent.where(batch_connection: connection).pluck(:status)
+  end
+
+  # COUNTS CURRENT STATUSES
+  def status_hash
+    @status_hash ||= {
+      complete: connected_parent_statuses.count("Complete") + connected_parent_statuses.count("Parent object deleted successfully"),
+      in_progress: connected_parent_statuses.count("In progress - no failures"),
+      failed: connected_parent_statuses.count("Failed"),
+      retry: connected_batch_statuses.count("retry"),
+      unknown: connected_parent_statuses.count("Unknown"),
+      total: connected_parent_statuses.count.to_f
+    }
+  end
+
+  # END OF BATCH STATUSES: ------------------------------------------------------------------------------ #
+
   # ADDS ADMIN SET KEYS TO BP TABLE
   def add_admin_set_to_bp(sets, object)
     key = admin_set_key_for(object)
@@ -274,21 +304,5 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
     when ParentObject
       object.admin_set.key
     end
-  end
-
-  # GETS LIST OF CONNECTED STATUSES
-  def connected_statuses
-    @connected_statuses ||= batch_connections.where(connectable_type: "ParentObject").map(&:status)
-  end
-
-  # COUNTS CURRENT STATUSES
-  def status_hash
-    @status_hash ||= {
-      complete: connected_statuses.count("Complete") + connected_statuses.count("Parent object deleted successfully"),
-      in_progress: connected_statuses.count("In progress - no failures"),
-      failed: connected_statuses.count("Failed"),
-      unknown: connected_statuses.count("Unknown"),
-      total: connected_statuses.count.to_f
-    }
   end
 end

--- a/spec/jobs/sync_from_preservica_job_spec.rb
+++ b/spec/jobs/sync_from_preservica_job_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
 
     expect(batch_process).to have_received(:batch_processing_event)
       .with('Setup job failed to save: Something went wrong', 'failed')
+    expect(batch_process.batch_status).to eq('View Messages')
   end
 
   it 'logs retry batch processing event when retries are exhausted' do
@@ -80,6 +81,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
 
       reasons = batch_process.batch_ingest_events.where(status: 'retry').pluck(:reason)
       expect(reasons).to include('Retrying Sync from Preservica - Request error Net::ReadTimeout for sample.com/uri')
+      expect(batch_process.batch_status).to eq('1 batch process has begun the retry process.')
     end
   end
 
@@ -96,6 +98,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
       .with("Setup job failed to save: #{error.message}", 'failed')
     expect(batch_process).not_to have_received(:batch_processing_event)
       .with(a_string_starting_with('Retrying Sync from Preservica - Request error'), 'retry')
+    expect(batch_process.batch_status).to eq('View Messages')
   end
 
   context 'when sync_from_preservica raises an exception' do
@@ -115,6 +118,7 @@ RSpec.describe SyncFromPreservicaJob, type: :job, prep_metadata_sources: true, p
       expect do
         described_class.new.perform(batch_process)
       end.to raise_error(RuntimeError, error_message)
+      expect(batch_process.batch_status).to eq('View Messages')
     end
   end
 end

--- a/spec/models/preservica/preservica_retry_spec.rb
+++ b/spec/models/preservica/preservica_retry_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
       expect(po_first.child_objects[0].preservica_content_object_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b486"
       expect(po_first.child_objects[1].preservica_content_object_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b489"
       expect(po_first.child_objects[2].preservica_content_object_uri).to eq "https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/ae328d84-e429-4d46-a865-9ee11157b487"
+      expect(batch_process.batch_status).to eq "Batch complete"
     end
   end
 end


### PR DESCRIPTION
# Summary
Adds the retry messaging to the kinds of messages that are captured by batch process statuses.

# Related Ticket
[#3031](https://github.com/yalelibrary/YUL-DC/issues/3031)