### PR TITLE
Batch Process Structure Editor

### DIFF
--- a/app/jobs/update_structure_ranges_job.rb
+++ b/app/jobs/update_structure_ranges_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UpdateStructureRangesJob < ApplicationJob
+  queue_as :default
+
+  def default_priority
+    20
+  end
+
+  def perform(batch_process)
+    batch_process.update_structure_ranges
+  rescue => e
+    batch_process.batch_processing_event("UpdateStructureRangesJob failed due to #{e.message}", "failed")
+  end
+end

--- a/app/models/batch_process.rb
+++ b/app/models/batch_process.rb
@@ -22,6 +22,8 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include UpdateFulltextStatus
   # RECREATE CHILD OID PTIFFS:
   include RecreateChildPtiff
+  # UPDATE STRUCTURE RANGES:
+  include Structurable
   attr_reader :file
   after_create :determine_background_jobs
   before_create :mets_oid
@@ -45,7 +47,7 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # LISTS AVAILABLE BATCH ACTIONS
   # rubocop:disable Layout/LineLength
   def self.batch_actions
-    ['create parent objects', 'update parent objects', 'update child objects caption and label', 'update child objects checksum', 'delete parent objects', 'delete child objects', 'export all parent objects by admin set', 'export parent metadata', 'export child oids', 'reassociate child oids', 'recreate child oid ptiffs', 'reindex all parents', 'update fulltext status', 'resync with preservica', 'activity stream updates']
+    ['create parent objects', 'update parent objects', 'update child objects caption and label', 'update child objects checksum', 'delete parent objects', 'delete child objects', 'export all parent objects by admin set', 'export parent metadata', 'export child oids', 'reassociate child oids', 'recreate child oid ptiffs', 'reindex all parents', 'update fulltext status', 'update structure ranges', 'resync with preservica', 'activity stream updates']
   end
   # rubocop:enable Layout/LineLength
 
@@ -190,6 +192,8 @@ class BatchProcess < ApplicationRecord # rubocop:disable Metrics/ClassLength
         RecreateChildOidPtiffsJob.perform_later(self)
       when 'update fulltext status'
         UpdateFulltextStatusJob.perform_later(self)
+      when 'update structure ranges'
+        UpdateStructureRangesJob.perform_later(self)
       when 'resync with preservica'
         SyncFromPreservicaJob.perform_later(self)
       end

--- a/app/models/concerns/iiif_range_builder.rb
+++ b/app/models/concerns/iiif_range_builder.rb
@@ -121,7 +121,11 @@ class IiifRangeBuilder
   def prune_structures_for_editor_save(parent_oid, manifest)
     kept = Structure.preservica_built
                     .where(parent_object_oid: parent_oid, resource_id: posted_resource_ids(manifest))
-    remove_structures(parent_oid, Structure.where(parent_object_oid: parent_oid).where.not(id: kept.select(:id)))
+    prune_structures_for_parent(parent_oid, kept.select(:id))
+  end
+
+  def prune_structures_for_parent(parent_oid, kept_ids)
+    remove_structures(parent_oid, Structure.where(parent_object_oid: parent_oid).where.not(id: kept_ids))
   end
 
   def posted_resource_ids(manifest, ids = [])

--- a/app/models/concerns/structurable.rb
+++ b/app/models/concerns/structurable.rb
@@ -178,20 +178,36 @@ module Structurable
 
   def build_structure_ranges_for(po, ranges)
     ActiveRecord::Base.transaction do
-      IiifRangeBuilder.new.destroy_existing_structure_by_parent_oid(po.oid, source: Structure::EDITOR)
+      reused = reusable_preservica_ranges(po, ranges.keys)
+      IiifRangeBuilder.new.prune_structures_for_parent(po.oid, reused.values.map(&:id))
 
       ranges.sort_by { |_name, r| [r[:range_order], r[:first_row]] }.each_with_index do |(name, r), range_index|
-        range = StructureRange.create!(resource_id: SecureRandom.uuid, label: name, position: range_index,
-                                       parent_object_oid: po.oid, top_level: true, structure_id: nil,
-                                       source: Structure::EDITOR)
+        range = structure_range_for(po, name, range_index, reused[name])
         r[:canvases].sort_by { |c| [c[:position], c[:row]] }.each_with_index do |c, canvas_index|
           StructureCanvas.create!(resource_id: IiifRangeBuilder.child_id_to_uri(c[:child_oid], po.oid),
                                   label: c[:label], position: canvas_index, parent_object_oid: po.oid,
                                   child_object_oid: c[:child_oid], structure_id: range.id,
-                                  source: Structure::EDITOR)
+                                  source: range.source)
         end
       end
     end
+  end
+
+  def reusable_preservica_ranges(po, range_names)
+    StructureRange.preservica_built.where(parent_object_oid: po.oid, label: range_names)
+                  .order(:position, :id).each_with_object({}) do |range, claimed|
+      claimed[range.label] ||= range
+    end
+  end
+
+  def structure_range_for(po, name, position, reused)
+    if reused
+      reused.update!(label: name, position: position, top_level: true, structure_id: nil)
+      return reused
+    end
+    StructureRange.create!(resource_id: SecureRandom.uuid, label: name, position: position,
+                           parent_object_oid: po.oid, top_level: true, structure_id: nil,
+                           source: Structure::EDITOR)
   end
 
   # Redirected parents were rejected in pass 1, so everything that reaches here wants a manifest.

