### PR TITLE
Preservica Ingest Case Sensitivity Ordering

### DIFF
--- a/app/services/preservica_image_service.rb
+++ b/app/services/preservica_image_service.rb
@@ -45,7 +45,7 @@ class PreservicaImageService
       if @pattern == :pattern_one
         structural_object = Preservica::StructuralObject.where(admin_set_key: @admin_set_key, id: (@uri.split('/')[-1]).to_s)
         begin
-          @information_objects = structural_object.information_objects.sort_by { |io| io.title.to_s }
+          @information_objects = structural_object.information_objects.sort_by { |io| [io.title.to_s.downcase, io.title.to_s] }
         rescue Net::OpenTimeout, Errno::ECONNREFUSED => e
           raise PreservicaImageServiceNetworkError.new(e.to_s, @uri.to_s)
         end
@@ -119,7 +119,7 @@ class PreservicaImageService
                                        preservica_content_object_index: index }
       end
       @folder_architecture = true if information_object_images.size > 1
-      @images.concat(information_object_images.sort_by { |image| image[:caption].to_s })
+      @images.concat(information_object_images.sort_by { |image| [image[:caption].to_s.downcase, image[:caption].to_s] })
     end
   end
   # rubocop:enable Metrics/MethodLength

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>cccc0006-0000-4000-8000-000000000006</xip:ContentObject>
+    <xip:FormatGroup>tiff</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0270_A002.tif</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/353</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Tagged Image File Format</xip:FormatName>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0270_A002.tif">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1/bitstreams/1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Bitstream>
+    <xip:Filename>ms_0664_s02_b016_f0270_A002.tif</xip:Filename>
+    <xip:FileSize>1131966</xip:FileSize>
+    <xip:Fixities>
+      <xip:Fixity>
+        <xip:FixityAlgorithmRef>SHA512</xip:FixityAlgorithmRef>
+        <xip:FixityValue>
+          d6e3926fbe14fedbf3a568b6a5dbdb3e8b2312f217daa460a743559d41a688af4a7c701e7bac908fc7e3fd51c505fa01dad9eee96fcfd2666e92c648249edf06
+        </xip:FixityValue>
+      </xip:Fixity>
+    </xip:Fixities>
+  </xip:Bitstream>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1/bitstreams/1
+    </Self>
+    <IntegrityCheckHistory>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1/bitstreams/1/integrity-check-history
+    </IntegrityCheckHistory>
+    <Content>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1/bitstreams/1/content
+    </Content>
+  </AdditionalInformation>
+</BitstreamResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Generations>
+    <Generation active="true">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1
+    </Generation>
+  </Generations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations
+    </Self>
+  </AdditionalInformation>
+</GenerationsResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GenerationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Generation original="true" active="true">
+    <xip:ContentObject>cccc0007-0000-4000-8000-000000000007</xip:ContentObject>
+    <xip:FormatGroup>tiff</xip:FormatGroup>
+    <xip:EffectiveDate>2025-02-21T00:00:00.000-05:00</xip:EffectiveDate>
+    <xip:Bitstreams>
+      <xip:Bitstream>ms_0664_s02_b016_f0270_a001.tif</xip:Bitstream>
+    </xip:Bitstreams>
+    <xip:Formats>
+      <xip:Format valid="true">
+        <xip:PUID>fmt/353</xip:PUID>
+        <xip:Priority>1</xip:Priority>
+        <xip:IdentificationMethod>Signature</xip:IdentificationMethod>
+        <xip:FormatName>Tagged Image File Format</xip:FormatName>
+      </xip:Format>
+    </xip:Formats>
+    <xip:Properties/>
+  </xip:Generation>
+  <Bitstreams>
+    <Bitstream filename="ms_0664_s02_b016_f0270_a001.tif">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1/bitstreams/1
+    </Bitstream>
+  </Bitstreams>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1
+    </Self>
+  </AdditionalInformation>
+</GenerationResponse>

--- a/spec/fixtures/preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1/bitstreams/1.xml
+++ b/spec/fixtures/preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1/bitstreams/1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<BitstreamResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Bitstream>
+    <xip:Filename>ms_0664_s02_b016_f0270_a001.tif</xip:Filename>
+    <xip:FileSize>1131966</xip:FileSize>
+    <xip:Fixities>
+      <xip:Fixity>
+        <xip:FixityAlgorithmRef>SHA512</xip:FixityAlgorithmRef>
+        <xip:FixityValue>
+          d6e3926fbe14fedbf3a568b6a5dbdb3e8b2312f217daa460a743559d41a688af4a7c701e7bac908fc7e3fd51c505fa01dad9eee96fcfd2666e92c648249edf07
+        </xip:FixityValue>
+      </xip:Fixity>
+    </xip:Fixities>
+  </xip:Bitstream>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1/bitstreams/1
+    </Self>
+    <IntegrityCheckHistory>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1/bitstreams/1/integrity-check-history
+    </IntegrityCheckHistory>
+    <Content>
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1/bitstreams/1/content
+    </Content>
+  </AdditionalInformation>
+</BitstreamResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationsResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Representations>
+    <Representation type="Preservation" name="Preservation-1">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations/Preservation/1
+    </Representation>
+  </Representations>
+  <Paging>
+    <TotalResults>1</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations
+    </Self>
+  </AdditionalInformation>
+</RepresentationsResponse>

