### PR TITLE
Update call object for download file

### DIFF
--- a/app/services/s3_service.rb
+++ b/app/services/s3_service.rb
@@ -48,8 +48,8 @@ class S3Service
   # Takes a remote S3 bucket path and writes the retrieved image to a local path.
   # It downloads it in chunks because images are very large.
   def self.download_image(remote_path, local_path, bucket = ENV['S3_SOURCE_BUCKET_NAME'])
-    object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
-    object.download_file(local_path, destination: local_path)
+    object = Aws::S3::TransferManager.new(client: @client)
+    object.download_file(local_path, bucket: bucket, key: remote_path)
   end
 
   def self.upload_image(local_path, remote_path, content_type, metadata)


### PR DESCRIPTION
# Summary
This PR will change out the soon to be deprecated use of `Aws::S3::Object.download_file` for the newer syntax of using the `Aws::S3::TransferManager` for the `download_file` method.

# Related Ticket
[#3410](https://github.com/yalelibrary/YUL-DC/issues/3410)