--- a/app/models/concerns/structurable.rb
+++ b/app/models/concerns/structurable.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+# Applies IIIF structure (ranges) to parent objects from a CSV, as an alternative to the structure editor.
+# rubocop:disable Metrics/ModuleLength
+module Structurable
+  extend ActiveSupport::Concern
+
+  STRUCTURE_HEADERS = %w[oid child_oid order_in_range range_name range_order].freeze
+  ALL_PARENTS = :all_parents
+
+  def update_structure_ranges
+    return unless batch_action == "update structure ranges"
+    self.admin_set = ''
+    sets = admin_set
+    return unless structure_headers_present?
+
+    plan, parents, rejected = build_structure_plan(sets)
+    reject_structure_parents(plan, parents, rejected)
+    applied = apply_structure_plan(plan, parents)
+    regenerate_structure_manifests(applied)
+  end
+
+  # THE CSV IS UNUSABLE WITHOUT EVERY COLUMN, SO THIS ABORTS THE RUN RATHER THAN SKIPPING EACH ROW
+  def structure_headers_present?
+    missing = STRUCTURE_HEADERS - (parsed_csv.headers || []).compact.map(&:strip)
+    return true if missing.empty?
+    batch_processing_event("Process failed. The CSV is missing required column(s): #{missing.join(', ')}", 'error')
+    false
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Layout/LineLength
+  def build_structure_plan(sets)
+    plan = {}
+    parents = {}
+    rejected = Set.new
+
+    parsed_csv.each_with_index do |row, index|
+      oid = row['oid'].to_s.strip
+      if oid.blank?
+        batch_processing_event("Process failed. Row [#{index + 2}] has a blank oid.", 'error')
+        rejected << ALL_PARENTS
+        next
+      end
+
+      po = structure_parent_for(oid, index, parents, sets)
+      if po == false
+        rejected << oid
+        next
+      end
+
+      canvas = structure_row_to_canvas(row, po, index)
+      if canvas.nil?
+        rejected << oid
+        next
+      end
+
+      rejected << oid unless add_canvas_to_structure_plan(plan, oid, canvas, index)
+    end
+
+    [plan, parents, rejected]
+  end
+
+  def reject_structure_parents(plan, parents, rejected)
+    oids = rejected.dup
+    oids.merge(plan.keys) if oids.delete?(ALL_PARENTS)
+
+    oids.each do |oid|
+      plan.delete(oid)
+      batch_processing_event("Skipping parent oid: #{oid} because one or more of its rows were invalid. No structure was changed for this parent.", 'Skipped Row')
+      po = parents[oid]
+      next unless po
+
+      attach_item(po)
+      po.processing_event("Structure was not applied because one or more CSV rows were invalid", 'failed')
+    end
+  end
+
+  def structure_parent_for(oid, index, parents, sets)
+    unless parents.key?(oid)
+      parents[oid] = updatable_parent_object(oid, index)
+      if parents[oid]
+        add_admin_set_to_bp(sets, parents[oid])
+        save!
+      end
+    end
+    parents[oid]
+  end
+
+  def structure_row_to_canvas(row, po, index)
+    oid = po.oid
+    name = row['range_name'].to_s.strip
+    valid = true
+    if name.blank?
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid} because range_name is blank", 'Invalid Blank')
+      valid = false
+    end
+    if row['child_oid'].to_s.strip.blank?
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid} because child_oid is blank", 'Invalid Blank')
+      valid = false
+    end
+
+    order_in_range = structure_integer(row['order_in_range'], 'order_in_range', oid, index)
+    range_order = structure_integer(row['range_order'], 'range_order', oid, index)
+    valid = false if order_in_range == :invalid || range_order == :invalid
+    return nil unless valid
+
+    co = structure_child_for(row, po, index)
+    return nil if co.nil?
+
+    { child_oid: co.oid, label: co.label, position: order_in_range,
+      range_name: name, range_order: range_order, row: index + 2 }
+  end
+
+  def structure_integer(value, column, oid, index)
+    raw = value.to_s.strip
+    unless raw.match?(/\A\d+\z/)
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid} because #{column} [#{value}] is not a non-negative integer", 'Skipped Row')
+      return :invalid
+    end
+    raw.to_i
+  end
+
+  def structure_child_for(row, po, index)
+    child_oid = row['child_oid'].to_s.strip
+    co = ChildObject.find_by(oid: child_oid)
+    if co.blank?
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{po.oid} because child oid: #{child_oid} was not found in local database", 'Skipped Row')
+      return nil
+    end
+    unless co.parent_object_oid == po.oid
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{po.oid} because child oid: #{child_oid} belongs to parent object: #{co.parent_object_oid}", 'Skipped Row')
+      return nil
+    end
+    co
+  end
+
+  def add_canvas_to_structure_plan(plan, oid, canvas, index)
+    name = canvas[:range_name]
+    bucket = ((plan[oid] ||= {})[name] ||= { range_order: canvas[:range_order], first_row: canvas[:row], canvases: [] })
+
+    if bucket[:range_order] != canvas[:range_order]
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid} because range [#{name}] has conflicting range_order values [#{bucket[:range_order]}] and [#{canvas[:range_order]}]", 'Skipped Row')
+      return false
+    end
+    if bucket[:canvases].any? { |c| c[:child_oid] == canvas[:child_oid] }
+      batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{oid} because child oid: #{canvas[:child_oid]} appears more than once in range [#{name}]", 'Skipped Row')
+      return false
+    end
+    bucket[:canvases] << canvas
+    true
+  end
+
+  def apply_structure_plan(plan, parents)
+    plan.filter_map do |oid, ranges|
+      po = parents[oid]
+      attach_item(po)
+      po.processing_event("Processing has been queued", "processing-queued")
+      begin
+        build_structure_ranges_for(po, ranges)
+        po.processing_event("Structure updated with #{ranges.size} range(s) from CSV", 'update-complete')
+        po
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+        batch_processing_event("Skipping parent oid: #{oid} because its structure could not be saved: #{e.message}", 'Skipped Row')
+        po.processing_event("Structure could not be saved: #{e.message}", 'failed')
+        nil
+      end
+    end
+  end
+
+  def build_structure_ranges_for(po, ranges)
+    ActiveRecord::Base.transaction do
+      IiifRangeBuilder.new.destroy_existing_structure_by_parent_oid(po.oid, source: Structure::EDITOR)
+
+      # sort_by is not stable, so first_row / row break ties by order of appearance in the CSV
+      ranges.sort_by { |_name, r| [r[:range_order], r[:first_row]] }.each_with_index do |(name, r), range_index|
+        range = StructureRange.create!(resource_id: SecureRandom.uuid, label: name, position: range_index,
+                                       parent_object_oid: po.oid, top_level: true, structure_id: nil,
+                                       source: Structure::EDITOR)
+        r[:canvases].sort_by { |c| [c[:position], c[:row]] }.each_with_index do |c, canvas_index|
+          StructureCanvas.create!(resource_id: IiifRangeBuilder.child_id_to_uri(c[:child_oid], po.oid),
+                                  label: c[:label], position: canvas_index, parent_object_oid: po.oid,
+                                  child_object_oid: c[:child_oid], structure_id: range.id,
+                                  source: Structure::EDITOR)
+        end
+      end
+    end
+  end
+
+  def regenerate_structure_manifests(applied)
+    applied.uniq(&:oid).each do |po|
+      if po.should_create_manifest_and_pdf?
+        GenerateManifestJob.perform_later(po, self, po.current_batch_connection)
+      else
+        po.solr_index_job
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Layout/LineLength

--- a/app/models/concerns/structurable.rb
+++ b/app/models/concerns/structurable.rb
@@ -179,7 +179,7 @@ module Structurable
   def build_structure_ranges_for(po, ranges)
     ActiveRecord::Base.transaction do
       reused = reusable_preservica_ranges(po, ranges.keys)
-      IiifRangeBuilder.new.prune_structures_for_parent(po.oid, reused.values.map(&:id))
+      IiifRangeBuilder.new.prune_structures_for_parent(po.oid, structure_rows_to_keep(po, reused))
 
       ranges.sort_by { |_name, r| [r[:range_order], r[:first_row]] }.each_with_index do |(name, r), range_index|
         range = structure_range_for(po, name, range_index, reused[name])
@@ -190,13 +190,27 @@ module Structurable
                                   source: range.source)
         end
       end
