### PR TITLE
Adds Specific Wait Times for Preservica Ingest Retry Attempts

### DIFF
--- a/app/jobs/sync_from_preservica_job.rb
+++ b/app/jobs/sync_from_preservica_job.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class SyncFromPreservicaJob < ApplicationJob
-  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, FrozenError, PreservicaImageService::PreservicaImageServiceNetworkError, attempts: 3 do |job, exception|
+  retry_on RuntimeError, Net::HTTPFatalError, Net::ReadTimeout, FrozenError, PreservicaImageService::PreservicaImageServiceNetworkError, wait: lambda { |executions|
+                                                                                                                                                 [30, 180, 10_800][executions - 1 || 10_800]
+                                                                                                                                               }, attempts: 3 do |job, exception|
     batch_arg = job.arguments.first
     batch_process_id = batch_arg&.respond_to?(:id) ? batch_arg.id : batch_arg&._aj_globalid&.split('/')&.last&.to_i
     batch_process = BatchProcess.find_by(id: batch_process_id)


### PR DESCRIPTION
# Summary
Adds specific wait times for the Preservica retry function: 30 seconds for first attempt, 3 minutes for second attempt, and 3 hours for third attempt.

# Related Ticket
[#3031](https://github.com/yalelibrary/YUL-DC/issues/3031)