--- a/spec/fixtures/preservica/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations/Preservation.xml
+++ b/spec/fixtures/preservica/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations/Preservation.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RepresentationResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <xip:Representation>
+    <xip:InformationObject>aaaa0003-0000-4000-8000-000000000003</xip:InformationObject>
+    <xip:Name>Preservation-1</xip:Name>
+    <xip:Type>Preservation</xip:Type>
+    <xip:ContentObjects>
+      <xip:ContentObject>cccc0006-0000-4000-8000-000000000006</xip:ContentObject>
+      <xip:ContentObject>cccc0007-0000-4000-8000-000000000007</xip:ContentObject>
+    </xip:ContentObjects>
+    <xip:RepresentationFormats/>
+    <xip:RepresentationProperties/>
+  </xip:Representation>
+  <ContentObjects>
+    <ContentObject title="ms_0664_s02_b016_f0270_A002" ref="cccc0006-0000-4000-8000-000000000006" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006
+    </ContentObject>
+    <ContentObject title="ms_0664_s02_b016_f0270_a001" ref="cccc0007-0000-4000-8000-000000000007" type="CO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007
+    </ContentObject>
+  </ContentObjects>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations/Preservation/1
+    </Self>
+  </AdditionalInformation>
+</RepresentationResponse>

--- a/spec/fixtures/preservica/api/entity/structural-objects/eeee0002-0000-4000-8000-000000000002/children.xml
+++ b/spec/fixtures/preservica/api/entity/structural-objects/eeee0002-0000-4000-8000-000000000002/children.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ChildrenResponse xmlns="http://preservica.com/EntityAPI/v6.3" xmlns:xip="http://preservica.com/XIP/v6.3">
+  <Children>
+    <Child title="[Preservica] ms_0664_s02-M-b016_f0269" ref="aaaa0002-0000-4000-8000-000000000002" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0002-0000-4000-8000-000000000002
+    </Child>
+    <Child title="[Preservica] ms_0664_s02-m-b016_f0268" ref="aaaa0001-0000-4000-8000-000000000001" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001
+    </Child>
+    <Child title="[Preservica] ms_0664_s02-m-b016_f0270" ref="aaaa0003-0000-4000-8000-000000000003" type="IO">
+      https://preservica-dev-v6.library.yale.edu/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003
+    </Child>
+  </Children>
+  <Paging>
+    <TotalResults>3</TotalResults>
+  </Paging>
+  <AdditionalInformation>
+    <Self>
+      https://preservica-dev-v6.library.yale.edu/api/entity/structural-objects/eeee0002-0000-4000-8000-000000000002/children
+    </Self>
+  </AdditionalInformation>
+</ChildrenResponse>

--- a/spec/models/preservica/preservica_ingest_case_one_spec.rb
+++ b/spec/models/preservica/preservica_ingest_case_one_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     stub_preservica_aspace_single
     stub_preservica_login
     fixtures = %w[preservica/api/entity/structural-objects/eeee0001-0000-4000-8000-000000000001/children
+                  preservica/api/entity/structural-objects/eeee0002-0000-4000-8000-000000000002/children
                   preservica/api/entity/structural-objects/88e52625-0000-4000-8000-00000000bad1/children
                   preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations
                   preservica/api/entity/information-objects/aaaa0001-0000-4000-8000-000000000001/representations/Preservation
@@ -68,7 +69,15 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
                   preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1
                   preservica/api/entity/content-objects/cccc0005-0000-4000-8000-000000000005/generations/1/bitstreams/1
                   preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations
-                  preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1]
+                  preservica/api/entity/content-objects/dddd0001-0000-4000-8000-000000000001/generations/1
+                  preservica/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations
+                  preservica/api/entity/information-objects/aaaa0003-0000-4000-8000-000000000003/representations/Preservation
+                  preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations
+                  preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1
+                  preservica/api/entity/content-objects/cccc0006-0000-4000-8000-000000000006/generations/1/bitstreams/1
+                  preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations
+                  preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1
+                  preservica/api/entity/content-objects/cccc0007-0000-4000-8000-000000000007/generations/1/bitstreams/1]
 
     fixtures.each do |fixture|
       stub_request(:get, "https://test#{fixture}").to_return(
@@ -98,6 +107,17 @@ RSpec.describe Preservica::PreservicaObject, type: :model, prep_metadata_sources
     expect(image_list.count).to eq 5
     expect(image_list.map { |image| image[:caption] }).to eq expected_captions
     expect(image_list.map { |image| image[:preservica_content_object_uri] }).to eq expected_content_object_uris
+  end
+
+  it 'orders folders and their files without giving weight to case' do
+    image_service = PreservicaImageService.new("/structural-objects/eeee0002-0000-4000-8000-000000000002", "sml")
+    image_list = image_service.image_list("Preservation")
+    expect(image_list.map { |image| image[:preservica_folder_label] }).to eq(
+      (["[Preservica] ms_0664_s02-m-b016_f0268"] * 3) +
+      (["[Preservica] ms_0664_s02-M-b016_f0269"] * 2) +
+      (["[Preservica] ms_0664_s02-m-b016_f0270"] * 2)
+    )
+    expect(image_list.map { |image| image[:caption] }).to eq expected_captions + ["ms_0664_s02_b016_f0270_a001.tif", "ms_0664_s02_b016_f0270_A002.tif"]
   end
 
   it 'raises a clear error when the structural object contains nested folders' do


### PR DESCRIPTION
## Summary  
Preservica ordering by filename no longer takes case sensitivity into account. Issue was from Rubys default string sorting. 