+
+      append_untouched_preservica_ranges(po, ranges.size, reused.values.map(&:id))
     end
+  end
+
+  def structure_rows_to_keep(po, reused)
+    kept = Structure.preservica_built.where(parent_object_oid: po.oid).pluck(:id)
+    kept - StructureCanvas.where(structure_id: reused.values.map(&:id)).pluck(:id)
   end
 
   def reusable_preservica_ranges(po, range_names)
     StructureRange.preservica_built.where(parent_object_oid: po.oid, label: range_names)
                   .order(:position, :id).each_with_object({}) do |range, claimed|
       claimed[range.label] ||= range
+    end
+  end
+
+  def append_untouched_preservica_ranges(po, offset, reused_ids)
+    StructureRange.preservica_built.where(parent_object_oid: po.oid, structure_id: nil)
+                  .where.not(id: reused_ids).order(:position, :id).each_with_index do |range, index|
+      range.update!(position: offset + index, top_level: true)
     end
   end
 

--- a/app/models/concerns/structurable.rb
+++ b/app/models/concerns/structurable.rb
@@ -173,7 +173,6 @@ module Structurable
     ActiveRecord::Base.transaction do
       IiifRangeBuilder.new.destroy_existing_structure_by_parent_oid(po.oid, source: Structure::EDITOR)
 
-      # sort_by is not stable, so first_row / row break ties by order of appearance in the CSV
       ranges.sort_by { |_name, r| [r[:range_order], r[:first_row]] }.each_with_index do |(name, r), range_index|
         range = StructureRange.create!(resource_id: SecureRandom.uuid, label: name, position: range_index,
                                        parent_object_oid: po.oid, top_level: true, structure_id: nil,

--- a/app/models/concerns/structurable.rb
+++ b/app/models/concerns/structurable.rb
@@ -79,13 +79,20 @@ module Structurable
 
   def structure_parent_for(oid, index, parents, sets)
     unless parents.key?(oid)
-      parents[oid] = updatable_parent_object(oid, index)
+      po = updatable_parent_object(oid, index)
+      parents[oid] = po && structure_writable_parent(po, index)
       if parents[oid]
         add_admin_set_to_bp(sets, parents[oid])
         save!
       end
     end
     parents[oid]
+  end
+
+  def structure_writable_parent(po, index)
+    return po if po.should_create_manifest_and_pdf?
+    batch_processing_event("Skipping row [#{index + 2}] with parent oid: #{po.oid} because it is redirected to #{po.redirect_to}", 'Skipped Row')
+    false
   end
 
   def structure_row_to_canvas(row, po, index)
@@ -187,13 +194,10 @@ module Structurable
     end
   end
 
+  # Redirected parents were rejected in pass 1, so everything that reaches here wants a manifest.
   def regenerate_structure_manifests(applied)
     applied.uniq(&:oid).each do |po|
-      if po.should_create_manifest_and_pdf?
-        GenerateManifestJob.perform_later(po, self, po.current_batch_connection)
-      else
-        po.solr_index_job
-      end
+      GenerateManifestJob.perform_later(po, self, po.current_batch_connection)
     end
   end
 end

--- a/public/batch_processes/templates/update_structure_ranges.csv
+++ b/public/batch_processes/templates/update_structure_ranges.csv
@@ -1,0 +1,1 @@
+oid,child_oid,order_in_range,range_name,range_order

--- a/spec/fixtures/csv/structure_ranges_blank_oid.csv
+++ b/spec/fixtures/csv/structure_ranges_blank_oid.csv
@@ -1,0 +1,3 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9011398,1,Folder 1,1
+,9021925,2,Folder 1,1

--- a/spec/fixtures/csv/structure_ranges_blank_values.csv
+++ b/spec/fixtures/csv/structure_ranges_blank_values.csv
@@ -1,0 +1,4 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,,1,Folder 1,1
+2002826,9021925,1,,1
+2002826,9011398,1,Folder 1,1

--- a/spec/fixtures/csv/structure_ranges_conflicting_range_order.csv
+++ b/spec/fixtures/csv/structure_ranges_conflicting_range_order.csv
@@ -1,0 +1,3 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9011398,1,Folder 1,1
+2002826,9021925,2,Folder 1,3

--- a/spec/fixtures/csv/structure_ranges_duplicate_child.csv
+++ b/spec/fixtures/csv/structure_ranges_duplicate_child.csv
@@ -1,0 +1,3 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9011398,1,Folder 1,1
+2002826,9011398,2,Folder 1,1

--- a/spec/fixtures/csv/structure_ranges_example.csv
+++ b/spec/fixtures/csv/structure_ranges_example.csv
@@ -1,0 +1,5 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9021926,2,Folder 2,2
+2002826,9011398,1,Folder 1,1
+2002826,9030368,1,Folder 2,2
+2002826,9021925,2,Folder 1,1

--- a/spec/fixtures/csv/structure_ranges_invalid_child.csv
+++ b/spec/fixtures/csv/structure_ranges_invalid_child.csv
@@ -1,0 +1,4 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9011398,1,Folder 1,1
+2002826,999999999,2,Folder 1,1
+2002826,9111398,3,Folder 1,1

--- a/spec/fixtures/csv/structure_ranges_invalid_order.csv
+++ b/spec/fixtures/csv/structure_ranges_invalid_order.csv
@@ -1,0 +1,4 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9011398,one,Folder 1,1
+2002826,9021925,2,Folder 1,first
+2002826,9021926,3,Folder 1,1

--- a/spec/fixtures/csv/structure_ranges_missing_column.csv
+++ b/spec/fixtures/csv/structure_ranges_missing_column.csv
@@ -1,0 +1,2 @@
+oid,child_oid,order_in_range,range_name
+2002826,9011398,1,Folder 1

--- a/spec/fixtures/csv/structure_ranges_multi_parent.csv
+++ b/spec/fixtures/csv/structure_ranges_multi_parent.csv
@@ -1,0 +1,4 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9011398,1,Folder 1,1
+2004548,9111398,1,Section A,1
+2004548,9111399,2,Section A,1

--- a/spec/fixtures/csv/structure_ranges_one_bad_parent.csv
+++ b/spec/fixtures/csv/structure_ranges_one_bad_parent.csv
@@ -1,0 +1,5 @@
+oid,child_oid,order_in_range,range_name,range_order
+2002826,9011398,1,Folder 1,1
+2002826,999999999,2,Folder 1,1
+2004548,9111398,1,Section A,1
+2004548,9111399,2,Section A,1

--- a/spec/jobs/update_structure_ranges_job_spec.rb
+++ b/spec/jobs/update_structure_ranges_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UpdateStructureRangesJob, type: :job, prep_admin_sets: true, prep_metadata_sources: true do
+  let(:structure_job) { described_class.new }
+  let(:user) { FactoryBot.create(:user) }
+  let(:batch_process) { FactoryBot.create(:batch_process, batch_action: 'update structure ranges', user: user) }
+
+  it 'increments the job queue by one' do
+    update_structure_ranges_job = described_class.perform_later(batch_process)
+    expect(update_structure_ranges_job.instance_variable_get(:@successfully_enqueued)).to be true
+  end
+
+  it "has correct priority" do
+    expect(described_class.new.default_priority).to eq(20)
+  end
+
+  it 'delegates to the batch process' do
+    expect(batch_process).to receive(:update_structure_ranges)
+    structure_job.perform(batch_process)
+  end
+
+  context 'job fails' do
+    it 'notifies on save failure' do
+      allow(batch_process).to receive(:update_structure_ranges).and_raise('boom!')
+      expect { structure_job.perform(batch_process) }.to change { IngestEvent.count }.by(1)
+      expect(IngestEvent.last.reason).to eq "UpdateStructureRangesJob failed due to boom!"
+      expect(IngestEvent.last.status).to eq "failed"
+    end
+  end
+end

--- a/spec/models/batch_process_structure_spec.rb
+++ b/spec/models/batch_process_structure_spec.rb
@@ -290,12 +290,18 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       upload("structure_ranges_example.csv")
     end
 
-    it "reindexes rather than regenerating when the parent is redirected" do
+    it "rejects a redirected parent, whose manifest could never carry the structure" do
+      existing = StructureRange.create!(resource_id: SecureRandom.uuid, label: "Untouched", position: 0,
+                                        top_level: true, parent_object_oid: 2_002_826, source: Structure::EDITOR)
       parent_object.update!(redirect_to: "https://collections.library.yale.edu/catalog/2004548")
       expect(GenerateManifestJob).not_to receive(:perform_later)
       upload("structure_ranges_example.csv")
 
-      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
+      expect(ranges_for(2_002_826).pluck(:label)).to eq [existing.label]
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Skipping row [2] with parent oid: 2002826 because it is redirected to https://collections.library.yale.edu/catalog/2004548",
+        "Skipping parent oid: 2002826 because one or more of its rows were invalid. No structure was changed for this parent."
+      )
     end
   end
 end

--- a/spec/models/batch_process_structure_spec.rb
+++ b/spec/models/batch_process_structure_spec.rb
@@ -128,16 +128,18 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
     end
 
-    it "removes a preservica range the csv does not name" do
+    it "keeps a preservica range the csv does not name, and files it after the csv's ranges" do
       preservica_canvas = StructureCanvas.create!(resource_id: IiifRangeBuilder.child_id_to_uri(9_021_926, 2_002_826),
                                                   position: 0, parent_object_oid: 2_002_826,
                                                   child_object_oid: 9_021_926, structure_id: preservica_range.id,
                                                   source: Structure::PRESERVICA)
       upload("structure_ranges_example.csv")
 
-      expect(StructureRange.where(id: preservica_range.id)).to be_empty
-      expect(StructureCanvas.where(id: preservica_canvas.id)).to be_empty
-      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2", "Preservica Folder"]
+      expect(preservica_range.reload.position).to eq 2
+      expect(preservica_range.source).to eq Structure::PRESERVICA
+      expect(canvas_oids_for(preservica_range)).to eq [9_021_926]
+      expect(preservica_canvas.reload.source).to eq Structure::PRESERVICA
     end
 
     it "reuses a preservica range whose label the csv repeats, so a resync will not duplicate it" do
@@ -164,12 +166,14 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(canvas_oids_for(ranges_for(2_002_826).first)).to eq [9_011_398, 9_021_925]
     end
 
-    it "leaves nothing behind when preservica and editor ranges were nested" do
+    it "returns a preservica range to the top level when the editor range holding it is replaced" do
       preservica_range.update!(structure_id: stale_range.id, top_level: false)
       upload("structure_ranges_example.csv")
 
-      expect(Structure.where(parent_object_oid: 2_002_826).pluck(:source).uniq).to eq [Structure::EDITOR]
-      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
+      expect(StructureRange.where(id: stale_range.id)).to be_empty
+      expect(preservica_range.reload.structure_id).to be_nil
+      expect(preservica_range.top_level).to be true
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2", "Preservica Folder"]
     end
 
     it "produces the same structure when the same csv is uploaded twice" do

--- a/spec/models/batch_process_structure_spec.rb
+++ b/spec/models/batch_process_structure_spec.rb
@@ -128,22 +128,48 @@ RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_adm
       expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
     end
 
-    it "leaves preservica built structure alone" do
+    it "removes a preservica range the csv does not name" do
       preservica_canvas = StructureCanvas.create!(resource_id: IiifRangeBuilder.child_id_to_uri(9_021_926, 2_002_826),
                                                   position: 0, parent_object_oid: 2_002_826,
                                                   child_object_oid: 9_021_926, structure_id: preservica_range.id,
                                                   source: Structure::PRESERVICA)
       upload("structure_ranges_example.csv")
 
-      expect(preservica_range.reload.label).to eq "Preservica Folder"
-      expect(preservica_canvas.reload.structure_id).to eq preservica_range.id
+      expect(StructureRange.where(id: preservica_range.id)).to be_empty
+      expect(StructureCanvas.where(id: preservica_canvas.id)).to be_empty
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
     end
 
-    it "returns a preservica range nested in a removed editor range to the top level" do
+    it "reuses a preservica range whose label the csv repeats, so a resync will not duplicate it" do
+      preservica_range.update!(label: "Folder 1")
+      upload("structure_ranges_example.csv")
+
+      folder_one, folder_two = ranges_for(2_002_826).to_a
+      expect(folder_one.id).to eq preservica_range.id
+      expect(folder_one.resource_id).to eq "b8b8-preservica"
+      expect(folder_one.source).to eq Structure::PRESERVICA
+      expect(folder_one.position).to eq 0
+      expect(canvas_oids_for(folder_one)).to eq [9_011_398, 9_021_925]
+      expect(folder_one.structures.pluck(:source).uniq).to eq [Structure::PRESERVICA]
+      expect(folder_two.source).to eq Structure::EDITOR
+    end
+
+    it "rebuilds the canvases of a reused preservica range from the csv" do
+      preservica_range.update!(label: "Folder 1")
+      StructureCanvas.create!(resource_id: IiifRangeBuilder.child_id_to_uri(9_030_368, 2_002_826), position: 0,
+                              parent_object_oid: 2_002_826, child_object_oid: 9_030_368,
+                              structure_id: preservica_range.id, source: Structure::PRESERVICA)
+      upload("structure_ranges_example.csv")
+
+      expect(canvas_oids_for(ranges_for(2_002_826).first)).to eq [9_011_398, 9_021_925]
+    end
+
+    it "leaves nothing behind when preservica and editor ranges were nested" do
       preservica_range.update!(structure_id: stale_range.id, top_level: false)
       upload("structure_ranges_example.csv")
 
-      expect(preservica_range.reload.structure_id).to be_nil
+      expect(Structure.where(parent_object_oid: 2_002_826).pluck(:source).uniq).to eq [Structure::EDITOR]
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
     end
 
     it "produces the same structure when the same csv is uploaded twice" do

--- a/spec/models/batch_process_structure_spec.rb
+++ b/spec/models/batch_process_structure_spec.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BatchProcess, type: :model, prep_metadata_sources: true, prep_admin_sets: true do
+  subject(:batch_process) { described_class.new(batch_action: "update structure ranges", user_id: user.id) }
+
+  let(:user) { FactoryBot.create(:user, uid: "mk2525") }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:parent_object) { FactoryBot.create(:parent_object, oid: "2002826", admin_set_id: admin_set.id) }
+  let(:parent_object_two) { FactoryBot.create(:parent_object, oid: "2004548", admin_set_id: admin_set.id) }
+  let(:child_one) { FactoryBot.create(:child_object, oid: "9011398", order: 1, label: "one", parent_object: parent_object) }
+  let(:child_two) { FactoryBot.create(:child_object, oid: "9021925", order: 2, label: "two", parent_object: parent_object) }
+  let(:child_three) { FactoryBot.create(:child_object, oid: "9021926", order: 3, label: "three", parent_object: parent_object) }
+  let(:child_four) { FactoryBot.create(:child_object, oid: "9030368", order: 4, label: "four", parent_object: parent_object) }
+  let(:other_child) { FactoryBot.create(:child_object, oid: "9111398", order: 1, label: "a", parent_object: parent_object_two) }
+  let(:other_child_two) { FactoryBot.create(:child_object, oid: "9111399", order: 2, label: "b", parent_object: parent_object_two) }
+
+  def upload(fixture)
+    batch_process.file = Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", fixture))
+    batch_process.save
+  end
+
+  def ranges_for(oid)
+    StructureRange.where(parent_object_oid: oid).order(:position)
+  end
+
+  def canvas_oids_for(range)
+    range.structures.where(type: 'StructureCanvas').order(:position).pluck(:child_object_oid)
+  end
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
+  before do
+    stub_metadata_cloud("2002826")
+    stub_metadata_cloud("2004548")
+    stub_ptiffs_and_manifests
+    parent_object
+    child_one
+    child_two
+    child_three
+    child_four
+    login_as(:user)
+    user.add_role(:editor, admin_set)
+  end
+
+  describe "applying structure from a csv" do
+    before { upload("structure_ranges_example.csv") }
+
+    it "creates a top level range per range_name, ordered by range_order" do
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
+      expect(ranges_for(2_002_826).pluck(:position)).to eq [0, 1]
+      expect(ranges_for(2_002_826).pluck(:top_level)).to eq [true, true]
+      expect(ranges_for(2_002_826).pluck(:structure_id)).to eq [nil, nil]
+    end
+
+    it "files each child into its range, ordered by order_in_range" do
+      folder_one, folder_two = ranges_for(2_002_826).to_a
+      expect(canvas_oids_for(folder_one)).to eq [9_011_398, 9_021_925]
+      expect(canvas_oids_for(folder_two)).to eq [9_030_368, 9_021_926]
+    end
+
+    it "marks every row it creates as editor built" do
+      expect(Structure.where(parent_object_oid: 2_002_826).pluck(:source).uniq).to eq [Structure::EDITOR]
+    end
+
+    it "builds canvas resource ids the same way the structure editor does" do
+      canvas = StructureCanvas.find_by(parent_object_oid: 2_002_826, child_object_oid: 9_011_398)
+      expect(canvas.resource_id).to eq IiifRangeBuilder.child_id_to_uri(9_011_398, 2_002_826)
+    end
+
+    it "does not change the order of the child objects" do
+      expect(ChildObject.find(9_011_398).order).to eq 1
+      expect(ChildObject.find(9_021_925).order).to eq 2
+      expect(ChildObject.find(9_021_926).order).to eq 3
+      expect(ChildObject.find(9_030_368).order).to eq 4
+    end
+
+    it "emits the structure into the iiif manifest" do
+      structures = ParentObject.find(2_002_826).iiif_presentation.manifest["structures"]
+      expect(structures.map { |s| s["label"]["en"].first }).to eq ["Folder 1", "Folder 2"]
+      expect(structures.first["items"].map { |i| i["id"] }).to eq [
+        IiifRangeBuilder.child_id_to_uri(9_011_398, 2_002_826),
+        IiifRangeBuilder.child_id_to_uri(9_021_925, 2_002_826)
+      ]
+    end
+
+    it "reports the parent as complete" do
+      expect(batch_process.batch_status).to eq "Batch complete"
+    end
+  end
+
+  describe "with more than one parent in the csv" do
+    before do
+      parent_object_two
+      other_child
+      other_child_two
+      upload("structure_ranges_multi_parent.csv")
+    end
+
+    it "applies structure to each parent" do
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1"]
+      expect(ranges_for(2_004_548).pluck(:label)).to eq ["Section A"]
+      expect(canvas_oids_for(ranges_for(2_004_548).first)).to eq [9_111_398, 9_111_399]
+    end
+  end
+
+  describe "replacing existing structure" do
+    let(:stale_range) do
+      StructureRange.create!(resource_id: SecureRandom.uuid, label: "Stale", position: 0, top_level: true,
+                             parent_object_oid: 2_002_826, source: Structure::EDITOR)
+    end
+    let(:preservica_range) do
+      StructureRange.create!(resource_id: "b8b8-preservica", label: "Preservica Folder", position: 0, top_level: true,
+                             parent_object_oid: 2_002_826, source: Structure::PRESERVICA)
+    end
+
+    it "removes editor built structure that is not in the csv" do
+      stale_range
+      StructureCanvas.create!(resource_id: IiifRangeBuilder.child_id_to_uri(9_011_398, 2_002_826), position: 0,
+                              parent_object_oid: 2_002_826, child_object_oid: 9_011_398,
+                              structure_id: stale_range.id, source: Structure::EDITOR)
+      upload("structure_ranges_example.csv")
+
+      expect(StructureRange.where(id: stale_range.id)).to be_empty
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
+    end
+
+    it "leaves preservica built structure alone" do
+      preservica_canvas = StructureCanvas.create!(resource_id: IiifRangeBuilder.child_id_to_uri(9_021_926, 2_002_826),
+                                                  position: 0, parent_object_oid: 2_002_826,
+                                                  child_object_oid: 9_021_926, structure_id: preservica_range.id,
+                                                  source: Structure::PRESERVICA)
+      upload("structure_ranges_example.csv")
+
+      expect(preservica_range.reload.label).to eq "Preservica Folder"
+      expect(preservica_canvas.reload.structure_id).to eq preservica_range.id
+    end
+
+    it "returns a preservica range nested in a removed editor range to the top level" do
+      preservica_range.update!(structure_id: stale_range.id, top_level: false)
+      upload("structure_ranges_example.csv")
+
+      expect(preservica_range.reload.structure_id).to be_nil
+    end
+
+    it "produces the same structure when the same csv is uploaded twice" do
+      upload("structure_ranges_example.csv")
+      first_resource_ids = ranges_for(2_002_826).pluck(:resource_id)
+
+      second_process = described_class.new(batch_action: "update structure ranges", user_id: user.id)
+      second_process.file = Rack::Test::UploadedFile.new(Rails.root.join(fixture_paths[0], "csv", "structure_ranges_example.csv"))
+      second_process.save
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
+      expect(canvas_oids_for(ranges_for(2_002_826).first)).to eq [9_011_398, 9_021_925]
+      # range uuids are regenerated on every upload; nothing external references them
+      expect(ranges_for(2_002_826).pluck(:resource_id)).not_to eq first_resource_ids
+    end
+  end
+
+  describe "rows that cannot be applied" do
+    let(:existing_range) do
+      StructureRange.create!(resource_id: SecureRandom.uuid, label: "Untouched", position: 0,
+                             top_level: true, parent_object_oid: 2_002_826, source: Structure::EDITOR)
+    end
+
+    it "leaves the parent untouched when a child is missing or belongs to another parent" do
+      parent_object_two
+      other_child
+      existing_range
+      upload("structure_ranges_invalid_child.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Untouched"]
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Skipping row [3] with parent oid: 2002826 because child oid: 999999999 was not found in local database",
+        "Skipping row [4] with parent oid: 2002826 because child oid: 9111398 belongs to parent object: 2004548",
+        "Skipping parent oid: 2002826 because one or more of its rows were invalid. No structure was changed for this parent."
+      )
+      expect(batch_process.batch_ingest_events.pluck(:status)).to include('Skipped Row')
+    end
+
+    it "reports every invalid row rather than stopping at the first" do
+      existing_range
+      upload("structure_ranges_invalid_order.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Untouched"]
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Skipping row [2] with parent oid: 2002826 because order_in_range [one] is not a non-negative integer",
+        "Skipping row [3] with parent oid: 2002826 because range_order [first] is not a non-negative integer"
+      )
+    end
+
+    it "leaves the parent untouched when a row contradicts the range_order set by an earlier row" do
+      existing_range
+      upload("structure_ranges_conflicting_range_order.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Untouched"]
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Skipping row [3] with parent oid: 2002826 because range [Folder 1] has conflicting range_order values [1] and [3]"
+      )
+    end
+
+    it "leaves the parent untouched when a child is listed twice in the same range" do
+      existing_range
+      upload("structure_ranges_duplicate_child.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Untouched"]
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Skipping row [3] with parent oid: 2002826 because child oid: 9011398 appears more than once in range [Folder 1]"
+      )
+    end
+
+    it "leaves the parent untouched when a required value is blank" do
+      existing_range
+      upload("structure_ranges_blank_values.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Untouched"]
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Skipping row [2] with parent oid: 2002826 because child_oid is blank",
+        "Skipping row [3] with parent oid: 2002826 because range_name is blank"
+      )
+      expect(batch_process.batch_ingest_events.pluck(:status)).to include('Invalid Blank')
+    end
+
+    it "marks the rejected parent as failed" do
+      upload("structure_ranges_duplicate_child.csv")
+
+      expect(batch_process.batch_status).to eq "Batch failed"
+      connection = batch_process.batch_connections.find_by(connectable: ParentObject.find(2_002_826))
+      expect(IngestEvent.where(batch_connection: connection).pluck(:reason)).to include(
+        "Structure was not applied because one or more CSV rows were invalid"
+      )
+    end
+
+    it "still applies the parents whose rows were all valid" do
+      parent_object_two
+      other_child
+      other_child_two
+      existing_range
+      upload("structure_ranges_one_bad_parent.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Untouched"]
+      expect(ranges_for(2_004_548).pluck(:label)).to eq ["Section A"]
+      expect(canvas_oids_for(ranges_for(2_004_548).first)).to eq [9_111_398, 9_111_399]
+    end
+
+    it "aborts the run when a row has a blank oid, since no parent can be shown to be complete" do
+      existing_range
+      upload("structure_ranges_blank_oid.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Untouched"]
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Process failed. Row [3] has a blank oid."
+      )
+      expect(batch_process.batch_ingest_events.pluck(:status)).to include('error')
+    end
+
+    it "aborts the run when a required column is missing" do
+      upload("structure_ranges_missing_column.csv")
+
+      expect(Structure.where(parent_object_oid: 2_002_826)).to be_empty
+      expect(batch_process.batch_ingest_events.pluck(:reason)).to include(
+        "Process failed. The CSV is missing required column(s): range_order"
+      )
+      expect(batch_process.batch_ingest_events.pluck(:status)).to include('error')
+    end
+  end
+
+  describe "as a user without an editor role" do
+    let(:user) { FactoryBot.create(:user, uid: "vw2525") }
+
+    before do
+      user.remove_role(:editor, admin_set)
+      user.add_role(:viewer, admin_set)
+      upload("structure_ranges_example.csv")
+    end
+
+    it "does not create any structure" do
+      expect(Structure.where(parent_object_oid: 2_002_826)).to be_empty
+      expect(batch_process.batch_ingest_events.pluck(:status)).to include('Permission Denied')
+    end
+  end
+
+  describe "manifest regeneration" do
+    it "queues one manifest job for the parent, not one per row" do
+      expect(GenerateManifestJob).to receive(:perform_later).once.and_call_original
+      upload("structure_ranges_example.csv")
+    end
+
+    it "reindexes rather than regenerating when the parent is redirected" do
+      parent_object.update!(redirect_to: "https://collections.library.yale.edu/catalog/2004548")
+      expect(GenerateManifestJob).not_to receive(:perform_later)
+      upload("structure_ranges_example.csv")
+
+      expect(ranges_for(2_002_826).pluck(:label)).to eq ["Folder 1", "Folder 2"]
+    end
+  end
+end

--- a/spec/requests/batch_processes_request_spec.rb
+++ b/spec/requests/batch_processes_request_spec.rb
@@ -201,5 +201,12 @@ RSpec.describe "BatchProcesses", type: :request, prep_metadata_sources: true do
       expect(response.content_type).to eq("text/csv; charset=utf-8")
       expect(response.body).to match("\xEF\xBB\xBFoid,sha512,sha256,sha1,md5")
     end
+
+    it "downloads templates for update structure ranges" do
+      get download_template_batch_processes_url(batch_action: "update structure ranges")
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("text/csv; charset=utf-8")
+      expect(response.body).to match("\xEF\xBB\xBFoid,child_oid,order_in_range,range_name,range_order")
+    end
   end
 end


### PR DESCRIPTION
## Summary  
Adds Batch Process for creating and updating parent objects structure ranges.  
  
Validations:  
- Parent exists in the local DB, and the batch's user has update permissions
- Range_name not blank
- Child_oid not blank
- Order_in_range is a non-negative integer
- Range_order is a non-negative integer
- Child exists in the local DB
- Child actually belongs to the parent named in the same row